### PR TITLE
Move GitHub MCP config to project-level slot, decouple from issues provider

### DIFF
--- a/claude.go
+++ b/claude.go
@@ -163,32 +163,32 @@ const mcpTimeoutMillis = "86400000"
 // claudeMCPConfig builds the JSON passed via --mcp-config. The "ask"
 // entry is always present (it's the loopback bridge for the question
 // modal, permission prompts, and the memory hooks). When the project
-// has a configured issue provider, its MCP descriptor lands as a peer
-// entry under its own name (e.g. "github") so the chat agent can call
-// list_issues / issue_read / search_issues without a separate config
-// step.
+// has a configured project MCP (today: the GitHub MCP slot), its
+// descriptor lands as a peer entry under its own name (e.g. "github")
+// so the chat agent can call list_issues / issue_read / search_issues
+// without a separate config step.
 //
-// The token in issue.Headers is sensitive — it goes onto a child
+// The token in projectMCP.Headers is sensitive — it goes onto a child
 // process's argv, which is visible to the user (`ps`) and to system
 // audit. That's the same trust boundary the GitHub MCP CLI itself
 // asks for, so we don't introduce extra indirection here, but DO
 // keep the JSON out of debug logs.
-func claudeMCPConfig(mcpPort int, issue *issueMCPServer) string {
+func claudeMCPConfig(mcpPort int, projectMCP *issueMCPServer) string {
 	servers := map[string]any{
 		"ask": map[string]any{
 			"type": "http",
 			"url":  fmt.Sprintf("http://127.0.0.1:%d/", mcpPort),
 		},
 	}
-	if issue != nil && issue.Name != "" && issue.URL != "" {
+	if projectMCP != nil && projectMCP.Name != "" && projectMCP.URL != "" {
 		entry := map[string]any{
 			"type": "http",
-			"url":  issue.URL,
+			"url":  projectMCP.URL,
 		}
-		if len(issue.Headers) > 0 {
-			entry["headers"] = issue.Headers
+		if len(projectMCP.Headers) > 0 {
+			entry["headers"] = projectMCP.Headers
 		}
-		servers[issue.Name] = entry
+		servers[projectMCP.Name] = entry
 	}
 	b, _ := json.Marshal(map[string]any{"mcpServers": servers})
 	return string(b)
@@ -226,7 +226,7 @@ func claudeCLIArgs(args ProviderSessionArgs, probe bool) []string {
 		out = append(out, "--plugin-dir", args.PluginDir)
 	}
 	if args.MCPPort > 0 {
-		out = append(out, "--mcp-config", claudeMCPConfig(args.MCPPort, args.IssueMCP))
+		out = append(out, "--mcp-config", claudeMCPConfig(args.MCPPort, args.ProjectMCP))
 		out = append(out, "--settings", claudeHookSettings(args.MCPPort))
 		if !probe {
 			out = append(out, "--permission-prompt-tool", "mcp__ask__approval_prompt")

--- a/claude_cli_test.go
+++ b/claude_cli_test.go
@@ -219,15 +219,15 @@ func TestClaudeCLIArgs_ExplicitModelPassesThrough(t *testing.T) {
 	}
 }
 
-// When the project has a configured issue provider, its MCP entry
-// must land in --mcp-config alongside the loopback "ask" bridge so
-// the chat agent has the same issue-tracker access ask uses for
-// ctrl+i. Auth headers go on the entry verbatim — the chat agent's
-// MCP client reads them and attaches Authorization: Bearer …
-func TestClaudeCLIArgs_IssueMCPInjectedIntoMCPConfig(t *testing.T) {
+// When the project has a configured GitHub MCP slot, its entry must
+// land in --mcp-config alongside the loopback "ask" bridge so the
+// chat agent has the same MCP access ask uses for ctrl+i. Auth
+// headers go on the entry verbatim — the chat agent's MCP client
+// reads them and attaches Authorization: Bearer …
+func TestClaudeCLIArgs_ProjectMCPInjectedIntoMCPConfig(t *testing.T) {
 	args := claudeCLIArgs(ProviderSessionArgs{
 		MCPPort: 4321,
-		IssueMCP: &issueMCPServer{
+		ProjectMCP: &issueMCPServer{
 			Name:    "github",
 			URL:     "https://api.githubcopilot.com/mcp",
 			Headers: map[string]string{"Authorization": "Bearer ghp_secret"},
@@ -263,7 +263,51 @@ func TestClaudeCLIArgs_IssueMCPInjectedIntoMCPConfig(t *testing.T) {
 	}
 }
 
-func TestClaudeCLIArgs_NoIssueMCP_OnlyAskEntry(t *testing.T) {
+// The end-to-end inversion: with Issues.Provider == "" but a
+// project-level MCP token populated, the chat agent must still
+// receive the github MCP entry via projectGitHubMCP →
+// ProviderSessionArgs.ProjectMCP → claudeMCPConfig. This is the whole
+// point of decoupling the MCP slot from the issues provider — chat
+// access without forcing the user into the issues UI.
+func TestClaudeCLIArgs_ProjectMCPIndependentOfIssueProvider(t *testing.T) {
+	isolateHome(t)
+	cwd := t.TempDir()
+	cfg, _ := loadConfig()
+	cfg = upsertProjectConfig(cfg, cwd, projectConfig{
+		MCP: projectMCPConfig{GitHub: githubMCPConfig{Token: "ghp_secret"}},
+		// Issues.Provider deliberately left empty.
+	})
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("seed saveConfig: %v", err)
+	}
+	args := claudeCLIArgs(ProviderSessionArgs{
+		MCPPort:    4321,
+		ProjectMCP: projectGitHubMCP(cwd),
+	}, false)
+	cfgRaw := argAfter(args, "--mcp-config")
+	if cfgRaw == "" {
+		t.Fatalf("--mcp-config missing: %v", args)
+	}
+	var parsed struct {
+		MCPServers map[string]struct {
+			Type    string            `json:"type"`
+			URL     string            `json:"url"`
+			Headers map[string]string `json:"headers"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal([]byte(cfgRaw), &parsed); err != nil {
+		t.Fatalf("--mcp-config not JSON (%v): %s", err, cfgRaw)
+	}
+	gh, ok := parsed.MCPServers["github"]
+	if !ok {
+		t.Fatalf("github MCP entry must be injected when MCP token is set even without an issue provider; got %s", cfgRaw)
+	}
+	if gh.Headers["Authorization"] != "Bearer ghp_secret" {
+		t.Errorf("Authorization header missing or wrong: %+v", gh.Headers)
+	}
+}
+
+func TestClaudeCLIArgs_NoProjectMCP_OnlyAskEntry(t *testing.T) {
 	args := claudeCLIArgs(ProviderSessionArgs{MCPPort: 4321}, false)
 	cfg := argAfter(args, "--mcp-config")
 	var parsed struct {
@@ -276,7 +320,7 @@ func TestClaudeCLIArgs_NoIssueMCP_OnlyAskEntry(t *testing.T) {
 		t.Errorf("ask entry should always exist: %s", cfg)
 	}
 	if len(parsed.MCPServers) != 1 {
-		t.Errorf("only ask should be present without IssueMCP, got %d entries: %s",
+		t.Errorf("only ask should be present without ProjectMCP, got %d entries: %s",
 			len(parsed.MCPServers), cfg)
 	}
 }

--- a/codex.go
+++ b/codex.go
@@ -210,9 +210,9 @@ type codexState struct {
 // flag writes to). Each path is strconv.Quote'd so spaces or quotes
 // don't break codex's TOML parser.
 //
-// IssueMCP translates to a -c mcp_servers.<name>.url override pair.
+// ProjectMCP translates to a -c mcp_servers.<name>.url override pair.
 // Codex pulls the bearer token from an env var (not from config), so
-// we point it at codexIssueMCPBearerEnv and codexEnv exports the
+// we point it at codexProjectMCPBearerEnv and codexEnv exports the
 // matching key.
 func codexCLIArgs(args ProviderSessionArgs) []string {
 	out := []string{"app-server", "--listen", "stdio://"}
@@ -224,29 +224,30 @@ func codexCLIArgs(args ProviderSessionArgs) []string {
 		out = append(out, "-c",
 			"sandbox_workspace_write.writable_roots=["+strings.Join(quoted, ",")+"]")
 	}
-	if mcp := args.IssueMCP; mcp != nil && mcp.Name != "" && mcp.URL != "" {
+	if mcp := args.ProjectMCP; mcp != nil && mcp.Name != "" && mcp.URL != "" {
 		base := "mcp_servers." + mcp.Name
 		out = append(out, "-c", base+".url="+strconv.Quote(mcp.URL))
-		if codexIssueBearerToken(mcp) != "" {
+		if codexProjectMCPBearerToken(mcp) != "" {
 			out = append(out, "-c",
-				base+".bearer_token_env_var="+strconv.Quote(codexIssueMCPBearerEnv))
+				base+".bearer_token_env_var="+strconv.Quote(codexProjectMCPBearerEnv))
 		}
 	}
 	return out
 }
 
-// codexIssueMCPBearerEnv is the env-var name codex reads for the
+// codexProjectMCPBearerEnv is the env-var name codex reads for the
 // streamable-HTTP bearer token. Hard-coded — codex's MCP config takes
-// only one bearer slot per server and ask only injects one issue MCP
-// per session, so a single well-known env var is enough.
-const codexIssueMCPBearerEnv = "ASK_ISSUE_MCP_BEARER"
+// only one bearer slot per server and ask only injects one project
+// MCP per session, so a single well-known env var is enough.
+const codexProjectMCPBearerEnv = "ASK_PROJECT_MCP_BEARER"
 
-// codexIssueBearerToken extracts the raw bearer token from an issue
-// MCP descriptor's Authorization header (`Bearer <token>`). Returns
-// empty string when the descriptor has no Authorization header — the
-// caller then omits the bearer_token_env_var override, leaving the
-// MCP server unauthenticated (which is fine for public servers).
-func codexIssueBearerToken(mcp *issueMCPServer) string {
+// codexProjectMCPBearerToken extracts the raw bearer token from a
+// project MCP descriptor's Authorization header (`Bearer <token>`).
+// Returns empty string when the descriptor has no Authorization
+// header — the caller then omits the bearer_token_env_var override,
+// leaving the MCP server unauthenticated (which is fine for public
+// servers).
+func codexProjectMCPBearerToken(mcp *issueMCPServer) string {
 	if mcp == nil {
 		return ""
 	}
@@ -260,18 +261,18 @@ func codexIssueBearerToken(mcp *issueMCPServer) string {
 
 // codexEnv returns the env block for the codex subprocess. Inherits
 // the parent process env and layers on the bearer-token env var when
-// an issue MCP with auth is configured. Pulled out so tests assert
+// a project MCP with auth is configured. Pulled out so tests assert
 // the env without spawning a process.
 func codexEnv(args ProviderSessionArgs) []string {
 	env := make([]string, 0, len(os.Environ())+1)
 	for _, e := range os.Environ() {
-		if strings.HasPrefix(e, codexIssueMCPBearerEnv+"=") {
+		if strings.HasPrefix(e, codexProjectMCPBearerEnv+"=") {
 			continue
 		}
 		env = append(env, e)
 	}
-	if tok := codexIssueBearerToken(args.IssueMCP); tok != "" {
-		env = append(env, codexIssueMCPBearerEnv+"="+tok)
+	if tok := codexProjectMCPBearerToken(args.ProjectMCP); tok != "" {
+		env = append(env, codexProjectMCPBearerEnv+"="+tok)
 	}
 	return env
 }

--- a/codex_cli_test.go
+++ b/codex_cli_test.go
@@ -83,13 +83,13 @@ func TestCodexCLIArgs_AddedDirsQuoteEscaped(t *testing.T) {
 	}
 }
 
-// IssueMCP must land as a -c mcp_servers.<name>.url override pair so
+// ProjectMCP must land as a -c mcp_servers.<name>.url override pair so
 // codex's TOML config picks up an HTTP MCP server at launch — same
 // access ask uses for ctrl+i. Bearer auth goes via env (codex's MCP
 // config takes only an env-var name, not the literal token).
-func TestCodexCLIArgs_IssueMCPEmitsURLAndBearerOverrides(t *testing.T) {
+func TestCodexCLIArgs_ProjectMCPEmitsURLAndBearerOverrides(t *testing.T) {
 	args := codexCLIArgs(ProviderSessionArgs{
-		IssueMCP: &issueMCPServer{
+		ProjectMCP: &issueMCPServer{
 			Name:    "github",
 			URL:     "https://api.githubcopilot.com/mcp",
 			Headers: map[string]string{"Authorization": "Bearer ghp_secret"},
@@ -109,9 +109,9 @@ func TestCodexCLIArgs_IssueMCPEmitsURLAndBearerOverrides(t *testing.T) {
 			}
 		case strings.HasPrefix(v, "mcp_servers.github.bearer_token_env_var="):
 			sawBearer = true
-			if !strings.Contains(v, `"`+codexIssueMCPBearerEnv+`"`) {
+			if !strings.Contains(v, `"`+codexProjectMCPBearerEnv+`"`) {
 				t.Errorf("bearer_token_env_var should point at %s, got %q",
-					codexIssueMCPBearerEnv, v)
+					codexProjectMCPBearerEnv, v)
 			}
 		}
 	}
@@ -126,9 +126,9 @@ func TestCodexCLIArgs_IssueMCPEmitsURLAndBearerOverrides(t *testing.T) {
 // Public/unauthenticated MCP servers (no Authorization header) skip
 // the bearer override but still emit the url. Otherwise codex would
 // refuse the launch citing a missing env var.
-func TestCodexCLIArgs_IssueMCPWithoutAuthOmitsBearer(t *testing.T) {
+func TestCodexCLIArgs_ProjectMCPWithoutAuthOmitsBearer(t *testing.T) {
 	args := codexCLIArgs(ProviderSessionArgs{
-		IssueMCP: &issueMCPServer{
+		ProjectMCP: &issueMCPServer{
 			Name: "public",
 			URL:  "https://example.com/mcp",
 		},
@@ -141,16 +141,16 @@ func TestCodexCLIArgs_IssueMCPWithoutAuthOmitsBearer(t *testing.T) {
 	}
 }
 
-// codexEnv must export the bearer token under codexIssueMCPBearerEnv
+// codexEnv must export the bearer token under codexProjectMCPBearerEnv
 // so the codex subprocess can read it. The token MUST appear only in
 // the env (process-private) — never on argv (visible via ps).
 func TestCodexEnv_ExportsBearerToken(t *testing.T) {
 	env := codexEnv(ProviderSessionArgs{
-		IssueMCP: &issueMCPServer{
+		ProjectMCP: &issueMCPServer{
 			Headers: map[string]string{"Authorization": "Bearer ghp_secret"},
 		},
 	})
-	want := codexIssueMCPBearerEnv + "=ghp_secret"
+	want := codexProjectMCPBearerEnv + "=ghp_secret"
 	var saw bool
 	for _, e := range env {
 		if e == want {
@@ -162,27 +162,57 @@ func TestCodexEnv_ExportsBearerToken(t *testing.T) {
 	}
 }
 
-func TestCodexEnv_NoIssueMCP_LeavesEnvUntouched(t *testing.T) {
-	t.Setenv(codexIssueMCPBearerEnv, "stale-token")
+func TestCodexEnv_NoProjectMCP_LeavesEnvUntouched(t *testing.T) {
+	t.Setenv(codexProjectMCPBearerEnv, "stale-token")
 	env := codexEnv(ProviderSessionArgs{})
 	for _, e := range env {
-		if strings.HasPrefix(e, codexIssueMCPBearerEnv+"=") {
-			t.Errorf("no IssueMCP should leave %s unset; saw %q", codexIssueMCPBearerEnv, e)
+		if strings.HasPrefix(e, codexProjectMCPBearerEnv+"=") {
+			t.Errorf("no ProjectMCP should leave %s unset; saw %q", codexProjectMCPBearerEnv, e)
 		}
 	}
 }
 
-func TestCodexEnv_PublicIssueMCPDoesNotLeakInheritedBearer(t *testing.T) {
-	t.Setenv(codexIssueMCPBearerEnv, "stale-token")
+// codexCLIArgs must surface the github MCP override whenever the
+// project has a token saved, even when Issues.Provider is empty.
+// Mirror of TestClaudeCLIArgs_ProjectMCPIndependentOfIssueProvider —
+// proves the inversion holds across both providers.
+func TestCodexCLIArgs_ProjectMCPIndependentOfIssueProvider(t *testing.T) {
+	isolateHome(t)
+	cwd := t.TempDir()
+	cfg, _ := loadConfig()
+	cfg = upsertProjectConfig(cfg, cwd, projectConfig{
+		MCP: projectMCPConfig{GitHub: githubMCPConfig{Token: "ghp_secret"}},
+		// Issues.Provider deliberately left empty.
+	})
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("seed saveConfig: %v", err)
+	}
+	args := codexCLIArgs(ProviderSessionArgs{
+		ProjectMCP: projectGitHubMCP(cwd),
+	})
+	var sawURL bool
+	for i, a := range args {
+		if a == "-c" && i+1 < len(args) &&
+			strings.HasPrefix(args[i+1], "mcp_servers.github.url=") {
+			sawURL = true
+		}
+	}
+	if !sawURL {
+		t.Errorf("github MCP url override must be injected when MCP token is set even without an issue provider; argv=%v", args)
+	}
+}
+
+func TestCodexEnv_PublicProjectMCPDoesNotLeakInheritedBearer(t *testing.T) {
+	t.Setenv(codexProjectMCPBearerEnv, "stale-token")
 	env := codexEnv(ProviderSessionArgs{
-		IssueMCP: &issueMCPServer{
+		ProjectMCP: &issueMCPServer{
 			Name: "public",
 			URL:  "https://example.com/mcp",
 		},
 	})
 	for _, e := range env {
-		if strings.HasPrefix(e, codexIssueMCPBearerEnv+"=") {
-			t.Errorf("public IssueMCP should not inherit %s; saw %q", codexIssueMCPBearerEnv, e)
+		if strings.HasPrefix(e, codexProjectMCPBearerEnv+"=") {
+			t.Errorf("public ProjectMCP should not inherit %s; saw %q", codexProjectMCPBearerEnv, e)
 		}
 	}
 }

--- a/config.go
+++ b/config.go
@@ -48,7 +48,33 @@ type askConfig struct {
 // absent, so callers don't have to nil-check.
 type projectConfig struct {
 	Issues    issuesConfig    `json:"issues,omitempty"`
+	MCP       projectMCPConfig `json:"mcp,omitempty"`
 	Workflows workflowsConfig `json:"workflows,omitempty"`
+}
+
+// projectMCPConfig holds the per-project MCP server credentials that
+// get injected into the chat agent's --mcp-config and reused by issue
+// providers that piggyback on the same backend (e.g. github issues
+// share the GitHub MCP). Today there's a single GitHub slot; future
+// MCP backends sit alongside as sibling fields.
+//
+// Decoupled from issuesConfig so the chat agent can have GitHub MCP
+// access without the issues UI being wired up — and conversely so a
+// user enabling github issues is forced to configure the MCP first
+// (the issue provider piggybacks on this slot, not the other way
+// around).
+type projectMCPConfig struct {
+	GitHub githubMCPConfig `json:"github,omitempty"`
+}
+
+// githubMCPConfig wires the GitHub MCP server. Endpoint defaults to
+// the official Copilot MCP host when blank; Token is the user's PAT.
+// Token is held in 0600 config — the user explicitly rejected env-var
+// indirection ("just config file for that specific project setting"),
+// so it lives here.
+type githubMCPConfig struct {
+	Endpoint string `json:"endpoint,omitempty"`
+	Token    string `json:"token,omitempty"`
 }
 
 // workflowsConfig holds the per-project workflows definition list and
@@ -113,9 +139,12 @@ type workflowSession struct {
 // issuesConfig is the per-project issue-tracking configuration.
 // Provider names which IssueProvider implementation to dispatch to;
 // the rest of the fields are provider-specific and only consulted
-// when the matching Provider is selected. This shape lets us add a
-// ClickUp / Linear / GitLab block as siblings to GitHub without
-// migrating the existing on-disk config.
+// when the matching Provider is selected. Backends that need a
+// network credential read it from projectConfig.MCP rather than
+// duplicating it here — e.g. github issues piggyback on
+// projectConfig.MCP.GitHub. This shape lets us add a ClickUp /
+// Linear / GitLab block as siblings to GitHub without migrating the
+// existing on-disk config.
 type issuesConfig struct {
 	// Provider is the IssueProvider id ("github", "clickup", …) or
 	// "" for "issues not configured for this project". The default
@@ -123,29 +152,17 @@ type issuesConfig struct {
 	// configured for this project" toast when the user opens the
 	// issues screen.
 	Provider string `json:"provider,omitempty"`
-
-	GitHub githubIssuesConfig `json:"github,omitempty"`
 }
 
-// githubIssuesConfig wires the GitHub MCP server. Endpoint defaults
-// to the official Copilot MCP host when blank; Token is the user's
-// PAT. Token is held in 0600 config — the user explicitly rejected
-// env-var indirection ("just config file for that specific project
-// setting"), so it lives here.
-type githubIssuesConfig struct {
-	Endpoint string `json:"endpoint,omitempty"`
-	Token    string `json:"token,omitempty"`
-}
+// githubMCPDefaultEndpoint is the official GitHub Copilot-hosted MCP
+// server. Used when githubMCPConfig.Endpoint is empty.
+const githubMCPDefaultEndpoint = "https://api.githubcopilot.com/mcp"
 
-// githubIssuesDefaultEndpoint is the official GitHub Copilot-hosted
-// MCP server. Used when githubIssuesConfig.Endpoint is empty.
-const githubIssuesDefaultEndpoint = "https://api.githubcopilot.com/mcp"
-
-// githubEndpointOrDefault applies the documented fallback so callers
+// githubMCPEndpointOrDefault applies the documented fallback so callers
 // don't have to remember the constant.
-func githubEndpointOrDefault(c githubIssuesConfig) string {
+func githubMCPEndpointOrDefault(c githubMCPConfig) string {
 	if c.Endpoint == "" {
-		return githubIssuesDefaultEndpoint
+		return githubMCPDefaultEndpoint
 	}
 	return c.Endpoint
 }
@@ -246,6 +263,9 @@ func upsertProjectConfig(cfg askConfig, cwd string, pc projectConfig) askConfig 
 // equality check that broke when workflowsConfig added a map field.
 func isProjectConfigEmpty(pc projectConfig) bool {
 	if pc.Issues != (issuesConfig{}) {
+		return false
+	}
+	if pc.MCP != (projectMCPConfig{}) {
 		return false
 	}
 	if len(pc.Workflows.Items) > 0 || len(pc.Workflows.Sessions) > 0 {
@@ -416,6 +436,7 @@ func loadConfig() (askConfig, error) {
 	}
 	_ = json.Unmarshal(data, &cfg)
 	migrateLegacyToolOutput(&cfg, data)
+	migrateLegacyIssuesGitHub(&cfg, data)
 	return cfg, nil
 }
 
@@ -442,6 +463,47 @@ func migrateLegacyToolOutput(cfg *askConfig, data []byte) {
 		cfg.UI.ToolOutput = string(toolOutputShort)
 	} else {
 		cfg.UI.ToolOutput = string(toolOutputOff)
+	}
+}
+
+// migrateLegacyIssuesGitHub lifts the old per-project
+// `issues.github.{endpoint,token}` block into the new
+// `mcp.github.{endpoint,token}` slot. The github MCP credentials used
+// to be tucked under the issue provider's own config; we inverted that
+// so the chat agent can have GitHub MCP access without issues being
+// wired up, and so enabling github issues piggybacks on a real MCP
+// configuration. For each project entry that has the legacy block, we
+// preserve a populated endpoint/token unless the new slot already
+// carries a non-empty value (an explicit new value always wins).
+func migrateLegacyIssuesGitHub(cfg *askConfig, data []byte) {
+	if len(cfg.Projects) == 0 {
+		return
+	}
+	var legacy struct {
+		Projects map[string]struct {
+			Issues struct {
+				GitHub struct {
+					Endpoint string `json:"endpoint,omitempty"`
+					Token    string `json:"token,omitempty"`
+				} `json:"github,omitempty"`
+			} `json:"issues,omitempty"`
+		} `json:"projects,omitempty"`
+	}
+	if err := json.Unmarshal(data, &legacy); err != nil {
+		return
+	}
+	for key, lp := range legacy.Projects {
+		pc, ok := cfg.Projects[key]
+		if !ok {
+			continue
+		}
+		if pc.MCP.GitHub.Endpoint == "" && lp.Issues.GitHub.Endpoint != "" {
+			pc.MCP.GitHub.Endpoint = lp.Issues.GitHub.Endpoint
+		}
+		if pc.MCP.GitHub.Token == "" && lp.Issues.GitHub.Token != "" {
+			pc.MCP.GitHub.Token = lp.Issues.GitHub.Token
+		}
+		cfg.Projects[key] = pc
 	}
 }
 

--- a/config_project.go
+++ b/config_project.go
@@ -28,50 +28,49 @@ type projectFieldSpec struct {
 }
 
 // projectFieldSpecs is the registry. Order doesn't matter; row
-// order in the submenu comes from projectPickerItems.
+// order in the submenu comes from projectPickerItems. The GitHub
+// rows write into projectConfig.MCP.GitHub — the project-level MCP
+// slot the github issue provider also piggybacks on.
 var projectFieldSpecs = map[string]projectFieldSpec{
-	"githubEndpoint": {
-		id:       "githubEndpoint",
+	"githubMCPEndpoint": {
+		id:       "githubMCPEndpoint",
 		title:    "GitHub MCP endpoint",
 		helpHint: "blank uses the default (api.githubcopilot.com/mcp); enter to save",
 		load: func(c askConfig, cwd string) string {
-			return loadProjectConfig(c, cwd).Issues.GitHub.Endpoint
+			return loadProjectConfig(c, cwd).MCP.GitHub.Endpoint
 		},
-		save: func(p *projectConfig, v string) { p.Issues.GitHub.Endpoint = v },
+		save: func(p *projectConfig, v string) { p.MCP.GitHub.Endpoint = v },
 	},
-	"githubToken": {
-		id:       "githubToken",
-		title:    "GitHub PAT",
+	"githubMCPToken": {
+		id:       "githubMCPToken",
+		title:    "GitHub MCP PAT",
 		helpHint: "personal access token with `repo` and `read:org`; enter to save",
 		masked:   true,
 		load: func(c askConfig, cwd string) string {
-			return loadProjectConfig(c, cwd).Issues.GitHub.Token
+			return loadProjectConfig(c, cwd).MCP.GitHub.Token
 		},
-		save: func(p *projectConfig, v string) { p.Issues.GitHub.Token = v },
+		save: func(p *projectConfig, v string) { p.MCP.GitHub.Token = v },
 	},
 }
 
 // projectPickerItems builds the row list for the Project Options
-// submenu. Rows are dynamic — when the issue provider is "none",
-// the GitHub-specific rows are hidden so the user isn't asked to
-// configure things that don't apply. Returns []configItem so the
+// submenu. The GitHub MCP rows are always visible — the project-
+// level MCP slot is independent of whether the issue provider is
+// configured (the chat agent gets the GitHub MCP whenever a token
+// is set, even with issues disabled). Returns []configItem so the
 // rows feed straight into the same renderLayeredConfigBox helper
 // the Global Options submenu uses (no per-picker styling drift).
 func (m model) projectPickerItems() []configItem {
 	cfg, _ := loadConfig()
 	pc := loadProjectConfig(cfg, m.cwd)
-	rows := []configItem{
-		{"Issue provider", issueProviderByID(pc.Issues.Provider).DisplayName(), "issueProvider"},
+	endpoint := pc.MCP.GitHub.Endpoint
+	if endpoint == "" {
+		endpoint = "(default)"
 	}
-	if pc.Issues.Provider == "github" {
-		endpoint := pc.Issues.GitHub.Endpoint
-		if endpoint == "" {
-			endpoint = "(default)"
-		}
-		rows = append(rows,
-			configItem{"GitHub endpoint", endpoint, "githubEndpoint"},
-			configItem{"GitHub PAT", maskedSummary(pc.Issues.GitHub.Token), "githubToken"},
-		)
+	rows := []configItem{
+		{"GitHub MCP endpoint", endpoint, "githubMCPEndpoint"},
+		{"GitHub MCP PAT", maskedSummary(pc.MCP.GitHub.Token), "githubMCPToken"},
+		{"Issue provider", issueProviderByID(pc.Issues.Provider).DisplayName(), "issueProvider"},
 	}
 	wfCount := len(pc.Workflows.Items)
 	wfDesc := "(none)"
@@ -214,6 +213,14 @@ func (m model) updateConfigProjectPicker(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 // cycle is tab-aware: existing tabs continue with whatever their
 // state was; the change applies to all future issue-screen loads
 // project-wide.
+//
+// Cycling INTO a provider that piggybacks on a project-level MCP slot
+// (today: github → projectConfig.MCP.GitHub) requires that slot to be
+// configured first; otherwise we'd land in a state where issues are
+// nominally "github" but every list call fails because no token is
+// wired. The gate only fires on the transition into the constrained
+// provider — wrap-around back to "" / none always succeeds so the
+// user can never get stuck.
 func (m model) cycleIssueProvider() (tea.Model, tea.Cmd) {
 	cfg, _ := loadConfig()
 	pc := loadProjectConfig(cfg, m.cwd)
@@ -228,18 +235,15 @@ func (m model) cycleIssueProvider() (tea.Model, tea.Cmd) {
 		curIdx = 0
 	}
 	next := issueProviderRegistry[(curIdx+1)%len(issueProviderRegistry)]
+	if next.ID() == "github" && pc.MCP.GitHub.Token == "" {
+		return m, m.toast.show("issues: configure GitHub MCP PAT first")
+	}
 	pc.Issues.Provider = next.ID()
 	cfg = upsertProjectConfig(cfg, m.cwd, pc)
 	if err := saveConfig(cfg); err != nil {
 		debugLog("project provider saveConfig: %v", err)
 		return m, m.toast.show("config: " + err.Error())
 	}
-	// The chat agent's MCP roster is baked at fork time, so an open
-	// session is still pointing at the previous issue provider's
-	// servers. Kill the proc; the next user input respawns it with
-	// the new --mcp-config — same pattern the worktree / skip-perms
-	// toggles use.
-	m.killProc()
 	return m, m.toast.show("issues: provider → " + next.DisplayName())
 }
 
@@ -291,12 +295,13 @@ func (m model) commitConfigProjectField() (tea.Model, tea.Cmd) {
 		return m, m.toast.show("config: save: " + err.Error())
 	}
 	m = m.closeConfigProjectFieldEditor()
-	// Issue-provider credentials get baked into the chat agent's
+	// Project MCP credentials get baked into the chat agent's
 	// --mcp-config at fork time. A live proc is still holding the
 	// pre-edit token/endpoint — kill it so the next user input
 	// respawns with the freshly saved values. All current project
-	// fields feed the issue provider, so unconditional is correct;
-	// when a non-issue field type lands later, gate this on spec.
+	// fields feed the chat agent's MCP roster, so unconditional is
+	// correct; when a non-MCP field type lands later, gate this on
+	// spec.
 	m.killProc()
 	return m, m.toast.show(spec.title + " saved")
 }
@@ -321,12 +326,13 @@ func (m model) viewConfigProjectPicker() string {
 }
 
 // viewConfigProjectFieldInput renders the inline editor for an
-// editable project field (GitHub PAT, GitHub endpoint) through
-// the same renderLayeredConfigBox as the pickers, so dropping
-// into a field editor is visually a peer-level swap rather than a
-// "different window" pop. The picker's "filter" row slot becomes
-// the editor's input prompt; the picker's row list slot stays
-// blank (no items), so the chrome is pixel-identical.
+// editable project field (GitHub MCP PAT, GitHub MCP endpoint)
+// through the same renderLayeredConfigBox as the pickers, so
+// dropping into a field editor is visually a peer-level swap
+// rather than a "different window" pop. The picker's "filter"
+// row slot becomes the editor's input prompt; the picker's row
+// list slot stays blank (no items), so the chrome is
+// pixel-identical.
 func (m model) viewConfigProjectFieldInput() string {
 	spec, ok := projectFieldSpecs[m.configProjectFieldEditing]
 	if !ok {

--- a/config_project_test.go
+++ b/config_project_test.go
@@ -72,16 +72,25 @@ func TestProjectPicker_DefaultsToNoneProvider(t *testing.T) {
 	if len(rows) == 0 {
 		t.Fatalf("project picker should have at least one row")
 	}
-	if rows[0].id != "issueProvider" {
-		t.Errorf("first row id=%q want issueProvider", rows[0].id)
-	}
-	if !strings.Contains(rows[0].key, "None") {
-		t.Errorf("default provider summary should say None, got %q", rows[0].key)
-	}
-	// GitHub-specific rows should NOT be visible while provider is None.
+	// GitHub MCP rows are unconditional now — they live above the
+	// issue-provider row so the user sees the project's MCP slot
+	// regardless of issues being configured.
+	have := map[string]bool{}
 	for _, r := range rows {
-		if r.id == "githubEndpoint" || r.id == "githubToken" {
-			t.Errorf("GitHub fields should be hidden when provider=None, found %q", r.id)
+		have[r.id] = true
+	}
+	if !have["githubMCPEndpoint"] || !have["githubMCPToken"] {
+		t.Errorf("GitHub MCP rows should always be present; rows=%+v", rows)
+	}
+	if !have["issueProvider"] {
+		t.Errorf("issueProvider row should always be present; rows=%+v", rows)
+	}
+	for _, r := range rows {
+		if r.id != "issueProvider" {
+			continue
+		}
+		if !strings.Contains(r.key, "None") {
+			t.Errorf("default provider summary should say None, got %q", r.key)
 		}
 	}
 }
@@ -91,22 +100,31 @@ func TestCycleIssueProvider_FlipsNoneToGitHubAndPersists(t *testing.T) {
 	m := newTestModel(t, newFakeProvider())
 	m.cwd = t.TempDir()
 	m.toast = NewToastModel(40, time.Second)
+	// Pre-seed the GitHub MCP token so cycleIssueProvider's
+	// "configure GitHub MCP first" gate doesn't refuse the cycle.
+	cfg, _ := loadConfig()
+	cfg = upsertProjectConfig(cfg, m.cwd, projectConfig{
+		MCP: projectMCPConfig{GitHub: githubMCPConfig{Token: "ghp_seed"}},
+	})
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("seed saveConfig: %v", err)
+	}
 	m = m.openConfigProjectPicker()
 	mi, _ := m.cycleIssueProvider()
 	mm := mi.(model)
-	cfg, _ := loadConfig()
+	cfg, _ = loadConfig()
 	pc := loadProjectConfig(cfg, mm.cwd)
 	if pc.Issues.Provider != "github" {
 		t.Errorf("after first cycle, provider=%q want github", pc.Issues.Provider)
 	}
-	// GitHub-specific rows should now appear.
+	// GitHub MCP rows are always present regardless of provider.
 	rows := mm.projectPickerItems()
 	have := map[string]bool{}
 	for _, r := range rows {
 		have[r.id] = true
 	}
-	if !have["githubEndpoint"] || !have["githubToken"] {
-		t.Errorf("GitHub fields should appear after cycling to github: %+v", rows)
+	if !have["githubMCPEndpoint"] || !have["githubMCPToken"] {
+		t.Errorf("GitHub MCP rows should remain visible: %+v", rows)
 	}
 }
 
@@ -115,6 +133,14 @@ func TestCycleIssueProvider_WrapsBackToNone(t *testing.T) {
 	m := newTestModel(t, newFakeProvider())
 	m.cwd = t.TempDir()
 	m.toast = NewToastModel(40, time.Second)
+	// Pre-seed the MCP token so the gate lets us cycle through.
+	cfg, _ := loadConfig()
+	cfg = upsertProjectConfig(cfg, m.cwd, projectConfig{
+		MCP: projectMCPConfig{GitHub: githubMCPConfig{Token: "ghp_seed"}},
+	})
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("seed saveConfig: %v", err)
+	}
 	m = m.openConfigProjectPicker()
 	// Cycle through every registered provider, expecting to land back
 	// on None. With 2 entries (none, github) that's 2 cycles.
@@ -122,7 +148,7 @@ func TestCycleIssueProvider_WrapsBackToNone(t *testing.T) {
 		mi, _ := m.cycleIssueProvider()
 		m = mi.(model)
 	}
-	cfg, _ := loadConfig()
+	cfg, _ = loadConfig()
 	pc := loadProjectConfig(cfg, m.cwd)
 	if pc.Issues.Provider != "" {
 		t.Errorf("after wrap, provider=%q want None (empty)", pc.Issues.Provider)
@@ -135,31 +161,30 @@ func TestProjectFieldEditor_OpensAndClosesCleanly(t *testing.T) {
 	m.cwd = t.TempDir()
 	m.toast = NewToastModel(40, time.Second)
 	m = m.openConfigProjectPicker()
-	// Set provider to github so the GitHub fields appear.
-	mi, _ := m.cycleIssueProvider()
-	m = mi.(model)
-	m = m.openConfigProjectFieldEditor("githubToken")
-	if m.configProjectFieldEditing != "githubToken" {
+	// GitHub MCP rows are always present — no need to cycle the issue
+	// provider just to access the token editor.
+	m = m.openConfigProjectFieldEditor("githubMCPToken")
+	if m.configProjectFieldEditing != "githubMCPToken" {
 		t.Fatalf("editor not opened: editing=%q", m.configProjectFieldEditing)
 	}
 	// Type the token.
 	for _, r := range "ghp_abc123" {
-		mi, _ = m.updateConfigProjectFieldInput(tea.KeyPressMsg{Text: string(r)})
+		mi, _ := m.updateConfigProjectFieldInput(tea.KeyPressMsg{Text: string(r)})
 		m = mi.(model)
 	}
 	if m.configProjectFieldDraft != "ghp_abc123" {
 		t.Fatalf("draft=%q want ghp_abc123", m.configProjectFieldDraft)
 	}
 	// Press Enter to commit.
-	mi, _ = m.updateConfigProjectFieldInput(tea.KeyPressMsg{Code: tea.KeyEnter})
+	mi, _ := m.updateConfigProjectFieldInput(tea.KeyPressMsg{Code: tea.KeyEnter})
 	m = mi.(model)
 	if m.configProjectFieldEditing != "" {
 		t.Errorf("editor should close on Enter; editing=%q", m.configProjectFieldEditing)
 	}
 	cfg, _ := loadConfig()
 	pc := loadProjectConfig(cfg, m.cwd)
-	if pc.Issues.GitHub.Token != "ghp_abc123" {
-		t.Errorf("token not persisted: %q", pc.Issues.GitHub.Token)
+	if pc.MCP.GitHub.Token != "ghp_abc123" {
+		t.Errorf("token not persisted: %q", pc.MCP.GitHub.Token)
 	}
 }
 
@@ -193,11 +218,40 @@ func TestEscFromProjectSubmenu_BacksOutToTopLevel(t *testing.T) {
 	}
 }
 
-// Cycling the issue provider must kill any open chat agent so the
-// next user input respawns it with the freshly built --mcp-config.
-// Otherwise the agent is still pointing at the previous provider's
-// MCP server and tools.
-func TestCycleIssueProvider_KillsOpenProc(t *testing.T) {
+// Cycling the issue provider must leave an open chat proc alone.
+// Provider selection now affects only the issues UI; chat MCP wiring
+// comes from the project-level MCP slot, so there is no reason to
+// tear down an unrelated active conversation.
+func TestCycleIssueProvider_LeavesOpenProcAlone(t *testing.T) {
+	isolateHome(t)
+	m := newTestModel(t, newFakeProvider())
+	m.cwd = t.TempDir()
+	m.toast = NewToastModel(40, time.Second)
+	// Pre-seed the MCP token so cycleIssueProvider's gate doesn't
+	// refuse the transition to "github".
+	cfg, _ := loadConfig()
+	cfg = upsertProjectConfig(cfg, m.cwd, projectConfig{
+		MCP: projectMCPConfig{GitHub: githubMCPConfig{Token: "ghp_seed"}},
+	})
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("seed saveConfig: %v", err)
+	}
+	m.proc = &providerProc{}
+	m = m.openConfigProjectPicker()
+	mi, _ := m.cycleIssueProvider()
+	mm := mi.(model)
+	if mm.proc == nil {
+		t.Errorf("cycleIssueProvider should not kill the open proc when chat MCP config is unchanged")
+	}
+}
+
+// cycleIssueProvider must refuse the transition to "github" when the
+// project has no GitHub MCP token configured — otherwise the user
+// ends up with a github issues backend that has nothing to talk to.
+// The refusal is a soft guard: it shows a toast, leaves Issues.Provider
+// untouched on disk, and keeps any open proc alive (no kill, since
+// nothing changed).
+func TestCycleIssueProvider_RefusesGitHubWithoutMCPToken(t *testing.T) {
 	isolateHome(t)
 	m := newTestModel(t, newFakeProvider())
 	m.cwd = t.TempDir()
@@ -206,13 +260,47 @@ func TestCycleIssueProvider_KillsOpenProc(t *testing.T) {
 	m = m.openConfigProjectPicker()
 	mi, _ := m.cycleIssueProvider()
 	mm := mi.(model)
-	if mm.proc != nil {
-		t.Errorf("cycleIssueProvider should kill the open proc; m.proc=%v", mm.proc)
+	cfg, _ := loadConfig()
+	pc := loadProjectConfig(cfg, mm.cwd)
+	if pc.Issues.Provider != "" {
+		t.Errorf("provider must stay None when MCP token is absent; got %q", pc.Issues.Provider)
+	}
+	if mm.proc == nil {
+		t.Errorf("refused cycle should NOT kill the open proc — nothing changed on disk")
 	}
 }
 
-// Saving a GitHub PAT (or any project field) likewise needs to kill
-// the open proc — the agent's MCP roster bakes the token at fork
+// The guard only fires on the transition INTO github. Cycling
+// AWAY from github (back to None) must always succeed regardless
+// of the MCP token state — otherwise a user who deletes their PAT
+// gets stuck on a broken github provider with no way back.
+func TestCycleIssueProvider_AllowsExitFromGitHubEvenWithoutToken(t *testing.T) {
+	isolateHome(t)
+	m := newTestModel(t, newFakeProvider())
+	m.cwd = t.TempDir()
+	m.toast = NewToastModel(40, time.Second)
+	// Put the project in the "github" state with a token, then yank
+	// the token out — emulating "user deleted their PAT and now wants
+	// to back out of github issues."
+	cfg, _ := loadConfig()
+	cfg = upsertProjectConfig(cfg, m.cwd, projectConfig{
+		Issues: issuesConfig{Provider: "github"},
+	})
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("seed saveConfig: %v", err)
+	}
+	m = m.openConfigProjectPicker()
+	mi, _ := m.cycleIssueProvider()
+	mm := mi.(model)
+	cfg, _ = loadConfig()
+	pc := loadProjectConfig(cfg, mm.cwd)
+	if pc.Issues.Provider != "" {
+		t.Errorf("cycle from github must wrap to None even without a token; got %q", pc.Issues.Provider)
+	}
+}
+
+// Saving a GitHub MCP PAT (or any project field) likewise needs to
+// kill the open proc — the agent's MCP roster bakes the token at fork
 // time, and a stale agent would happily keep using the previous
 // credential until the user manually killed it.
 func TestCommitConfigProjectField_KillsOpenProc(t *testing.T) {
@@ -221,19 +309,15 @@ func TestCommitConfigProjectField_KillsOpenProc(t *testing.T) {
 	m.cwd = t.TempDir()
 	m.toast = NewToastModel(40, time.Second)
 	m = m.openConfigProjectPicker()
-	// Set provider to github so the GitHub fields appear.
-	mi, _ := m.cycleIssueProvider()
-	m = mi.(model)
-	// A live proc must survive the cycle (we already test the kill in
-	// the cycle test); install a fresh one so we can observe the kill
-	// triggered by the field commit specifically.
+	// Install a live proc so we can observe the kill triggered by
+	// the field commit specifically.
 	m.proc = &providerProc{}
-	m = m.openConfigProjectFieldEditor("githubToken")
+	m = m.openConfigProjectFieldEditor("githubMCPToken")
 	for _, r := range "ghp_abc" {
-		mi, _ = m.updateConfigProjectFieldInput(tea.KeyPressMsg{Text: string(r)})
+		mi, _ := m.updateConfigProjectFieldInput(tea.KeyPressMsg{Text: string(r)})
 		m = mi.(model)
 	}
-	mi, _ = m.updateConfigProjectFieldInput(tea.KeyPressMsg{Code: tea.KeyEnter})
+	mi, _ := m.updateConfigProjectFieldInput(tea.KeyPressMsg{Code: tea.KeyEnter})
 	mm := mi.(model)
 	if mm.proc != nil {
 		t.Errorf("commit on a project field should kill the open proc; m.proc=%v", mm.proc)

--- a/config_test.go
+++ b/config_test.go
@@ -219,6 +219,178 @@ func TestLoadConfig_NewToolOutputWinsOverLegacy(t *testing.T) {
 	}
 }
 
+// TestLoadConfig_MigratesLegacyIssuesGitHub covers the auto-migration
+// from the deprecated `issues.github.{endpoint,token}` block to the
+// new top-level `mcp.github.*` slot. Real users on disk still have the
+// legacy shape; loadConfig must preserve their endpoint/token without
+// any manual intervention. Each case asserts the legacy fields land in
+// the new slot and that an explicit new value always wins.
+func TestLoadConfig_MigratesLegacyIssuesGitHub(t *testing.T) {
+	cases := []struct {
+		name         string
+		raw          string
+		wantToken    string
+		wantEndpoint string
+	}{
+		{
+			name:         "token and endpoint both move",
+			raw:          `{"projects":{"/proj":{"issues":{"provider":"github","github":{"token":"ghp_legacy","endpoint":"https://ghe.example/mcp"}}}}}`,
+			wantToken:    "ghp_legacy",
+			wantEndpoint: "https://ghe.example/mcp",
+		},
+		{
+			name:         "token only",
+			raw:          `{"projects":{"/proj":{"issues":{"provider":"github","github":{"token":"ghp_only"}}}}}`,
+			wantToken:    "ghp_only",
+			wantEndpoint: "",
+		},
+		{
+			name:         "endpoint only",
+			raw:          `{"projects":{"/proj":{"issues":{"provider":"github","github":{"endpoint":"https://ghe.example/mcp"}}}}}`,
+			wantToken:    "",
+			wantEndpoint: "https://ghe.example/mcp",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			home := isolateHome(t)
+			path := filepath.Join(home, ".config", "ask", "ask.json")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if err := os.WriteFile(path, []byte(c.raw), 0o600); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			cfg, err := loadConfig()
+			if err != nil {
+				t.Fatalf("loadConfig: %v", err)
+			}
+			pc, ok := cfg.Projects["/proj"]
+			if !ok {
+				t.Fatalf("project entry missing from cfg.Projects after load")
+			}
+			if pc.MCP.GitHub.Token != c.wantToken {
+				t.Errorf("MCP.GitHub.Token=%q want %q", pc.MCP.GitHub.Token, c.wantToken)
+			}
+			if pc.MCP.GitHub.Endpoint != c.wantEndpoint {
+				t.Errorf("MCP.GitHub.Endpoint=%q want %q", pc.MCP.GitHub.Endpoint, c.wantEndpoint)
+			}
+			// Issues.Provider must be preserved through the migration —
+			// the user opted into github issues, and we don't want to
+			// silently disable that just because the credential moved.
+			if pc.Issues.Provider != "github" {
+				t.Errorf("Issues.Provider=%q want %q (migration must preserve provider)",
+					pc.Issues.Provider, "github")
+			}
+		})
+	}
+}
+
+// An explicit value in the new slot must beat the legacy value — the
+// migration runs on every load, and a user who has saved a fresh PAT
+// under mcp.github should not see it silently rewritten by a stale
+// issues.github value left over in the same file.
+func TestLoadConfig_NewMCPGitHubWinsOverLegacy(t *testing.T) {
+	home := isolateHome(t)
+	path := filepath.Join(home, ".config", "ask", "ask.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	raw := `{"projects":{"/proj":{
+		"issues":{"provider":"github","github":{"token":"ghp_legacy","endpoint":"https://legacy"}},
+		"mcp":{"github":{"token":"ghp_new","endpoint":"https://new"}}
+	}}}`
+	if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	pc := cfg.Projects["/proj"]
+	if pc.MCP.GitHub.Token != "ghp_new" {
+		t.Errorf("explicit new token should win, got %q", pc.MCP.GitHub.Token)
+	}
+	if pc.MCP.GitHub.Endpoint != "https://new" {
+		t.Errorf("explicit new endpoint should win, got %q", pc.MCP.GitHub.Endpoint)
+	}
+}
+
+// Migration must be a no-op for projects that have no entry in
+// cfg.Projects yet — otherwise a malformed legacy block could
+// accidentally synthesise an entry that didn't exist before.
+func TestLoadConfig_MigrationIsNoOpForUnknownProjects(t *testing.T) {
+	home := isolateHome(t)
+	path := filepath.Join(home, ".config", "ask", "ask.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// projects:{} (empty), no entries — migration must not panic
+	// on the empty map and must not create entries from thin air.
+	raw := `{"projects":{}}`
+	if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if len(cfg.Projects) != 0 {
+		t.Errorf("empty projects map should remain empty, got %d entries", len(cfg.Projects))
+	}
+}
+
+// Round-trip the new shape: write via saveConfig, read back via
+// loadConfig — MCP.GitHub fields persist verbatim and the migration
+// is idempotent (a load → save → load cycle on a freshly-written
+// new-shape file leaves the values unchanged).
+func TestSaveConfig_RoundTripPreservesMCPGitHub(t *testing.T) {
+	isolateHome(t)
+	want := askConfig{
+		Projects: map[string]projectConfig{
+			"/proj": {
+				Issues: issuesConfig{Provider: "github"},
+				MCP: projectMCPConfig{
+					GitHub: githubMCPConfig{
+						Token:    "ghp_xyz",
+						Endpoint: "https://ghe.example/mcp",
+					},
+				},
+			},
+		},
+	}
+	if err := saveConfig(want); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+	got, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	pc := got.Projects["/proj"]
+	if pc.MCP.GitHub.Token != "ghp_xyz" {
+		t.Errorf("token lost in roundtrip: %q", pc.MCP.GitHub.Token)
+	}
+	if pc.MCP.GitHub.Endpoint != "https://ghe.example/mcp" {
+		t.Errorf("endpoint lost in roundtrip: %q", pc.MCP.GitHub.Endpoint)
+	}
+	if pc.Issues.Provider != "github" {
+		t.Errorf("issues.provider lost in roundtrip: %q", pc.Issues.Provider)
+	}
+	// Idempotence: a second save+load cycle must produce the same
+	// values, proving the migration doesn't drift the data each pass.
+	if err := saveConfig(got); err != nil {
+		t.Fatalf("second saveConfig: %v", err)
+	}
+	got2, err := loadConfig()
+	if err != nil {
+		t.Fatalf("second loadConfig: %v", err)
+	}
+	pc2 := got2.Projects["/proj"]
+	if pc2.MCP != pc.MCP || pc2.Issues != pc.Issues {
+		t.Errorf("migration not idempotent:\n got: %+v\nwant: %+v", pc2, pc)
+	}
+}
+
 func TestConfigPath_UnderHome(t *testing.T) {
 	home := isolateHome(t)
 	path, err := configPath()

--- a/issue_provider.go
+++ b/issue_provider.go
@@ -134,19 +134,10 @@ type IssueProvider interface {
 	// resolve to a valid backend project (e.g. github needs
 	// owner/repo from `git remote get-url origin`).
 	IssueRef(cfg projectConfig, cwd string, it issue) (issueRef, error)
-
-	// MCPServer returns the MCP server descriptor that should be
-	// injected into the chat agent's --mcp-config when this project
-	// uses the provider, so the chat agent has the same issue-tracker
-	// access ask itself uses for ctrl+i. nil means "don't inject" —
-	// either the provider is unconfigured (token missing, cwd doesn't
-	// resolve to a valid backend) or the provider has no MCP surface
-	// to share. The returned spec is consumed verbatim by claudeCLIArgs.
-	MCPServer(cfg projectConfig, cwd string) *issueMCPServer
 }
 
-// issueMCPServer is the MCP server descriptor an IssueProvider exposes
-// to the chat agent. Name is the key that appears under mcpServers in
+// issueMCPServer is the MCP server descriptor ask injects into the
+// chat agent. Name is the key that appears under mcpServers in
 // claude's --mcp-config (and the prefix the agent sees for tools, e.g.
 // `mcp__github__list_issues`). URL is the streamable HTTP endpoint;
 // Headers carries any auth headers the server needs (typically
@@ -264,4 +255,3 @@ func (noneIssueProvider) KanbanIssueStatus(KanbanColumnSpec) string { return "" 
 func (noneIssueProvider) IssueRef(projectConfig, string, issue) (issueRef, error) {
 	return issueRef{}, errIssueProviderNotConfigured
 }
-func (noneIssueProvider) MCPServer(projectConfig, string) *issueMCPServer { return nil }

--- a/issue_provider_fake_test.go
+++ b/issue_provider_fake_test.go
@@ -53,11 +53,11 @@ func newFakeIssueProvider() *fakeIssueProvider {
 	}
 }
 
-func (f *fakeIssueProvider) ID() string                                 { return f.id }
-func (f *fakeIssueProvider) DisplayName() string                        { return f.displayName }
-func (f *fakeIssueProvider) Configured(projectConfig, string) bool      { return f.configured }
-func (f *fakeIssueProvider) QuerySyntaxHelp() string                    { return f.syntaxHelp }
-func (f *fakeIssueProvider) KanbanColumns() []KanbanColumnSpec          { return f.columns }
+func (f *fakeIssueProvider) ID() string                            { return f.id }
+func (f *fakeIssueProvider) DisplayName() string                   { return f.displayName }
+func (f *fakeIssueProvider) Configured(projectConfig, string) bool { return f.configured }
+func (f *fakeIssueProvider) QuerySyntaxHelp() string               { return f.syntaxHelp }
+func (f *fakeIssueProvider) KanbanColumns() []KanbanColumnSpec     { return f.columns }
 
 func (f *fakeIssueProvider) ParseQuery(text string) (IssueQuery, error) {
 	if f.parseQueryFn != nil {
@@ -127,8 +127,6 @@ func (f *fakeIssueProvider) IssueRef(cfg projectConfig, cwd string, it issue) (i
 		Number:   it.number,
 	}, nil
 }
-
-func (f *fakeIssueProvider) MCPServer(projectConfig, string) *issueMCPServer { return nil }
 
 // newFakeMockProvider produces a fake provider configured with
 // one kanban column per distinct status in the supplied data.

--- a/issue_provider_github.go
+++ b/issue_provider_github.go
@@ -64,14 +64,16 @@ func (p *githubIssueProvider) ID() string          { return "github" }
 func (p *githubIssueProvider) DisplayName() string { return "GitHub Issues" }
 
 // Configured reports whether the provider can dispatch a request.
-// Three things must line up: provider selected, token set, and
-// cwd resolves to a github.com remote. Endpoint is allowed to be
-// empty — it falls through to the documented default.
+// Three things must line up: provider selected, MCP token set
+// (cfg.MCP.GitHub — the issue provider piggybacks on the project's
+// GitHub MCP slot), and cwd resolves to a github.com remote.
+// Endpoint is allowed to be empty — it falls through to the
+// documented default.
 func (p *githubIssueProvider) Configured(cfg projectConfig, cwd string) bool {
 	if cfg.Issues.Provider != p.ID() {
 		return false
 	}
-	if cfg.Issues.GitHub.Token == "" {
+	if cfg.MCP.GitHub.Token == "" {
 		return false
 	}
 	if _, _, err := resolveGitHubRepo(cwd); err != nil {
@@ -250,7 +252,7 @@ func (p *githubIssueProvider) KanbanColumns() []KanbanColumnSpec {
 // array (older shape) we fall back to HasMore = (len(issues) ==
 // perPage) and leave NextCursor blank.
 func (p *githubIssueProvider) ListIssues(ctx context.Context, cfg projectConfig, cwd string, query IssueQuery, page IssuePagination) (IssueListPage, error) {
-	if cfg.Issues.GitHub.Token == "" {
+	if cfg.MCP.GitHub.Token == "" {
 		return IssueListPage{}, errIssueProviderNotConfigured
 	}
 	owner, repo, err := resolveGitHubRepo(cwd)
@@ -260,7 +262,7 @@ func (p *githubIssueProvider) ListIssues(ctx context.Context, cfg projectConfig,
 	if page.PerPage <= 0 {
 		page.PerPage = githubDefaultPerPage
 	}
-	cs, err := p.connect(ctx, cfg.Issues.GitHub)
+	cs, err := p.connect(ctx, cfg.MCP.GitHub)
 	if err != nil {
 		return IssueListPage{}, err
 	}
@@ -309,14 +311,14 @@ func (p *githubIssueProvider) ListIssues(ctx context.Context, cfg projectConfig,
 // calls and merge; comments are best-effort since the description
 // alone is still a useful detail page if the second call fails.
 func (p *githubIssueProvider) GetIssue(ctx context.Context, cfg projectConfig, cwd string, number int) (issue, error) {
-	if cfg.Issues.GitHub.Token == "" {
+	if cfg.MCP.GitHub.Token == "" {
 		return issue{}, errIssueProviderNotConfigured
 	}
 	owner, repo, err := resolveGitHubRepo(cwd)
 	if err != nil {
 		return issue{}, fmt.Errorf("resolve repo: %w", err)
 	}
-	cs, err := p.connect(ctx, cfg.Issues.GitHub)
+	cs, err := p.connect(ctx, cfg.MCP.GitHub)
 	if err != nil {
 		return issue{}, err
 	}
@@ -357,7 +359,7 @@ func (p *githubIssueProvider) GetIssue(ctx context.Context, cfg projectConfig, c
 // drops are short-circuited at the kanban layer and never reach
 // this method.
 func (p *githubIssueProvider) MoveIssue(ctx context.Context, cfg projectConfig, cwd string, it issue, target KanbanColumnSpec) error {
-	if cfg.Issues.GitHub.Token == "" {
+	if cfg.MCP.GitHub.Token == "" {
 		return errIssueProviderNotConfigured
 	}
 	owner, repo, err := resolveGitHubRepo(cwd)
@@ -368,7 +370,7 @@ func (p *githubIssueProvider) MoveIssue(ctx context.Context, cfg projectConfig, 
 	if !ok || gq == nil {
 		return fmt.Errorf("move: target column has no github query")
 	}
-	cs, err := p.connect(ctx, cfg.Issues.GitHub)
+	cs, err := p.connect(ctx, cfg.MCP.GitHub)
 	if err != nil {
 		return err
 	}
@@ -425,28 +427,6 @@ func githubBuildMoveIssueArgs(owner, repo string, issueNumber int, target *githu
 	return githubToolIssueWrite, args
 }
 
-// MCPServer returns the github MCP server descriptor for injection
-// into the chat agent's --mcp-config. Returns nil when the project
-// isn't fully configured (no PAT, or cwd doesn't resolve to a github
-// remote) — letting the chat agent see a half-wired github tool that
-// errors on every call would be worse than not exposing it at all.
-//
-// The Authorization header carries the user's PAT verbatim. Keep the
-// Headers field out of any debug log; the bearerRoundTripper warning
-// in this file applies here too.
-func (p *githubIssueProvider) MCPServer(cfg projectConfig, cwd string) *issueMCPServer {
-	if !p.Configured(cfg, cwd) {
-		return nil
-	}
-	return &issueMCPServer{
-		Name: "github",
-		URL:  githubEndpointOrDefault(cfg.Issues.GitHub),
-		Headers: map[string]string{
-			"Authorization": "Bearer " + cfg.Issues.GitHub.Token,
-		},
-	}
-}
-
 // IssueRef resolves cwd to "owner/repo" via the same mechanism the
 // rest of the github provider uses (`git remote get-url origin`),
 // then assembles the canonical issueRef for `it`. Returns
@@ -491,8 +471,8 @@ func (p *githubIssueProvider) fetchComments(ctx context.Context, cs *mcp.ClientS
 // in either field tears down the old session and spins up a fresh
 // one against the new credentials. Concurrent callers serialise on
 // p.mu so a flurry of issues-screen renders only handshakes once.
-func (p *githubIssueProvider) connect(ctx context.Context, cfg githubIssuesConfig) (*mcp.ClientSession, error) {
-	endpoint := githubEndpointOrDefault(cfg)
+func (p *githubIssueProvider) connect(ctx context.Context, cfg githubMCPConfig) (*mcp.ClientSession, error) {
+	endpoint := githubMCPEndpointOrDefault(cfg)
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.session != nil && p.cachedEndpoint == endpoint && p.cachedToken == cfg.Token {

--- a/issue_provider_github_live_test.go
+++ b/issue_provider_github_live_test.go
@@ -48,7 +48,7 @@ func TestGitHubProvider_LiveDumpToolNames(t *testing.T) {
 	defer cancel()
 	cli := mcp.NewClient(&mcp.Implementation{Name: "ask-debug", Version: "0.1"}, nil)
 	transport := &mcp.StreamableClientTransport{
-		Endpoint: githubIssuesDefaultEndpoint,
+		Endpoint: githubMCPDefaultEndpoint,
 		HTTPClient: &http.Client{
 			Transport: &bearerRoundTripper{base: http.DefaultTransport, token: token},
 			Timeout:   30 * time.Second,
@@ -81,7 +81,7 @@ func TestGitHubProvider_LiveDumpIssueRead(t *testing.T) {
 	defer cancel()
 	cli := mcp.NewClient(&mcp.Implementation{Name: "ask-debug", Version: "0.1"}, nil)
 	transport := &mcp.StreamableClientTransport{
-		Endpoint: githubIssuesDefaultEndpoint,
+		Endpoint: githubMCPDefaultEndpoint,
 		HTTPClient: &http.Client{
 			Transport: &bearerRoundTripper{base: http.DefaultTransport, token: token},
 			Timeout:   30 * time.Second,
@@ -131,7 +131,7 @@ func TestGitHubProvider_LiveDumpListIssuesPayload(t *testing.T) {
 	defer cancel()
 	cli := mcp.NewClient(&mcp.Implementation{Name: "ask-debug", Version: "0.1"}, nil)
 	transport := &mcp.StreamableClientTransport{
-		Endpoint: githubIssuesDefaultEndpoint,
+		Endpoint: githubMCPDefaultEndpoint,
 		HTTPClient: &http.Client{
 			Transport: &bearerRoundTripper{base: http.DefaultTransport, token: token},
 			Timeout:   30 * time.Second,
@@ -196,10 +196,8 @@ func TestGitHubProvider_LiveListIssues(t *testing.T) {
 	}
 	p := &githubIssueProvider{}
 	pc := projectConfig{
-		Issues: issuesConfig{
-			Provider: "github",
-			GitHub:   githubIssuesConfig{Token: token},
-		},
+		Issues: issuesConfig{Provider: "github"},
+		MCP:    projectMCPConfig{GitHub: githubMCPConfig{Token: token}},
 	}
 	if !p.Configured(pc, cwd) {
 		t.Fatalf("Configured returned false for cwd=%q — origin not on github.com?", cwd)
@@ -246,10 +244,8 @@ func TestGitHubProvider_LiveGetIssue(t *testing.T) {
 	}
 	p := &githubIssueProvider{}
 	pc := projectConfig{
-		Issues: issuesConfig{
-			Provider: "github",
-			GitHub:   githubIssuesConfig{Token: token},
-		},
+		Issues: issuesConfig{Provider: "github"},
+		MCP:    projectMCPConfig{GitHub: githubMCPConfig{Token: token}},
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()

--- a/issue_provider_github_test.go
+++ b/issue_provider_github_test.go
@@ -231,7 +231,10 @@ func TestGitHubProviderConfigured_RejectsWhenTokenBlank(t *testing.T) {
 
 func TestGitHubProviderConfigured_RejectsWhenProviderMismatch(t *testing.T) {
 	p := &githubIssueProvider{}
-	pc := projectConfig{Issues: issuesConfig{Provider: "clickup", GitHub: githubIssuesConfig{Token: "x"}}}
+	pc := projectConfig{
+		Issues: issuesConfig{Provider: "clickup"},
+		MCP:    projectMCPConfig{GitHub: githubMCPConfig{Token: "x"}},
+	}
 	if p.Configured(pc, "/tmp") {
 		t.Error("Configured should be false when Provider != github")
 	}
@@ -640,75 +643,6 @@ func TestParseGitHubPageInfo_NoEnvelopeYieldsNotFound(t *testing.T) {
 	}
 }
 
-// MCPServer must return nil whenever the provider isn't fully
-// configured. The chat agent only gets a github MCP entry when ask
-// itself can talk to the same backend — anything less would expose a
-// half-wired tool to claude.
-func TestGitHubProvider_MCPServer_NilWhenUnconfigured(t *testing.T) {
-	p := &githubIssueProvider{}
-	dir := initGitRepo(t)
-	runGit(t, dir, "remote", "add", "origin", "https://github.com/Cidan/ask.git")
-
-	cases := []struct {
-		name string
-		pc   projectConfig
-		cwd  string
-	}{
-		{
-			name: "wrong provider id",
-			pc:   projectConfig{Issues: issuesConfig{Provider: "none", GitHub: githubIssuesConfig{Token: "ghp_x"}}},
-			cwd:  dir,
-		},
-		{
-			name: "missing token",
-			pc:   projectConfig{Issues: issuesConfig{Provider: "github"}},
-			cwd:  dir,
-		},
-		{
-			name: "non-github remote",
-			pc:   projectConfig{Issues: issuesConfig{Provider: "github", GitHub: githubIssuesConfig{Token: "ghp_x"}}},
-			cwd:  initGitRepo(t), // fresh repo with no remote at all
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := p.MCPServer(tc.pc, tc.cwd); got != nil {
-				t.Errorf("MCPServer should return nil when unconfigured, got %+v", got)
-			}
-		})
-	}
-}
-
-// Configured projects expose a github MCP server with the user's PAT
-// in the Authorization header so the chat agent can call list_issues
-// / issue_read without re-authenticating. The endpoint follows the
-// same default that ask itself uses for ctrl+i.
-func TestGitHubProvider_MCPServer_ConfiguredEmitsAuthHeader(t *testing.T) {
-	p := &githubIssueProvider{}
-	dir := initGitRepo(t)
-	runGit(t, dir, "remote", "add", "origin", "https://github.com/Cidan/ask.git")
-
-	pc := projectConfig{
-		Issues: issuesConfig{
-			Provider: "github",
-			GitHub:   githubIssuesConfig{Token: "ghp_secret"},
-		},
-	}
-	got := p.MCPServer(pc, dir)
-	if got == nil {
-		t.Fatalf("MCPServer should return a descriptor when fully configured")
-	}
-	if got.Name != "github" {
-		t.Errorf("Name=%q want %q", got.Name, "github")
-	}
-	if got.URL != githubIssuesDefaultEndpoint {
-		t.Errorf("URL=%q want default %q", got.URL, githubIssuesDefaultEndpoint)
-	}
-	if auth := got.Headers["Authorization"]; auth != "Bearer ghp_secret" {
-		t.Errorf("Authorization header=%q want %q", auth, "Bearer ghp_secret")
-	}
-}
-
 // TestGitHubBuildMoveIssueArgs covers the carry-and-drop translation
 // from a kanban column spec to the issue_write tool call. Each of the
 // four canonical GitHub columns must produce the right state +
@@ -758,27 +692,5 @@ func TestGitHubBuildMoveIssueArgs(t *testing.T) {
 				t.Errorf("state_reason=%v want %q", args["state_reason"], tc.wantReason)
 			}
 		})
-	}
-}
-
-// A custom endpoint (GHE-style) overrides the default. Token is still
-// passed through verbatim.
-func TestGitHubProvider_MCPServer_HonoursCustomEndpoint(t *testing.T) {
-	p := &githubIssueProvider{}
-	dir := initGitRepo(t)
-	runGit(t, dir, "remote", "add", "origin", "https://github.com/Cidan/ask.git")
-
-	pc := projectConfig{
-		Issues: issuesConfig{
-			Provider: "github",
-			GitHub:   githubIssuesConfig{Token: "ghp_x", Endpoint: "https://ghe.example/mcp"},
-		},
-	}
-	got := p.MCPServer(pc, dir)
-	if got == nil {
-		t.Fatalf("MCPServer should return a descriptor when fully configured")
-	}
-	if got.URL != "https://ghe.example/mcp" {
-		t.Errorf("URL=%q want %q", got.URL, "https://ghe.example/mcp")
 	}
 }

--- a/issue_provider_test.go
+++ b/issue_provider_test.go
@@ -91,9 +91,9 @@ func TestActiveIssueProvider_RoutesToConfiguredProvider(t *testing.T) {
 func TestProjectConfig_RoundTripPersistsViaUpsert(t *testing.T) {
 	cfg := askConfig{}
 	pc := projectConfig{
-		Issues: issuesConfig{
-			Provider: "github",
-			GitHub:   githubIssuesConfig{Token: "ghp_secret", Endpoint: "https://example.com/mcp"},
+		Issues: issuesConfig{Provider: "github"},
+		MCP: projectMCPConfig{
+			GitHub: githubMCPConfig{Token: "ghp_secret", Endpoint: "https://example.com/mcp"},
 		},
 	}
 	cfg = upsertProjectConfig(cfg, "/home/me/proj", pc)
@@ -179,15 +179,15 @@ func TestProjectRoot_FallsBackToCwdWhenNoGit(t *testing.T) {
 	}
 }
 
-func TestGitHubEndpointDefault_AppliesWhenBlank(t *testing.T) {
-	got := githubEndpointOrDefault(githubIssuesConfig{})
-	if got != githubIssuesDefaultEndpoint {
-		t.Errorf("default = %q want %q", got, githubIssuesDefaultEndpoint)
+func TestGitHubMCPEndpointDefault_AppliesWhenBlank(t *testing.T) {
+	got := githubMCPEndpointOrDefault(githubMCPConfig{})
+	if got != githubMCPDefaultEndpoint {
+		t.Errorf("default = %q want %q", got, githubMCPDefaultEndpoint)
 	}
 }
 
-func TestGitHubEndpointDefault_RespectsExplicit(t *testing.T) {
-	got := githubEndpointOrDefault(githubIssuesConfig{Endpoint: "https://ghe.example/mcp"})
+func TestGitHubMCPEndpointDefault_RespectsExplicit(t *testing.T) {
+	got := githubMCPEndpointOrDefault(githubMCPConfig{Endpoint: "https://ghe.example/mcp"})
 	if got != "https://ghe.example/mcp" {
 		t.Errorf("explicit endpoint not preserved: %q", got)
 	}

--- a/proc.go
+++ b/proc.go
@@ -36,7 +36,7 @@ func (m model) sessionArgs() ProviderSessionArgs {
 		ResumeCwd:          m.resumeCwd,
 		PluginDir:          usagePluginDir,
 		AddedDirs:          append([]string(nil), m.addedDirs...),
-		IssueMCP:           projectIssueMCP(m.cwd),
+		ProjectMCP:         projectGitHubMCP(m.cwd),
 	}
 	if m.sessionMinted {
 		args.NewSessionID = m.sessionID
@@ -46,14 +46,17 @@ func (m model) sessionArgs() ProviderSessionArgs {
 	return args
 }
 
-// projectIssueMCP resolves the configured issue provider for cwd to
-// its MCP server descriptor, or nil when no provider is configured
-// (or the one selected isn't fully configured). Pulled out of
-// sessionArgs so the prepareProviderSession path — which also rebuilds
-// args from disk-backed config inside startAndSendProviderCmd — can
-// pick up the latest issue config after the user edits it without
-// having to re-thread state through every caller.
-func projectIssueMCP(cwd string) *issueMCPServer {
+// projectGitHubMCP resolves the project-level GitHub MCP credentials
+// for cwd into a wire-shape descriptor, or nil when the project hasn't
+// configured a token. Independent of the issue provider — the chat
+// agent receives the GitHub MCP whenever the user has populated
+// MCP.GitHub.Token, even if the issues backend is "" / disabled.
+// Pulled out of sessionArgs so the prepareProviderSession path — which
+// also rebuilds args from disk-backed config inside
+// startAndSendProviderCmd — can pick up the latest MCP config after
+// the user edits it without having to re-thread state through every
+// caller.
+func projectGitHubMCP(cwd string) *issueMCPServer {
 	if cwd == "" {
 		return nil
 	}
@@ -61,8 +64,17 @@ func projectIssueMCP(cwd string) *issueMCPServer {
 	if err != nil {
 		return nil
 	}
-	provider, pc := activeIssueProvider(cfg, cwd)
-	return provider.MCPServer(pc, cwd)
+	pc := loadProjectConfig(cfg, cwd)
+	if pc.MCP.GitHub.Token == "" {
+		return nil
+	}
+	return &issueMCPServer{
+		Name: "github",
+		URL:  githubMCPEndpointOrDefault(pc.MCP.GitHub),
+		Headers: map[string]string{
+			"Authorization": "Bearer " + pc.MCP.GitHub.Token,
+		},
+	}
 }
 
 // ensureProc lazily starts a provider session on first send in a turn.

--- a/proc_test.go
+++ b/proc_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"testing"
+)
+
+// projectGitHubMCP must return a wired-up descriptor whenever the
+// project has a GitHub MCP token saved — even when the issues
+// backend is None. The whole point of decoupling the MCP slot from
+// the issues slot is so the chat agent can have GitHub access
+// without the user needing to opt in to the issues UI as well.
+func TestProjectGitHubMCP_ReturnsDescriptorWhenTokenSetEvenWithIssuesDisabled(t *testing.T) {
+	isolateHome(t)
+	cwd := t.TempDir()
+	cfg, _ := loadConfig()
+	cfg = upsertProjectConfig(cfg, cwd, projectConfig{
+		MCP: projectMCPConfig{GitHub: githubMCPConfig{Token: "ghp_secret"}},
+		// Issues.Provider deliberately left empty — chat agent should
+		// still get the GitHub MCP entry.
+	})
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("seed saveConfig: %v", err)
+	}
+	got := projectGitHubMCP(cwd)
+	if got == nil {
+		t.Fatalf("projectGitHubMCP should return a descriptor when a token is set, regardless of Issues.Provider")
+	}
+	if got.Name != "github" {
+		t.Errorf("Name=%q want github", got.Name)
+	}
+	if got.URL != githubMCPDefaultEndpoint {
+		t.Errorf("URL=%q want default %q", got.URL, githubMCPDefaultEndpoint)
+	}
+	if got.Headers["Authorization"] != "Bearer ghp_secret" {
+		t.Errorf("Authorization header missing or wrong: %+v", got.Headers)
+	}
+}
+
+// projectGitHubMCP must return nil when no token is configured.
+// Otherwise the chat agent's MCP roster would carry a half-wired
+// github entry that errors on every tool call.
+func TestProjectGitHubMCP_NilWhenTokenAbsent(t *testing.T) {
+	isolateHome(t)
+	cwd := t.TempDir()
+	// No saved config at all — projectGitHubMCP must default to nil.
+	if got := projectGitHubMCP(cwd); got != nil {
+		t.Errorf("projectGitHubMCP should be nil with no config; got %+v", got)
+	}
+	// Even if the project entry exists with the issue provider set
+	// to github, an empty token is still nil.
+	cfg, _ := loadConfig()
+	cfg = upsertProjectConfig(cfg, cwd, projectConfig{
+		Issues: issuesConfig{Provider: "github"},
+	})
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("seed saveConfig: %v", err)
+	}
+	if got := projectGitHubMCP(cwd); got != nil {
+		t.Errorf("projectGitHubMCP should be nil when token is empty; got %+v", got)
+	}
+}
+
+// projectGitHubMCP honours an explicitly configured custom endpoint
+// (GHE-style) so users on enterprise hosts are not forced through the
+// public copilot endpoint.
+func TestProjectGitHubMCP_HonoursCustomEndpoint(t *testing.T) {
+	isolateHome(t)
+	cwd := t.TempDir()
+	cfg, _ := loadConfig()
+	cfg = upsertProjectConfig(cfg, cwd, projectConfig{
+		MCP: projectMCPConfig{
+			GitHub: githubMCPConfig{
+				Token:    "ghp_secret",
+				Endpoint: "https://ghe.example/mcp",
+			},
+		},
+	})
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("seed saveConfig: %v", err)
+	}
+	got := projectGitHubMCP(cwd)
+	if got == nil {
+		t.Fatalf("projectGitHubMCP should return a descriptor")
+	}
+	if got.URL != "https://ghe.example/mcp" {
+		t.Errorf("URL=%q want %q", got.URL, "https://ghe.example/mcp")
+	}
+}
+
+// projectGitHubMCP returns nil when cwd is empty so callers that
+// don't yet know their working directory don't blow up. The model's
+// initial sessionArgs build can hit this path before cwd is set.
+func TestProjectGitHubMCP_NilOnEmptyCwd(t *testing.T) {
+	isolateHome(t)
+	if got := projectGitHubMCP(""); got != nil {
+		t.Errorf("projectGitHubMCP(\"\") should be nil; got %+v", got)
+	}
+}

--- a/provider.go
+++ b/provider.go
@@ -192,13 +192,15 @@ type ProviderSessionArgs struct {
 	// --add-dir; codex: sandbox_workspace_write.writable_roots). The
 	// list is deduped and ordered as the user added them.
 	AddedDirs []string
-	// IssueMCP is the project's issue-provider MCP server (the same
-	// backend ask uses for ctrl+i), exposed to the chat agent so it can
-	// search/read issues directly. nil when no provider is configured
-	// or the configured one is missing credentials. Providers wire this
+	// ProjectMCP is the project-level MCP server (today: the GitHub
+	// MCP slot the github issue provider also piggybacks on), exposed
+	// to the chat agent so it can call the same tools ask uses for
+	// ctrl+i. nil when the project hasn't configured a token. The chat
+	// agent gets this whenever projectConfig.MCP.GitHub.Token is set,
+	// regardless of whether issues are wired up. Providers wire this
 	// into their native MCP plumbing — claude appends it to its
 	// --mcp-config; providers without an MCP surface ignore it.
-	IssueMCP *issueMCPServer
+	ProjectMCP *issueMCPServer
 }
 
 // HistoryOpts narrows what the history replay renders. ToolOutput is

--- a/update_test.go
+++ b/update_test.go
@@ -1471,7 +1471,7 @@ func TestUpdate_PasteMsgInConfigProjectFieldEditorRoutes(t *testing.T) {
 	m := newTestModel(t, newFakeProvider())
 	m.mode = modeConfig
 	m.configProjectPickerActive = true
-	m.configProjectFieldEditing = "githubToken"
+	m.configProjectFieldEditing = "githubMCPToken"
 	m.configProjectFieldDraft = "ghp_"
 	m.input.SetValue("composer-untouched")
 

--- a/worktree.go
+++ b/worktree.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 )
 
@@ -25,6 +26,11 @@ const (
 	workspaceBackendNone workspaceBackend = iota
 	workspaceBackendGit
 	workspaceBackendJJ
+)
+
+var (
+	worktreeNameMu        sync.Mutex
+	reservedWorktreeNames = map[string]map[string]struct{}{}
 )
 
 // ensureWorktreeGitignore makes sure the repo at cwd ignores
@@ -569,9 +575,15 @@ func createWorktree() (path, name string, err error) {
 }
 
 func createWorktreeAt(cwd string) (path, name string, err error) {
+	parent := filepath.Join(cwd, ".claude", "worktrees")
 	name = newWorktreeName(cwd)
+	defer func() {
+		if err != nil && name != "" {
+			releaseWorktreeName(parent, name)
+		}
+	}()
 	path = worktreePath(cwd, name)
-	if err := os.MkdirAll(filepath.Join(cwd, ".claude", "worktrees"), 0o755); err != nil {
+	if err := os.MkdirAll(parent, 0o755); err != nil {
 		return "", "", fmt.Errorf("prepare worktrees dir: %w", err)
 	}
 	switch worktreeBackendAt(cwd) {
@@ -608,19 +620,62 @@ func worktreePath(cwd, name string) string {
 
 // newWorktreeName returns a fresh worktree directory name as an
 // `<adjective>-<verb>-<noun>` triple drawn uniformly from the curated lists in
-// worktree_words.go (125,000 combinations). A stat-based collision check
-// retries the triple if the directory happens to exist; after eight draws we
-// fall back to the same triple plus a 6-char alphanumeric tail so the function
-// can't spin forever even in pathological repos.
+// worktree_words.go (125,000 combinations). It rejects both names that already
+// exist on disk and names the current process has already handed out for the
+// same repo root, so back-to-back calls stay unique even before createWorktree
+// has created the directory. After eight triple-only draws we fall back to the
+// same triple plus a 6-char alphanumeric tail so the function can't spin
+// forever even in pathological repos.
 func newWorktreeName(cwd string) string {
 	parent := filepath.Join(cwd, ".claude", "worktrees")
 	for attempt := 0; attempt < 8; attempt++ {
 		name := randomWhimsy()
+		if !reserveWorktreeName(parent, name) {
+			continue
+		}
 		if _, err := os.Stat(filepath.Join(parent, name)); os.IsNotExist(err) {
 			return name
 		}
+		releaseWorktreeName(parent, name)
 	}
-	return randomWhimsy() + "-" + randomAlphanum(6)
+	for {
+		name := randomWhimsy() + "-" + randomAlphanum(6)
+		if !reserveWorktreeName(parent, name) {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(parent, name)); os.IsNotExist(err) {
+			return name
+		}
+		releaseWorktreeName(parent, name)
+	}
+}
+
+func reserveWorktreeName(parent, name string) bool {
+	worktreeNameMu.Lock()
+	defer worktreeNameMu.Unlock()
+	used := reservedWorktreeNames[parent]
+	if used == nil {
+		used = map[string]struct{}{}
+		reservedWorktreeNames[parent] = used
+	}
+	if _, exists := used[name]; exists {
+		return false
+	}
+	used[name] = struct{}{}
+	return true
+}
+
+func releaseWorktreeName(parent, name string) {
+	worktreeNameMu.Lock()
+	defer worktreeNameMu.Unlock()
+	used := reservedWorktreeNames[parent]
+	if used == nil {
+		return
+	}
+	delete(used, name)
+	if len(used) == 0 {
+		delete(reservedWorktreeNames, parent)
+	}
 }
 
 // randomWhimsy picks one adjective, one verb, one noun from the curated lists


### PR DESCRIPTION
## Summary

This PR inverts the ownership of the GitHub MCP credential. Previously it lived under `projectConfig.Issues.GitHub` and was dual-purposed: it powered both the ctrl+i kanban issues client and the chat agent's `--mcp-config` injection. That coupling meant you couldn't give the chat agent GitHub MCP access without enabling the issues UI, and it buried a network credential under a sub-system that conceptually doesn't own it.

### What changed

**Schema (`config.go`)**
- New top-level `projectConfig.MCP.GitHub.{Endpoint,Token}` slot (type `projectMCPConfig` / `githubMCPConfig`).
- `issuesConfig.GitHub` field removed; `githubIssuesConfig` type removed.
- Constants/helpers renamed: `githubIssuesDefaultEndpoint` → `githubMCPDefaultEndpoint`, `githubEndpointOrDefault` → `githubMCPEndpointOrDefault`.
- `migrateLegacyIssuesGitHub` auto-migrates on-disk `issues.github.{endpoint,token}` into `mcp.github.*` at load time (explicit new value always wins; no data is lost on double-set).
- `isProjectConfigEmpty` updated to cover the new MCP slot.

**Issue provider (`issue_provider_github.go`, `issue_provider.go`)**
- `Configured()`, `connect()`, `ListIssues()`, `GetIssue()`, `MoveIssue()` all read `cfg.MCP.GitHub` instead of the now-removed `cfg.Issues.GitHub`.
- `MCPServer()` removed from the `IssueProvider` interface entirely — there is now **one** MCP source of truth (`proc.go:projectGitHubMCP`), not two parallel paths.

**Chat injection (`proc.go`, `provider.go`, `claude.go`, `codex.go`)**
- `projectIssueMCP` → `projectGitHubMCP`: reads `pc.MCP.GitHub` directly; the chat agent receives the GitHub MCP whenever a token is set, **regardless of whether `Issues.Provider` is configured**.
- `ProviderSessionArgs.IssueMCP` → `ProjectMCP`.
- Codex env var renamed: `ASK_ISSUE_MCP_BEARER` → `ASK_PROJECT_MCP_BEARER`.

**UI (`config_project.go`)**
- "GitHub MCP endpoint" and "GitHub MCP PAT" rows are now **unconditional** under Project Options (previously only appeared when the issue provider was already set to `github`).
- `cycleIssueProvider` gates the `"" → "github"` transition on `pc.MCP.GitHub.Token` being non-empty. Cycling away from `github` is always allowed (escape hatch). The coupling rule: you cannot enable GitHub issues without a project MCP configured — the provider piggybacks on it.

**Worktree fix (`worktree.go`)**
- Fixes a flaky bug in `newWorktreeName`: previously only checked the filesystem for name uniqueness, so repeated calls before directory creation could collide. Names are now reserved in-process per repo root via a package-level map and released on creation failure.

## Behavior changes

| Scenario | Before | After |
|---|---|---|
| `MCP.GitHub.Token` set, `Issues.Provider = ""` | Chat agent got no GitHub MCP | Chat agent gets GitHub MCP ✓ |
| `Issues.Provider = "github"` with no token | Worked (silently degraded) | Refused at `cycleIssueProvider` with toast |
| Existing on-disk `issues.github.*` | Read directly | Auto-migrated to `mcp.github.*` at load |
| Issue provider toggle restarts chat proc | Yes (unnecessary) | No — proc restart is scoped to MCP-credential edits only |

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — 1189 pass, 0 fail

**New tests added:**
- `config_test.go`: 6 migration scenarios (token+endpoint, token-only, endpoint-only, explicit-new-wins, no-op-on-empty-projects, save→load round-trip).
- `config_project_test.go`: cycle-gate refusal when no MCP token; cycle-away always succeeds; issue-provider toggle no longer kills open proc.
- `proc_test.go` (new file): `projectGitHubMCP` — issues=none + MCP set → descriptor returned; no token → nil; custom endpoint; empty-cwd guard.
- `claude_cli_test.go` / `codex_cli_test.go`: chat injection with `Issues.Provider=""` + `MCP.GitHub.Token` set → GitHub MCP appears in args.

**Updated tests:**
- All existing `IssueMCP` / `MCPServer` / `githubIssuesConfig` / field-ID references updated to the new names and config path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)