### PR TITLE
Themes: add Ayu Mirage as the sixteenth theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 pipes events through a Bubble Tea TUI, and swaps Claude's built-in
 `AskUserQuestion` tool for a tabbed modal backed by an embedded MCP
 server. Sessions resume, tabs isolate, shell mode drops you straight
-into `$SHELL`, and fifteen themes re-paint the whole UI live.
+into `$SHELL`, and sixteen themes re-paint the whole UI live.
 
 ## Features
 
@@ -30,7 +30,7 @@ into `$SHELL`, and fifteen themes re-paint the whole UI live.
 - **Resume sessions** — `/resume` opens a picker of prior conversations in the current directory
 - **Pick the Claude model** — `/model` opens a picker (default / haiku / sonnet / opus / custom) and persists the choice
 - **Configurable UI** — `/config` toggles quiet mode, cursor blink, inline diff rendering, and skip-all-permissions; persisted to `~/.config/ask/ask.json`
-- **Themes** — pick a palette from `/config` → Theme (15 flavors: `default`, `dracula`, `nord`, `gruvbox`, `tokyo night`, the four Catppuccin variants `latte`/`frappé`/`macchiato`/`mocha` plus the green-leaning Mocha sibling `matcha`, `rose pine`, `fighter` (Monokai Pro), `love` (crush), `hacker` (Matrix), `amber` (CRT)). Backgrounds, foregrounds, borders, and glamour markdown/syntax highlighting all follow the active theme.
+- **Themes** — pick a palette from `/config` → Theme (16 flavors: `default`, `dracula`, `nord`, `gruvbox`, `tokyo night`, the four Catppuccin variants `latte`/`frappé`/`macchiato`/`mocha` plus the green-leaning Mocha sibling `matcha`, `rose pine`, `fighter` (Monokai Pro), `love` (crush), `hacker` (Matrix), `amber` (CRT), `ayu` (Ayu Mirage)). Backgrounds, foregrounds, borders, and glamour markdown/syntax highlighting all follow the active theme.
 - **Inline markdown rendering** with [glamour](https://github.com/charmbracelet/glamour), cached per history entry so typing stays responsive in long chats
 - **Live turn status** — spinner line surfaces the tool Claude is running (`Read: file.go`, `Bash: <description>`, `Grep: <pattern>`, `Task: <subagent>`, …)
 - **Live todo panel** — `TodoWrite` entries render inline as a bordered box with ☐ / ▸ / ✓ markers while the turn is active
@@ -127,13 +127,13 @@ rather than a swatch. `Enter` saves the selection to
 `~/.config/ask/ask.json`; `Esc` reverts to whatever theme was active
 when you opened the picker.
 
-Fifteen flavors ship by default: `default` (respects your terminal's
+Sixteen flavors ship by default: `default` (respects your terminal's
 own background), `dracula`, `nord`, `gruvbox`, `tokyo night`, all four
 official Catppuccin variants (`latte`, `frappé`, `macchiato`, `mocha`),
 the green-leaning Mocha sibling `matcha`, `rose pine`, `fighter` (the
 softer Monokai Pro / Octagon palette), `love` (the Charm crush
-charmtone palette), `hacker` (Matrix phosphor green on CRT black), and
-`amber` (1970s DEC/IBM amber phosphor). All glamour markdown and
+charmtone palette), `hacker` (Matrix phosphor green on CRT black),
+`amber` (1970s DEC/IBM amber phosphor), and `ayu` (Ayu Mirage). All glamour markdown and
 syntax highlighting follow the active theme, so code blocks in
 responses re-theme too.
 

--- a/themes.go
+++ b/themes.go
@@ -21,6 +21,8 @@ type theme struct {
 	inverseFG   color.Color
 	darkFG      color.Color
 	rowHL       color.Color
+	highlightFG color.Color
+	stringFG    color.Color
 	scrollTrack color.Color
 	tabActive   color.Color
 
@@ -49,6 +51,7 @@ var themeRegistry = []theme{
 	hackerTheme(),
 	amberTheme(),
 	loveTheme(),
+	ayuTheme(),
 }
 
 func defaultTheme() theme {
@@ -395,6 +398,34 @@ func loveTheme() theme {
 		scrollTrack: lipgloss.Color("#201F26"),
 		tabActive:   lipgloss.Color("#FF60FF"),
 		background:  lipgloss.Color("#201F26"),
+	}
+}
+
+// ayuTheme is Ayu Mirage: a dark blue-grey base (#1F2430) with the signature
+// Ayu/Codex yellow (#E6B450) as the primary accent and Ayu cyan/teal (#95E6CB)
+// as the secondary. Background and foreground are explicit so the theme reads
+// the same on terminals whose default fg is light.
+func ayuTheme() theme {
+	return theme{
+		name:        "ayu",
+		accent:      lipgloss.Color("#E6B450"),
+		accentAlt:   lipgloss.Color("#95E6CB"),
+		prompt:      lipgloss.Color("#DABAFA"),
+		promptDot:   lipgloss.Color("#90E1C6"),
+		success:     lipgloss.Color("#87D96C"),
+		errorFG:     lipgloss.Color("#F28779"),
+		warn:        lipgloss.Color("#FFD173"),
+		dim:         lipgloss.Color("#686868"),
+		muted:       lipgloss.Color("#B5B5B5"),
+		inverseFG:   lipgloss.Color("#CCCAC2"),
+		darkFG:      lipgloss.Color("#1F2430"),
+		rowHL:       lipgloss.Color("#242B38"),
+		highlightFG: lipgloss.Color("#E6B450"),
+		stringFG:    lipgloss.Color("#95E6CB"),
+		scrollTrack: lipgloss.Color("#1F2430"),
+		tabActive:   lipgloss.Color("#E6B450"),
+		background:  lipgloss.Color("#1F2430"),
+		foreground:  lipgloss.Color("#E6E1CF"),
 	}
 }
 

--- a/themes_test.go
+++ b/themes_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"testing"
+
+	lipgloss "charm.land/lipgloss/v2"
+)
+
+func TestThemeRegistryContainsAyu(t *testing.T) {
+	got := themeByName("ayu")
+	if got.name != "ayu" {
+		t.Fatalf("themeByName(\"ayu\").name = %q, want %q", got.name, "ayu")
+	}
+	if got.accent != lipgloss.Color("#E6B450") {
+		t.Errorf("ayu accent = %v, want #E6B450", got.accent)
+	}
+	if got.background != lipgloss.Color("#1F2430") {
+		t.Errorf("ayu background = %v, want #1F2430", got.background)
+	}
+	if got.foreground != lipgloss.Color("#E6E1CF") {
+		t.Errorf("ayu foreground = %v, want #E6E1CF", got.foreground)
+	}
+	if got.highlightFG != lipgloss.Color("#E6B450") {
+		t.Errorf("ayu highlightFG = %v, want #E6B450", got.highlightFG)
+	}
+	if got.stringFG != lipgloss.Color("#95E6CB") {
+		t.Errorf("ayu stringFG = %v, want #95E6CB", got.stringFG)
+	}
+}
+
+func TestThemeByNameUnknownFallsBackToDefault(t *testing.T) {
+	got := themeByName("definitely-not-a-theme")
+	if got.name != "default" {
+		t.Fatalf("themeByName(unknown).name = %q, want %q", got.name, "default")
+	}
+}
+
+func TestBuildGlamourStyleUsesThemeMarkdownOverrides(t *testing.T) {
+	style := buildGlamourStyle(ayuTheme())
+	if got := style.Code.StylePrimitive.Color; got == nil || *got != "#E6B450" {
+		t.Fatalf("inline code color = %v, want #E6B450", got)
+	}
+	if got := style.CodeBlock.Chroma.LiteralString.Color; got == nil || *got != "#95E6CB" {
+		t.Fatalf("string token color = %v, want #95E6CB", got)
+	}
+}
+
+func TestBuildGlamourStyleFallsBackToSemanticThemeColors(t *testing.T) {
+	style := buildGlamourStyle(draculaTheme())
+	if got := style.Code.StylePrimitive.Color; got == nil || *got != "#BFBFBF" {
+		t.Fatalf("inline code fallback color = %v, want #BFBFBF", got)
+	}
+	if got := style.CodeBlock.Chroma.LiteralString.Color; got == nil || *got != "#50FA7B" {
+		t.Fatalf("string token fallback color = %v, want #50FA7B", got)
+	}
+}

--- a/view.go
+++ b/view.go
@@ -69,6 +69,14 @@ func buildGlamourStyle(t theme) ansi.StyleConfig {
 	successHex := hexOf(t.success)
 	warnHex := hexOf(t.warn)
 	errHex := hexOf(t.errorFG)
+	highlightHex := mutedHex
+	if t.highlightFG != nil {
+		highlightHex = hexOf(t.highlightFG)
+	}
+	stringHex := successHex
+	if t.stringFG != nil {
+		stringHex = hexOf(t.stringFG)
+	}
 
 	s.Document.StylePrimitive.Color = &textHex
 
@@ -81,7 +89,7 @@ func buildGlamourStyle(t theme) ansi.StyleConfig {
 	s.LinkText.Color = &promptDotHex
 	s.HorizontalRule.Color = &dimHex
 
-	s.Code.StylePrimitive.Color = &mutedHex
+	s.Code.StylePrimitive.Color = &highlightHex
 	s.Code.StylePrimitive.BackgroundColor = &rowHex
 
 	s.CodeBlock.StyleBlock.StylePrimitive.Color = &textHex
@@ -104,7 +112,7 @@ func buildGlamourStyle(t theme) ansi.StyleConfig {
 		NameDecorator:       ansi.StylePrimitive{Color: &warnHex},
 		NameFunction:        ansi.StylePrimitive{Color: &altHex},
 		LiteralNumber:       ansi.StylePrimitive{Color: &warnHex},
-		LiteralString:       ansi.StylePrimitive{Color: &successHex},
+		LiteralString:       ansi.StylePrimitive{Color: &stringHex},
 		LiteralStringEscape: ansi.StylePrimitive{Color: &accentHex},
 		GenericDeleted:      ansi.StylePrimitive{Color: &errHex},
 		GenericEmph:         ansi.StylePrimitive{Italic: boolPtr(true)},


### PR DESCRIPTION
## Summary

Closes #2

Adds the **Ayu Mirage** palette (`ayu`) as a sixteenth built-in theme, selectable from `/config` → Theme.

- **New theme** (`themes.go`): `ayuTheme()` registers `ayu` alongside the existing dark themes. Colors sourced from the canonical Ayu Mirage palette — dark blue-grey base `#1F2430`, yellow accent `#E6B450`, cyan secondary `#95E6CB`, explicit background and foreground so the theme reads consistently regardless of terminal defaults.

- **Data-driven renderer overrides** (`themes.go`, `view.go`): The `theme` struct gains two optional fields — `highlightFG` and `stringFG` — which let a theme express per-theme inline-code and string-token colors in the glamour markdown renderer. `buildGlamourStyle` falls back to the previous semantic colors (`muted` / `success`) when a theme leaves these unset, so all fifteen existing themes keep their current appearance unchanged. Ayu populates both fields with its signature yellow and cyan.

- **Docs updated** (`README.md`): Theme count bumped from fifteen → sixteen in two places; `ayu (Ayu Mirage)` added to the feature-list and themes-section descriptions.

- **Tests** (`themes_test.go`): New file covering registry lookup, unknown-name fallback to `default`, per-theme renderer overrides (Ayu), and the semantic-fallback path for themes that don't set the new fields (Dracula as a representative existing theme).

## Test plan

- [ ] `go build ./...` — clean
- [ ] `go vet ./...` — clean
- [ ] `go test ./...` — 1013/1013 pass (run as `env -u ASK_ISSUE_MCP_BEARER go test ./...` if that env var is set in your shell, to avoid an unrelated existing env-sensitive test failing)
- [ ] Launch `ask`, open `/config` → Theme, select `ayu` — UI re-paints with dark blue-grey background, yellow accents
- [ ] Send a message with a code block — inline code renders in `#E6B450` yellow, string literals in `#95E6CB` cyan
- [ ] Switch back to another theme — colors revert correctly, no regression in existing themes