### PR TITLE
Honor LastProvider on ask resume, fixes #4

### DIFF
--- a/main.go
+++ b/main.go
@@ -214,30 +214,55 @@ func parseCLICommand(args []string) (cliCommand, error) {
 }
 
 // resumeLookup resolves vsID against ~/.config/ask/sessions.json and
-// returns the matching VS id and the recorded workspace path. Pure: no
-// side effects — main is responsible for the os.Chdir, which keeps
-// tests self-contained (chdirs from a test process pollute every test
+// returns the matching VS id, the recorded workspace path, and the
+// provider id that wrote the most recent turn (empty for legacy VSes
+// stored before LastProvider was tracked). Pure: no side effects —
+// main is responsible for the os.Chdir, which keeps tests
+// self-contained (chdirs from a test process pollute every test
 // that follows because the cleanup ordering against t.TempDir teardown
 // is fragile when the cwd points inside a doomed tempdir).
-func resumeLookup(vsID string) (id, workspace string, err error) {
+func resumeLookup(vsID string) (id, workspace, lastProvider string, err error) {
 	if vsID == "" {
-		return "", "", fmt.Errorf("missing virtual session id")
+		return "", "", "", fmt.Errorf("missing virtual session id")
 	}
 	store, err := loadVirtualSessions()
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 	vs := store.findByID(vsID)
 	if vs == nil {
-		return "", "", fmt.Errorf("virtual session %q not found", vsID)
+		return "", "", "", fmt.Errorf("virtual session %q not found", vsID)
 	}
 	if vs.Workspace == "" {
-		return "", "", fmt.Errorf("virtual session %q has no workspace recorded", vsID)
+		return "", "", "", fmt.Errorf("virtual session %q has no workspace recorded", vsID)
 	}
 	if _, err := os.Stat(vs.Workspace); err != nil {
-		return "", "", fmt.Errorf("workspace %s: %w", vs.Workspace, err)
+		return "", "", "", fmt.Errorf("workspace %s: %w", vs.Workspace, err)
 	}
-	return vs.ID, vs.Workspace, nil
+	return vs.ID, vs.Workspace, vs.LastProvider, nil
+}
+
+// resolveStartupProvider picks the provider id ask should use for
+// this session, given an optional resume-side override and the saved
+// default. When the override resolves to a registered provider it
+// wins; when the override is a stale id (provider removed or renamed
+// since the VS was written), warn on `warn` and fall back to the
+// saved default. Empty override → saved default, matching the pre-fix
+// CLI behavior so legacy VSes (written before LastProvider tracking)
+// keep working.
+//
+// The warn writer is parameterised so tests can capture the line
+// without touching os.Stderr.
+func resolveStartupProvider(resumeProviderID, savedDefault string, warn io.Writer) string {
+	if resumeProviderID == "" {
+		return savedDefault
+	}
+	if _, ok := providerByIDStrict(resumeProviderID); ok {
+		return resumeProviderID
+	}
+	fmt.Fprintf(warn, "ask: resumed session was last used with provider %q which is no longer registered; falling back to %q\n",
+		resumeProviderID, savedDefault)
+	return savedDefault
 }
 
 func main() {
@@ -254,13 +279,13 @@ func main() {
 		printHelp(os.Stderr)
 		os.Exit(2)
 	}
-	var startupResumeVID string
+	var startupResumeVID, startupResumeProvider string
 	switch cmd.Kind {
 	case cliHelp:
 		printHelp(os.Stdout)
 		return
 	case cliResume:
-		vid, ws, err := resumeLookup(cmd.VSID)
+		vid, ws, lastProv, err := resumeLookup(cmd.VSID)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "ask resume:", err)
 			os.Exit(1)
@@ -270,9 +295,15 @@ func main() {
 			os.Exit(1)
 		}
 		startupResumeVID = vid
+		startupResumeProvider = lastProv
 	}
 	cfg, _ := loadConfig()
 	_ = saveConfig(cfg)
+	// Resume-time provider override: respects the conversation's
+	// LastProvider so resuming a Claude thread under a Codex default
+	// reopens under Claude. Applied AFTER saveConfig so the override
+	// stays per-launch and never rewrites the persisted default.
+	cfg.Provider = resolveStartupProvider(startupResumeProvider, cfg.Provider, os.Stderr)
 	if cfg.UI.Worktree != nil && *cfg.UI.Worktree {
 		ensureWorktreeGitignore()
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -20,7 +20,7 @@ func TestResumeLookup_FindsVSAndReturnsWorkspace(t *testing.T) {
 		t.Fatalf("save: %v", err)
 	}
 
-	gotID, gotWS, err := resumeLookup(vsID)
+	gotID, gotWS, gotProv, err := resumeLookup(vsID)
 	if err != nil {
 		t.Fatalf("resumeLookup: %v", err)
 	}
@@ -32,18 +32,51 @@ func TestResumeLookup_FindsVSAndReturnsWorkspace(t *testing.T) {
 	if gotAbs != wantAbs {
 		t.Errorf("returned workspace=%q want %q", gotAbs, wantAbs)
 	}
+	if gotProv != "claude" {
+		t.Errorf("returned lastProvider=%q want claude", gotProv)
+	}
+}
+
+// Legacy VSes written before LastProvider was tracked have an empty
+// string for the field — resumeLookup should pass it through as-is so
+// resolveStartupProvider can fall back to the saved default without
+// any extra plumbing in main.
+func TestResumeLookup_LegacyVSReturnsEmptyLastProvider(t *testing.T) {
+	isolateHome(t)
+	ws := t.TempDir()
+	store := &virtualSessionStore{
+		Version: 1,
+		Sessions: []VirtualSession{{
+			ID:           "vs-legacy",
+			Workspace:    ws,
+			CreatedAt:    time.Now().UTC(),
+			UpdatedAt:    time.Now().UTC(),
+			Preview:      "old session",
+			LastProvider: "", // pre-LastProvider VS
+		}},
+	}
+	if err := saveVirtualSessions(store); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	_, _, gotProv, err := resumeLookup("vs-legacy")
+	if err != nil {
+		t.Fatalf("resumeLookup: %v", err)
+	}
+	if gotProv != "" {
+		t.Errorf("legacy VS should return empty lastProvider, got %q", gotProv)
+	}
 }
 
 func TestResumeLookup_EmptyIDErrors(t *testing.T) {
 	isolateHome(t)
-	if _, _, err := resumeLookup(""); err == nil {
+	if _, _, _, err := resumeLookup(""); err == nil {
 		t.Fatal("empty id should error")
 	}
 }
 
 func TestResumeLookup_UnknownIDErrors(t *testing.T) {
 	isolateHome(t)
-	_, _, err := resumeLookup("vs-does-not-exist")
+	_, _, _, err := resumeLookup("vs-does-not-exist")
 	if err == nil {
 		t.Fatal("unknown vsID should error")
 	}
@@ -61,7 +94,7 @@ func TestResumeLookup_MissingWorkspaceErrors(t *testing.T) {
 	if err := saveVirtualSessions(store); err != nil {
 		t.Fatalf("save: %v", err)
 	}
-	_, _, err := resumeLookup(vsID)
+	_, _, _, err := resumeLookup(vsID)
 	if err == nil {
 		t.Fatal("missing workspace should error")
 	}
@@ -75,7 +108,7 @@ func TestResumeLookup_EmptyWorkspaceErrors(t *testing.T) {
 	if err := saveVirtualSessions(store); err != nil {
 		t.Fatalf("save: %v", err)
 	}
-	_, _, err := resumeLookup(vsID)
+	_, _, _, err := resumeLookup(vsID)
 	if err == nil {
 		t.Fatal("empty workspace should error")
 	}
@@ -128,6 +161,127 @@ func TestParseCLICommand(t *testing.T) {
 				t.Errorf("VSID=%q want %q", got.VSID, c.wantVSID)
 			}
 		})
+	}
+}
+
+// resolveStartupProvider is the heart of the #4 fix. The matrix
+// covers every override × default combination that can hit the CLI
+// resume path: legacy VS, override matches default, override differs
+// from default, override is stale (provider removed/renamed), and
+// the corner cases around an empty saved default.
+func TestResolveStartupProvider(t *testing.T) {
+	f1 := newFakeProvider()
+	f1.id = "claude"
+	f2 := newFakeProvider()
+	f2.id = "codex"
+	withRegisteredProviders(t, f1, f2)
+
+	cases := []struct {
+		name           string
+		resumeOverride string
+		savedDefault   string
+		want           string
+		wantWarn       bool
+	}{
+		{
+			name:           "legacy VS keeps saved default",
+			resumeOverride: "",
+			savedDefault:   "codex",
+			want:           "codex",
+		},
+		{
+			name:           "override differs from default — override wins (the bug fix)",
+			resumeOverride: "claude",
+			savedDefault:   "codex",
+			want:           "claude",
+		},
+		{
+			name:           "override matches default — override wins (no-op semantically)",
+			resumeOverride: "claude",
+			savedDefault:   "claude",
+			want:           "claude",
+		},
+		{
+			name:           "stale override — fall back + warn",
+			resumeOverride: "gemini-removed",
+			savedDefault:   "codex",
+			want:           "codex",
+			wantWarn:       true,
+		},
+		{
+			name:           "stale override + empty saved default — fall back to empty + warn",
+			resumeOverride: "gemini-removed",
+			savedDefault:   "",
+			want:           "",
+			wantWarn:       true,
+		},
+		{
+			name:           "valid override + unknown saved default — override still wins, no warn",
+			resumeOverride: "claude",
+			savedDefault:   "stale-default-survives",
+			want:           "claude",
+		},
+		{
+			name:           "empty override + empty default — empty out (caller's providerByID handles fallback)",
+			resumeOverride: "",
+			savedDefault:   "",
+			want:           "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var warn bytes.Buffer
+			got := resolveStartupProvider(c.resumeOverride, c.savedDefault, &warn)
+			if got != c.want {
+				t.Errorf("got %q want %q", got, c.want)
+			}
+			gotWarn := warn.Len() > 0
+			if gotWarn != c.wantWarn {
+				t.Errorf("warn=%q gotWarn=%v wantWarn=%v", warn.String(), gotWarn, c.wantWarn)
+			}
+			if c.wantWarn {
+				// Stale-id warnings must name the bad id so the
+				// user can correlate and rename or update config.
+				if !strings.Contains(warn.String(), c.resumeOverride) {
+					t.Errorf("warn should name the stale id %q; got %q",
+						c.resumeOverride, warn.String())
+				}
+			}
+		})
+	}
+}
+
+// End-to-end: a Claude VS recovered via resumeLookup, fed through
+// resolveStartupProvider with a Codex saved default, must produce a
+// resolved id equal to "claude". This is the exact data-loss bug
+// in #4 — proves the wiring across both helpers, not just each in
+// isolation.
+func TestResumeFlow_ClaudeVSUnderCodexDefaultPicksClaude(t *testing.T) {
+	f1 := newFakeProvider()
+	f1.id = "claude"
+	f2 := newFakeProvider()
+	f2.id = "codex"
+	withRegisteredProviders(t, f1, f2)
+	isolateHome(t)
+	ws := t.TempDir()
+	store := &virtualSessionStore{Version: 1}
+	vsID := upsertVirtualSession(store, "", ws, "claude", "native-1", ws,
+		"hi", time.Now().UTC())
+	if err := saveVirtualSessions(store); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	_, _, lastProv, err := resumeLookup(vsID)
+	if err != nil {
+		t.Fatalf("resumeLookup: %v", err)
+	}
+	var warn bytes.Buffer
+	resolved := resolveStartupProvider(lastProv, "codex", &warn)
+	if resolved != "claude" {
+		t.Errorf("CLI resume of a Claude VS under Codex default resolved to %q want claude — the #4 data-loss bug",
+			resolved)
+	}
+	if warn.Len() != 0 {
+		t.Errorf("happy-path resume must not warn; got %q", warn.String())
 	}
 }
 

--- a/provider.go
+++ b/provider.go
@@ -307,6 +307,24 @@ func providerByID(id string) Provider {
 	return nil
 }
 
+// providerByIDStrict returns the provider with the given ID and true,
+// or nil and false when nothing matches. Unlike providerByID it does
+// not fall back to the first registered provider — used by callers
+// (the resume-side LastProvider override) that need to detect a
+// missing/renamed id and surface it instead of silently swapping
+// providers under the user.
+func providerByIDStrict(id string) (Provider, bool) {
+	if id == "" {
+		return nil, false
+	}
+	for _, p := range providerRegistry {
+		if p.ID() == id {
+			return p, true
+		}
+	}
+	return nil, false
+}
+
 // kill terminates the subprocess and closes stdin. Safe on nil or
 // already-reaped receivers.
 func (p *providerProc) kill() {

--- a/provider_test.go
+++ b/provider_test.go
@@ -65,6 +65,57 @@ func TestProviderByID_EmptyIDReturnsFirst(t *testing.T) {
 	}
 }
 
+// providerByIDStrict must NEVER fall back to the first registered
+// provider. The resume-side LastProvider override depends on this:
+// silently swapping providers when the recorded id is missing would
+// either reopen the conversation under the wrong backend (defeating
+// the purpose) or hide the rename/removal from the user.
+func TestProviderByIDStrict_HitReturnsTrue(t *testing.T) {
+	f1 := newFakeProvider()
+	f1.id = "alpha"
+	f2 := newFakeProvider()
+	f2.id = "beta"
+	withRegisteredProviders(t, f1, f2)
+	got, ok := providerByIDStrict("beta")
+	if !ok {
+		t.Fatal("strict lookup should find beta")
+	}
+	if got != f2 {
+		t.Errorf("strict beta returned %v want f2", got)
+	}
+}
+
+func TestProviderByIDStrict_MissReturnsNilFalse(t *testing.T) {
+	f1 := newFakeProvider()
+	f1.id = "alpha"
+	withRegisteredProviders(t, f1)
+	got, ok := providerByIDStrict("not-real")
+	if ok {
+		t.Error("strict miss must return false, not the first-fallback")
+	}
+	if got != nil {
+		t.Errorf("strict miss should return nil, got %v", got)
+	}
+}
+
+func TestProviderByIDStrict_EmptyIDReturnsNilFalse(t *testing.T) {
+	f1 := newFakeProvider()
+	f1.id = "alpha"
+	withRegisteredProviders(t, f1)
+	got, ok := providerByIDStrict("")
+	if ok || got != nil {
+		t.Errorf("strict empty id must miss; got=%v ok=%v", got, ok)
+	}
+}
+
+func TestProviderByIDStrict_EmptyRegistryMisses(t *testing.T) {
+	withRegisteredProviders(t)
+	got, ok := providerByIDStrict("anything")
+	if ok || got != nil {
+		t.Errorf("strict empty registry must miss; got=%v ok=%v", got, ok)
+	}
+}
+
 func TestClaudeProvider_Metadata(t *testing.T) {
 	var p claudeProvider
 	if got := p.ID(); got != "claude" {


### PR DESCRIPTION
## Summary

Fixes #4. `ask resume <vsID>` now respects the conversation's recorded `LastProvider`, so resuming a Claude thread under a Codex saved default reopens under Claude. Before this PR the override was silently dropped: `main` always used `cfg.Provider`, the saved default, and the Claude history became unreachable from the freshly-opened Codex session.

## Approach

The data was already there — `VirtualSession.LastProvider` is populated on every `applyTurn` and is consumed by the in-tab `/resume` picker via `resumeVirtualSession`. Only the CLI entry path dropped it. Three small changes restore the wiring:

1. **`resumeLookup` now returns the LastProvider** alongside id and workspace. Backwards-compatible via the type system: legacy VSes carry an empty string for the field, which short-circuits to the saved default in step 3 below.

2. **New `providerByIDStrict(id) (Provider, bool)`** in `provider.go` — strict counterpart to the existing permissive `providerByID`. The resume override needs strict semantics so a stale id (provider removed/renamed since the VS was written) is detectable and surfaces a warning instead of silently picking the first registered provider.

3. **New `resolveStartupProvider(resumeOverride, savedDefault, warn) string`** in `main.go`:
   - Empty override → savedDefault (legacy-VS path)
   - Override resolves via `providerByIDStrict` → override wins
   - Override is stale → write a warning naming the bad id, fall back to savedDefault

`main()` calls `resolveStartupProvider` **after** `saveConfig(cfg)` so the override stays one-shot and never rewrites the persisted default — matching the precedent the issue calls out for the future #5/#6 CLI overrides.

## Drift from the issue's sketch

The issue's resolution order was `--provider flag → LastProvider → cfg.Provider`. The flag doesn't exist yet (#5), so I implemented `LastProvider → cfg.Provider`. When #5 lands, the flag override slots in upstream of `resolveStartupProvider` with no signature change.

## Tests (heavy coverage as requested)

**`provider_test.go` — strict registry helper, 4 tests:**
- `TestProviderByIDStrict_HitReturnsTrue` — happy path
- `TestProviderByIDStrict_MissReturnsNilFalse` — never falls back to first
- `TestProviderByIDStrict_EmptyIDReturnsNilFalse` — empty input misses
- `TestProviderByIDStrict_EmptyRegistryMisses` — empty registry misses

**`main_test.go` — resolveStartupProvider matrix (table-driven, 7 cases):**
- legacy VS keeps saved default
- override differs from default → override wins (the bug fix)
- override matches default → override wins (semantically a no-op)
- stale override → fall back + warn naming the bad id
- stale override + empty saved default → empty + warn
- valid override + unknown saved default → override still wins, no warn
- empty override + empty default → empty out

**`main_test.go` — resumeLookup signature update + new coverage:**
- All five existing `TestResumeLookup_*` updated for the new four-return signature
- New `TestResumeLookup_LegacyVSReturnsEmptyLastProvider` — legacy VS path

**`main_test.go` — end-to-end wiring:**
- `TestResumeFlow_ClaudeVSUnderCodexDefaultPicksClaude` — stitches `resumeLookup` → `resolveStartupProvider` and asserts the resolved id is `"claude"`. Direct regression test for the data-loss bug.

15 tests total, including 7 subtests, all behavior-only per the repo's testing conventions.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — full suite passes
- [x] `gofmt -d` clean on touched files
- [x] Manual: start Claude session, write a turn, quit; `/config` switch default to Codex, quit; `ask resume <vsID>`; verify the Claude history is visible and the next turn lands on Claude not Codex
- [x] Manual: `ask resume <vsID-with-fake-LastProvider>` (rename a provider in sessions.json) → confirm warning on stderr and fall back to saved default

🤖 Generated with [Claude Code](https://claude.com/claude-code)