### PR TITLE
Capture codex thread id at startup, fixes #13

### DIFF
--- a/claude.go
+++ b/claude.go
@@ -312,6 +312,10 @@ func (claudeProvider) Interrupt(_ *providerProc) (bool, error) { return false, n
 // turn's `result` event).
 func (claudeProvider) PreMintSessionID(_ ProviderSessionArgs) string { return newUUIDv4() }
 
+// NativeSessionID returns "" — claude's id is pre-minted, so the model
+// already has it before StartSession returns.
+func (claudeProvider) NativeSessionID(_ *providerProc) string { return "" }
+
 func (claudeProvider) Send(p *providerProc, text string, attachments []pendingAttachment) error {
 	payload := map[string]any{
 		"type": "user",

--- a/claude_cli_test.go
+++ b/claude_cli_test.go
@@ -369,6 +369,34 @@ func TestCodexProvider_PreMintSessionIDReturnsEmpty(t *testing.T) {
 	}
 }
 
+func TestClaudeProvider_NativeSessionIDReturnsEmpty(t *testing.T) {
+	// Claude pre-mints the id into m.sessionID before fork, so the
+	// post-startup hook has nothing to add.
+	if got := (claudeProvider{}).NativeSessionID(&providerProc{}); got != "" {
+		t.Errorf("claudeProvider.NativeSessionID=%q want empty", got)
+	}
+}
+
+func TestCodexProvider_NativeSessionIDReturnsThreadID(t *testing.T) {
+	// The threadID is stashed on proc.payload by codexHandshake; the
+	// hook reads it back so handleProviderStartDone can capture it
+	// before the first turn/completed.
+	proc := &providerProc{payload: &codexState{threadID: "thread-xyz"}}
+	got := codexProvider{}.NativeSessionID(proc)
+	if got != "thread-xyz" {
+		t.Errorf("NativeSessionID=%q want thread-xyz", got)
+	}
+}
+
+func TestCodexProvider_NativeSessionIDEmptyPayload(t *testing.T) {
+	// Defensive: a proc without a codexState payload (test fakes,
+	// future refactors) must not panic.
+	got := codexProvider{}.NativeSessionID(&providerProc{})
+	if got != "" {
+		t.Errorf("NativeSessionID(no payload)=%q want empty", got)
+	}
+}
+
 func TestClaudeCLIArgs_NeverPassesWorktreeFlag(t *testing.T) {
 	// ask owns worktree lifecycle end-to-end now; claude's own
 	// --worktree machinery must not be triggered regardless of input.

--- a/codex.go
+++ b/codex.go
@@ -127,6 +127,22 @@ func (codexProvider) BaseSlashCommands() []slashCmd {
 // has no caller-chosen id slot.
 func (codexProvider) PreMintSessionID(_ ProviderSessionArgs) string { return "" }
 
+// NativeSessionID returns the threadID assigned during the
+// thread/start handshake. Available as soon as StartSession returns,
+// so handleProviderStartDone can capture it before the first
+// turn/completed — without that, an interrupt mid-turn leaves
+// m.sessionID empty and the next send hits thread/start instead of
+// thread/resume.
+func (codexProvider) NativeSessionID(p *providerProc) string {
+	state, _ := p.payload.(*codexState)
+	if state == nil {
+		return ""
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	return state.threadID
+}
+
 func (codexProvider) ProbeInit(args ProviderSessionArgs) tea.Cmd {
 	return func() tea.Msg {
 		skills, err := fetchCodexSkills(args.Cwd)

--- a/proc.go
+++ b/proc.go
@@ -337,6 +337,18 @@ func (m model) handleProviderStartDone(msg providerStartDoneMsg) (tea.Model, tea
 	m.busy = true
 	m.status = "thinking…"
 
+	// Capture the provider-native session id at startup so an
+	// interrupt before turn/completed doesn't leave m.sessionID empty
+	// and force the next send down the fresh-session path. Pre-minted
+	// providers (claude) return "" here — m.sessionID is already set
+	// by preMintNativeSessionIfNeeded before the fork.
+	if m.sessionID == "" {
+		if id := m.provider.NativeSessionID(m.proc); id != "" {
+			m.sessionID = id
+			m.recordVirtualSession(id)
+		}
+	}
+
 	queued := m.queuedTurns
 	m.queuedTurns = nil
 	for _, turn := range queued {

--- a/provider.go
+++ b/provider.go
@@ -55,6 +55,16 @@ type Provider interface {
 	// --session-id <uuid>).
 	PreMintSessionID(args ProviderSessionArgs) string
 
+	// NativeSessionID returns the provider-assigned session id carried
+	// on a started proc, or "" when the provider has no post-handshake
+	// id to surface (e.g. claude pre-mints; the model already knows it).
+	// Codex assigns its threadID during the app-server handshake, so
+	// returning it here lets the model capture the id at startup
+	// instead of waiting for turn/completed — without that, an
+	// interrupt-before-turn-completed leaves m.sessionID empty and the
+	// next send wrongly takes the fresh-thread path.
+	NativeSessionID(p *providerProc) string
+
 	// StartSession forks the agent CLI in streaming mode. Returns the
 	// process handle and its event channel on success; err non-nil on
 	// launch failure.

--- a/testhelpers_test.go
+++ b/testhelpers_test.go
@@ -26,16 +26,17 @@ type fakeProvider struct {
 	effortOptions []string
 	baseSlash     []slashCmd
 
-	probeInitFn    func(ProviderSessionArgs) tea.Cmd
-	preMintFn      func(ProviderSessionArgs) string
-	startSessionFn func(ProviderSessionArgs) (*providerProc, chan tea.Msg, error)
-	sendFn         func(*providerProc, string, []pendingAttachment) error
-	interruptFn    func(*providerProc) (bool, error)
-	listSessionsFn func(string) ([]sessionEntry, error)
-	loadHistoryFn  func(string, HistoryOpts) ([]historyEntry, error)
-	loadSettingsFn func() ProviderSettings
-	saveSettingsFn func(ProviderSettings) error
-	materializeFn  func(string, []NeutralTurn) (string, string, error)
+	probeInitFn     func(ProviderSessionArgs) tea.Cmd
+	preMintFn       func(ProviderSessionArgs) string
+	nativeSessionFn func(*providerProc) string
+	startSessionFn  func(ProviderSessionArgs) (*providerProc, chan tea.Msg, error)
+	sendFn          func(*providerProc, string, []pendingAttachment) error
+	interruptFn     func(*providerProc) (bool, error)
+	listSessionsFn  func(string) ([]sessionEntry, error)
+	loadHistoryFn   func(string, HistoryOpts) ([]historyEntry, error)
+	loadSettingsFn  func() ProviderSettings
+	saveSettingsFn  func(ProviderSettings) error
+	materializeFn   func(string, []NeutralTurn) (string, string, error)
 
 	settings ProviderSettings
 
@@ -81,6 +82,13 @@ func (f *fakeProvider) ProbeInit(args ProviderSessionArgs) tea.Cmd {
 func (f *fakeProvider) PreMintSessionID(args ProviderSessionArgs) string {
 	if f.preMintFn != nil {
 		return f.preMintFn(args)
+	}
+	return ""
+}
+
+func (f *fakeProvider) NativeSessionID(p *providerProc) string {
+	if f.nativeSessionFn != nil {
+		return f.nativeSessionFn(p)
 	}
 	return ""
 }

--- a/update_test.go
+++ b/update_test.go
@@ -1117,6 +1117,51 @@ func TestHandleCommand_ConfigEntersConfigMode(t *testing.T) {
 	}
 }
 
+func TestProviderStartDone_CapturesNativeSessionID(t *testing.T) {
+	fp := newFakeProvider()
+	fp.nativeSessionFn = func(*providerProc) string { return "thread-abc" }
+	m := newTestModel(t, fp)
+	m.procStarting = true
+	m.procStartSeq = 1
+	m.busy = true
+
+	proc := &providerProc{stdin: &bufferCloser{Buffer: &bytes.Buffer{}}}
+	ch := make(chan tea.Msg, 1)
+	m2, _ := runUpdate(t, m, providerStartDoneMsg{
+		tabID:      m.id,
+		seq:        1,
+		providerID: fp.id,
+		proc:       proc,
+		streamCh:   ch,
+	})
+	if m2.sessionID != "thread-abc" {
+		t.Errorf("sessionID=%q want thread-abc", m2.sessionID)
+	}
+}
+
+func TestProviderStartDone_PreMintedSessionIDNotOverwritten(t *testing.T) {
+	fp := newFakeProvider()
+	fp.nativeSessionFn = func(*providerProc) string { return "should-be-ignored" }
+	m := newTestModel(t, fp)
+	m.procStarting = true
+	m.procStartSeq = 1
+	m.busy = true
+	m.sessionID = "pre-minted"
+
+	proc := &providerProc{stdin: &bufferCloser{Buffer: &bytes.Buffer{}}}
+	ch := make(chan tea.Msg, 1)
+	m2, _ := runUpdate(t, m, providerStartDoneMsg{
+		tabID:      m.id,
+		seq:        1,
+		providerID: fp.id,
+		proc:       proc,
+		streamCh:   ch,
+	})
+	if m2.sessionID != "pre-minted" {
+		t.Errorf("sessionID=%q want pre-minted (NativeSessionID must not stomp existing id)", m2.sessionID)
+	}
+}
+
 func TestPersistSlashCmdsCmd_CallsSaveSettings(t *testing.T) {
 	fp := newFakeProvider()
 	slashes := []providerSlashEntry{{Name: "foo"}}


### PR DESCRIPTION
## Summary

Fixes #13 — Codex interrupt mid-turn no longer wipes the thread on the next send.

The codex app-server assigns the `threadID` during the synchronous `thread/start` handshake, but ask only copied it onto `m.sessionID` from `providerDoneMsg`, which fires on `turn/completed`. An interrupt before that left `m.sessionID` empty, so the next send went down `thread/start` instead of `thread/resume`.

## Approach

- New `Provider.NativeSessionID(*providerProc) string` interface method, symmetric to the existing `PreMintSessionID`.
- `claudeProvider` returns `""` — claude's id is pre-minted into `m.sessionID` before the fork.
- `codexProvider` returns `state.threadID` from the proc payload (under `state.mu`, matching `Send`/`Interrupt`).
- `handleProviderStartDone` calls it after wiring `m.proc`; if `m.sessionID` is empty, it captures the id and records the virtual-session row.

This keeps model code provider-agnostic — no `*codexState` type-assertion leaks out of `codex.go`. Cross-provider swap (`provider_switcher.go`) already pre-sets `m.sessionID`, so the new branch is a no-op there.

## Tests

Behavior-only, in the matching `_test.go` files per the convention table:

- `TestCodexProvider_NativeSessionIDReturnsThreadID` — codex unit
- `TestCodexProvider_NativeSessionIDEmptyPayload` — defensive (no panic on missing payload)
- `TestClaudeProvider_NativeSessionIDReturnsEmpty` — claude unit
- `TestProviderStartDone_CapturesNativeSessionID` — bug regression at the model level
- `TestProviderStartDone_PreMintedSessionIDNotOverwritten` — claude-side guard against stomping a pre-minted id

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -run "ProviderStartDone|NativeSession|PreMint|ProviderRegistry|ClaudeProvider|CodexProvider" ./...` — all 19 pass
- [x] `gofmt -d` clean on all touched files
- [x] Manual: start codex, send a prompt, interrupt before turn/completed, send again — verify `thread/resume` (not `thread/start`) by tailing the app-server JSON traffic with `ASK_DEBUG=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)