### PR TITLE
Add /provider slash command, closes #3

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -323,5 +323,6 @@ func (p *providerProc) kill() {
 // provider (they configure the app itself).
 var appBuiltinSlashCmds = []slashCmd{
 	{"/config", "configure ask"},
+	{"/provider", "switch provider for this tab"},
 	{"/workflows", "edit workflow pipelines"},
 }

--- a/update.go
+++ b/update.go
@@ -1807,6 +1807,20 @@ func (m model) handleCommand(line string) (tea.Model, tea.Cmd) {
 	case "/config":
 		m = m.startConfigModal()
 		return m, nil
+	case "/provider":
+		// Mirror the Ctrl+B guards — refuse mid-turn (the stream
+		// reader is tied to the current proc and the session id is
+		// about to be wiped) and refuse from a cwd that fails the
+		// LLM-startup gate (provider switch ends up calling ProbeInit
+		// which forks the new provider).
+		if m.busy {
+			return m, nil
+		}
+		if invalid := validateAskCwd(m.cwd); invalid.Msg != "" {
+			m.appendHistory(outputStyle.Render(errStyle.Render(invalid.Msg)))
+			return m, nil
+		}
+		return m.openProviderSwitch(), nil
 	case "/workflows":
 		// /workflows opens the builder. Same flow as Ctrl+W: drop
 		// any in-flight issues query so re-entry to the issues

--- a/update_test.go
+++ b/update_test.go
@@ -1117,6 +1117,55 @@ func TestHandleCommand_ConfigEntersConfigMode(t *testing.T) {
 	}
 }
 
+func TestHandleCommand_ProviderEntersSwitcher(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m2, _ := m.handleCommand("/provider")
+	mm := m2.(model)
+	if mm.mode != modeProviderSwitch {
+		t.Errorf("/provider mode=%v want modeProviderSwitch", mm.mode)
+	}
+}
+
+// Mid-turn /provider must no-op for the same reason Ctrl+B does:
+// the stream reader is bound to the current proc and the session id
+// is about to be wiped, so swapping providers would orphan both.
+func TestHandleCommand_ProviderRefusesWhileBusy(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m.busy = true
+	historyLen := len(m.history)
+	m2, _ := m.handleCommand("/provider")
+	mm := m2.(model)
+	if mm.mode == modeProviderSwitch {
+		t.Errorf("/provider should refuse while busy; entered modeProviderSwitch")
+	}
+	if len(mm.history) != historyLen {
+		t.Errorf("/provider while busy should not append history; len=%d want %d",
+			len(mm.history), historyLen)
+	}
+}
+
+// /provider from a cwd that fails the LLM-startup gate (e.g. inside
+// an ask-managed worktree) must report the same error path the
+// chat-send and Ctrl+B paths use, not silently open the switcher
+// (which would then crash on ProbeInit's first fork).
+func TestHandleCommand_ProviderRefusesFromInvalidCwd(t *testing.T) {
+	dir := t.TempDir()
+	worktreeDir := filepath.Join(dir, ".claude", "worktrees", "alpha")
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	m := newTestModel(t, newFakeProvider())
+	m.cwd = worktreeDir
+	m2, _ := m.handleCommand("/provider")
+	mm := m2.(model)
+	if mm.mode == modeProviderSwitch {
+		t.Errorf("/provider should refuse from worktree cwd; entered modeProviderSwitch")
+	}
+	if len(mm.history) == 0 {
+		t.Errorf("/provider should append an error from invalid cwd; history empty")
+	}
+}
+
 func TestProviderStartDone_CapturesNativeSessionID(t *testing.T) {
 	fp := newFakeProvider()
 	fp.nativeSessionFn = func(*providerProc) string { return "thread-abc" }


### PR DESCRIPTION
## Summary

Closes #3. Exposes the in-tab provider switcher as `/provider`, mirroring the existing `Ctrl+B` shortcut for users on terminals or multiplexers that swallow it (tmux's prefix being the canonical case).

Same shape as `/config` and `/workflows`: registered in `appBuiltinSlashCmds` and dispatched in `handleCommand`.

## Guards

The slash path matches the Ctrl+B path exactly — not just the busy gate the issue sketch shows. Both guards are necessary:

- **Busy** — refused mid-turn because the stream reader is tied to the current proc and the session id is about to be wiped.
- **Invalid cwd** (`validateAskCwd`) — the switcher ends up calling `ProbeInit` on the new provider, which forks claude/codex; same LLM-startup precondition has to hold.

If only the busy guard were applied, `/provider` from inside an ask-managed worktree would silently open the picker and crash on the new provider's first ProbeInit fork.

## Tests

In `update_test.go`, alongside the existing `/config` test:

- `TestHandleCommand_ProviderEntersSwitcher` — happy path lands in `modeProviderSwitch`
- `TestHandleCommand_ProviderRefusesWhileBusy` — busy → no-op, no history mutation, no mode change
- `TestHandleCommand_ProviderRefusesFromInvalidCwd` — cwd inside `.claude/worktrees/<n>` → error appended, mode unchanged

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — full suite passes
- [x] `gofmt -d` clean on touched files
- [x] Manual: in a tmux session, type `/provider`, confirm the switcher opens at the current provider's row and Enter still drives down into the model picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)