### PR TITLE
Reject unknown CLI flags and subcommands, closes #8

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"charm.land/bubbles/v2/key"
@@ -159,6 +160,59 @@ the TUI. Quitting ask prints the active tab's id so it can be passed to
 `)
 }
 
+// cliCommandKind discriminates the dispatched ask subcommand.
+type cliCommandKind string
+
+const (
+	cliRun    cliCommandKind = "run"
+	cliHelp   cliCommandKind = "help"
+	cliResume cliCommandKind = "resume"
+)
+
+// cliCommand is the parsed shape of os.Args[1:].
+type cliCommand struct {
+	Kind cliCommandKind
+	VSID string
+}
+
+// parseCLICommand validates argv (without the program name) and
+// returns the dispatched command. Bare ask is "run"; --help/-h/help
+// are "help"; resume <vid> is "resume". Anything else — unknown
+// flags, unknown leading positionals, wrong-arity resume — is an
+// error so typos in shell aliases (`ask --proivder claude`) fail
+// loudly instead of silently launching the TUI.
+//
+// The internal _hook subcommand is stripped by the caller before
+// parseCLICommand sees argv: it's a non-user entry point and its
+// argv is opaque to the validator.
+func parseCLICommand(args []string) (cliCommand, error) {
+	if len(args) == 0 {
+		return cliCommand{Kind: cliRun}, nil
+	}
+	head, rest := args[0], args[1:]
+	switch head {
+	case "--help", "-h", "help":
+		if len(rest) > 0 {
+			return cliCommand{}, fmt.Errorf("help takes no arguments")
+		}
+		return cliCommand{Kind: cliHelp}, nil
+	case "resume":
+		switch {
+		case len(rest) == 0:
+			return cliCommand{}, fmt.Errorf("resume: missing virtual session id")
+		case strings.HasPrefix(rest[0], "-"):
+			return cliCommand{}, fmt.Errorf("unknown option: %s", rest[0])
+		case len(rest) > 1:
+			return cliCommand{}, fmt.Errorf("resume: extra arguments after vsID: %v", rest[1:])
+		}
+		return cliCommand{Kind: cliResume, VSID: rest[0]}, nil
+	}
+	if strings.HasPrefix(head, "-") {
+		return cliCommand{}, fmt.Errorf("unknown option: %s", head)
+	}
+	return cliCommand{}, fmt.Errorf("unknown argument: %s", head)
+}
+
 // resumeLookup resolves vsID against ~/.config/ask/sessions.json and
 // returns the matching VS id and the recorded workspace path. Pure: no
 // side effects — main is responsible for the os.Chdir, which keeps
@@ -193,30 +247,29 @@ func main() {
 		}
 		return
 	}
+	cmd, err := parseCLICommand(os.Args[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ask:", err)
+		fmt.Fprintln(os.Stderr)
+		printHelp(os.Stderr)
+		os.Exit(2)
+	}
 	var startupResumeVID string
-	if len(os.Args) >= 2 {
-		switch os.Args[1] {
-		case "--help", "-h", "help":
-			printHelp(os.Stdout)
-			return
-		case "resume":
-			if len(os.Args) < 3 {
-				fmt.Fprintln(os.Stderr, "ask resume: missing virtual session id")
-				fmt.Fprintln(os.Stderr)
-				printHelp(os.Stderr)
-				os.Exit(2)
-			}
-			vid, ws, err := resumeLookup(os.Args[2])
-			if err != nil {
-				fmt.Fprintln(os.Stderr, "ask resume:", err)
-				os.Exit(1)
-			}
-			if err := os.Chdir(ws); err != nil {
-				fmt.Fprintln(os.Stderr, "ask resume: chdir", ws+":", err)
-				os.Exit(1)
-			}
-			startupResumeVID = vid
+	switch cmd.Kind {
+	case cliHelp:
+		printHelp(os.Stdout)
+		return
+	case cliResume:
+		vid, ws, err := resumeLookup(cmd.VSID)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "ask resume:", err)
+			os.Exit(1)
 		}
+		if err := os.Chdir(ws); err != nil {
+			fmt.Fprintln(os.Stderr, "ask resume: chdir", ws+":", err)
+			os.Exit(1)
+		}
+		startupResumeVID = vid
 	}
 	cfg, _ := loadConfig()
 	_ = saveConfig(cfg)

--- a/main_test.go
+++ b/main_test.go
@@ -81,6 +81,56 @@ func TestResumeLookup_EmptyWorkspaceErrors(t *testing.T) {
 	}
 }
 
+func TestParseCLICommand(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		wantKind cliCommandKind
+		wantVSID string
+		wantErr  string // substring; "" means no error
+	}{
+		{name: "no args", args: nil, wantKind: cliRun},
+		{name: "empty argv", args: []string{}, wantKind: cliRun},
+		{name: "--help", args: []string{"--help"}, wantKind: cliHelp},
+		{name: "-h", args: []string{"-h"}, wantKind: cliHelp},
+		{name: "bare help", args: []string{"help"}, wantKind: cliHelp},
+		{name: "help with extra arg", args: []string{"help", "--foo"}, wantErr: "help takes no arguments"},
+		{name: "resume with vsID", args: []string{"resume", "vs-deadbeef"}, wantKind: cliResume, wantVSID: "vs-deadbeef"},
+		{name: "resume missing vsID", args: []string{"resume"}, wantErr: "missing virtual session id"},
+		{name: "resume extra arg", args: []string{"resume", "vs-1", "vs-2"}, wantErr: "extra arguments"},
+		{name: "resume option-like vsID", args: []string{"resume", "--foo"}, wantErr: "unknown option: --foo"},
+		{name: "unknown long flag", args: []string{"--frobnicate"}, wantErr: "unknown option: --frobnicate"},
+		{name: "unknown short flag", args: []string{"-x"}, wantErr: "unknown option: -x"},
+		{name: "unknown subcommand", args: []string{"banana"}, wantErr: "unknown argument: banana"},
+		// Provider-typo regression: caught as an unknown option, not
+		// silently swallowed (the bug this issue fixes).
+		{name: "provider typo", args: []string{"--proivder", "claude"}, wantErr: "unknown option: --proivder"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := parseCLICommand(c.args)
+			if c.wantErr != "" {
+				if err == nil {
+					t.Fatalf("want error containing %q, got nil (cmd=%+v)", c.wantErr, got)
+				}
+				if !strings.Contains(err.Error(), c.wantErr) {
+					t.Errorf("err=%q want substring %q", err.Error(), c.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Kind != c.wantKind {
+				t.Errorf("Kind=%q want %q", got.Kind, c.wantKind)
+			}
+			if got.VSID != c.wantVSID {
+				t.Errorf("VSID=%q want %q", got.VSID, c.wantVSID)
+			}
+		})
+	}
+}
+
 func TestPrintHelp_MentionsKeyCommands(t *testing.T) {
 	var buf bytes.Buffer
 	printHelp(&buf)
@@ -311,4 +361,3 @@ func TestUpdate_StartupResumeMsgIgnoresWrongTab(t *testing.T) {
 		t.Errorf("wrong tab should not seed virtualSessionID, got %q", newM.virtualSessionID)
 	}
 }
-


### PR DESCRIPTION
## Summary

Closes #8. Today `ask --frobnicate` and `ask banana` silently launch the TUI as if no arguments were passed; typos in shell aliases (`ask --proivder claude`) are invisible. Validate argv up front and exit with the help text on anything we don't recognise.

## Approach

Adds `parseCLICommand(args []string) (cliCommand, error)` — a pure helper next to `printHelp`/`resumeLookup` in `main.go`. Returns:

- `Kind: cliRun` — bare `ask`, no args
- `Kind: cliHelp` — `--help`, `-h`, or `help`
- `Kind: cliResume` + `VSID` — `resume <vid>`
- `error` — anything else

Rules per the issue:
- Help forms reject extra args (`help --foo` → error).
- `resume` requires exactly one positional; an option-like trailing arg like `resume --foo` reports `unknown option: --foo` rather than treating `--foo` as a vsID.
- Unknown leading `-`-prefixed token → `unknown option: <token>`.
- Unknown leading positional → `unknown argument: <token>`.

`main` calls `parseCLICommand` after stripping the internal `_hook` subcommand (which is an opaque non-user entry point and bypasses validation, per the issue's "pre-parser flags" note). Validation errors print to stderr followed by the help block, exit code 2 — matching the existing arity-error path for bare `ask resume`. Runtime errors from `resumeLookup` keep their existing exit code 1.

## Tests

`TestParseCLICommand` is a table-driven test covering every behavior in the issue's "Tests worth adding" list, plus a `--proivder` typo regression case (the bug-flavor sentence in the issue's "Why" section):

- `no args` / `empty argv` → `cliRun`
- `--help` / `-h` / `help` → `cliHelp`
- `help --foo` → error "help takes no arguments"
- `resume <vid>` → `cliResume`, VSID populated
- `resume` (missing) → error "missing virtual session id"
- `resume a b` → error "extra arguments"
- `resume --foo` → error "unknown option: --foo"
- `--frobnicate`, `-x` → error "unknown option: ..."
- `banana` → error "unknown argument: banana"
- `--proivder claude` → error "unknown option: --proivder"

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — full suite passes
- [x] `gofmt -d` clean on touched files
- [x] Manual: `ask --frobnicate` exits 2 with help; `ask resume` (no arg) exits 2 with help; `ask resume vs-realone` still resumes correctly; bare `ask` still launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)