### PR TITLE
Add Ctrl+P PR screen with kanban view, merge flow, and detail/comments

### DIFF
--- a/ask_question.go
+++ b/ask_question.go
@@ -517,6 +517,15 @@ func (m model) viewCloseTabConfirm() string {
 	return renderCancelConfirmBox("Close this tab?", "Stops claude in this tab.", m.closeTabChoice)
 }
 
+func (m model) viewMergePRConfirm() string {
+	title := fmt.Sprintf("Merge PR #%d?", m.mergePRItem.number)
+	sub := "Merges this pull request via GitHub."
+	if strings.TrimSpace(m.mergePRReason) != "" {
+		sub = m.mergePRReason
+	}
+	return renderCancelConfirmBox(title, sub, m.mergePRChoice)
+}
+
 func renderCancelConfirmBox(title, sub string, choice int) string {
 	no := askConfirmBtnStyle.Render("No")
 	yes := askConfirmBtnStyle.Render("Yes")

--- a/issue_provider.go
+++ b/issue_provider.go
@@ -134,6 +134,49 @@ type IssueProvider interface {
 	// resolve to a valid backend project (e.g. github needs
 	// owner/repo from `git remote get-url origin`).
 	IssueRef(cfg projectConfig, cwd string, it issue) (issueRef, error)
+	// SupportsCarry reports whether this provider participates in the
+	// kanban carry-and-drop status switcher (Space pickup, Tab move,
+	// Space drop). Issue providers typically return true so users can
+	// move cards between Open / Closed columns; PR providers return
+	// false because PRs don't drag — Open → Merged is an explicit
+	// merge action, not a column drag.
+	SupportsCarry() bool
+}
+
+// IssueMerger is an optional capability interface providers can
+// implement when their items support a merge action (PRs in
+// practice). The PR kanban screen probes the active provider via
+// type assertion: when it's an IssueMerger the `m` keybind on a
+// focused card runs the two-step flow (Mergeable pre-flight, then
+// Merge once the user confirms).
+//
+// Mergeable is a pre-flight check — providers consult their backend
+// for the latest "can this be merged" signal and return a
+// mergeableState that the screen translates into either a confirmation
+// modal (canMerge=true) or a refusal toast carrying the reason
+// (canMerge=false).
+//
+// Merge attempts the actual merge. On success the screen reloads the
+// affected columns; on error the screen surfaces the error verbatim
+// and leaves the row in place.
+type IssueMerger interface {
+	Mergeable(ctx context.Context, cfg projectConfig, cwd string, it issue) (mergeableState, error)
+	Merge(ctx context.Context, cfg projectConfig, cwd string, it issue) error
+}
+
+// mergeableState captures the pre-flight result returned by
+// IssueMerger.Mergeable. canMerge=true means the merge can be
+// attempted; canMerge=false means reason carries a human-readable
+// explanation (merge conflict, draft, blocked by branch protection,
+// behind base, …) the UI surfaces verbatim in a toast.
+//
+// state is the raw provider-side label (github's mergeable_state
+// string) preserved so tests and future renderers can branch on the
+// canonical token instead of the human-readable reason.
+type mergeableState struct {
+	canMerge bool
+	reason   string
+	state    string
 }
 
 // issueMCPServer is the MCP server descriptor ask injects into the
@@ -208,6 +251,8 @@ var issueProviderRegistry = []IssueProvider{
 	&githubIssueProvider{},
 }
 
+var githubPRScreenProvider IssueProvider = &githubPRProvider{}
+
 // issueProviderByID returns the registered provider with the given
 // id, or noneIssueProvider when nothing matches (including the
 // empty string for unconfigured projects). Never returns nil — the
@@ -227,6 +272,11 @@ func issueProviderByID(id string) IssueProvider {
 func activeIssueProvider(cfg askConfig, cwd string) (IssueProvider, projectConfig) {
 	pc := loadProjectConfig(cfg, cwd)
 	return issueProviderByID(pc.Issues.Provider), pc
+}
+
+func activePRProvider(cfg askConfig, cwd string) (IssueProvider, projectConfig) {
+	pc := loadProjectConfig(cfg, cwd)
+	return githubPRScreenProvider, pc
 }
 
 // noneIssueProvider is the explicit "issues are not configured"
@@ -255,3 +305,4 @@ func (noneIssueProvider) KanbanIssueStatus(KanbanColumnSpec) string { return "" 
 func (noneIssueProvider) IssueRef(projectConfig, string, issue) (issueRef, error) {
 	return issueRef{}, errIssueProviderNotConfigured
 }
+func (noneIssueProvider) SupportsCarry() bool { return false }

--- a/issue_provider_fake_test.go
+++ b/issue_provider_fake_test.go
@@ -20,12 +20,18 @@ type fakeQuery struct {
 // method has an overridable *Fn hook so tests can simulate
 // arbitrary behaviour (errors, slow responses, custom column
 // taxonomies). When a hook is nil, sensible defaults take over.
+//
+// Carry support defaults to true so existing kanban-carry tests
+// against the default fake keep working. PR-screen tests that need
+// the merger surface use fakeMergerIssueProvider, which composes
+// over a fakeIssueProvider with carry disabled.
 type fakeIssueProvider struct {
 	id            string
 	displayName   string
 	configured    bool
 	syntaxHelp    string
 	columns       []KanbanColumnSpec
+	supportsCarry bool
 	parseQueryFn  func(string) (IssueQuery, error)
 	formatQueryFn func(IssueQuery) string
 	listIssuesFn  func(context.Context, projectConfig, string, IssueQuery, IssuePagination) (IssueListPage, error)
@@ -46,10 +52,11 @@ type fakeMoveCall struct {
 
 func newFakeIssueProvider() *fakeIssueProvider {
 	return &fakeIssueProvider{
-		id:          "fake",
-		displayName: "Fake Issues",
-		configured:  true,
-		syntaxHelp:  "fake syntax",
+		id:            "fake",
+		displayName:   "Fake Issues",
+		configured:    true,
+		syntaxHelp:    "fake syntax",
+		supportsCarry: true,
 	}
 }
 
@@ -58,6 +65,7 @@ func (f *fakeIssueProvider) DisplayName() string                   { return f.di
 func (f *fakeIssueProvider) Configured(projectConfig, string) bool { return f.configured }
 func (f *fakeIssueProvider) QuerySyntaxHelp() string               { return f.syntaxHelp }
 func (f *fakeIssueProvider) KanbanColumns() []KanbanColumnSpec     { return f.columns }
+func (f *fakeIssueProvider) SupportsCarry() bool                   { return f.supportsCarry }
 
 func (f *fakeIssueProvider) ParseQuery(text string) (IssueQuery, error) {
 	if f.parseQueryFn != nil {
@@ -194,5 +202,57 @@ func newFakeMockProvider(all []issue) *fakeIssueProvider {
 			HasMore:    hasMore,
 		}, nil
 	}
+	p.getIssueFn = func(_ context.Context, _ projectConfig, _ string, number int) (issue, error) {
+		for _, it := range all {
+			if it.number == number {
+				return it, nil
+			}
+		}
+		return issue{number: number}, nil
+	}
 	return p
+}
+
+// fakeMergerIssueProvider is the test double for an IssueProvider
+// that ALSO implements IssueMerger. PR-screen tests use this to
+// exercise the `m` merge keybind, the pre-flight Mergeable() round
+// trip, and the post-merge reload. It composes over fakeIssueProvider
+// so all the existing IssueProvider hooks are still available; the
+// added Mergeable / Merge methods record their call args so tests
+// can assert dispatch happened with the right issue snapshot.
+//
+// Default behaviour: Mergeable returns canMerge=true / state=clean,
+// Merge returns nil. Tests override the *Fn hooks for failure paths.
+type fakeMergerIssueProvider struct {
+	*fakeIssueProvider
+
+	mergeableFn func(context.Context, projectConfig, string, issue) (mergeableState, error)
+	mergeFn     func(context.Context, projectConfig, string, issue) error
+
+	mergeableCalls []issue
+	mergeCalls     []issue
+}
+
+func newFakeMergerIssueProvider() *fakeMergerIssueProvider {
+	base := newFakeIssueProvider()
+	base.id = "fake-merger"
+	base.displayName = "Fake PRs"
+	base.supportsCarry = false
+	return &fakeMergerIssueProvider{fakeIssueProvider: base}
+}
+
+func (f *fakeMergerIssueProvider) Mergeable(ctx context.Context, cfg projectConfig, cwd string, it issue) (mergeableState, error) {
+	f.mergeableCalls = append(f.mergeableCalls, it)
+	if f.mergeableFn != nil {
+		return f.mergeableFn(ctx, cfg, cwd, it)
+	}
+	return mergeableState{canMerge: true, state: "clean"}, nil
+}
+
+func (f *fakeMergerIssueProvider) Merge(ctx context.Context, cfg projectConfig, cwd string, it issue) error {
+	f.mergeCalls = append(f.mergeCalls, it)
+	if f.mergeFn != nil {
+		return f.mergeFn(ctx, cfg, cwd, it)
+	}
+	return nil
 }

--- a/issue_provider_github.go
+++ b/issue_provider_github.go
@@ -427,6 +427,11 @@ func githubBuildMoveIssueArgs(owner, repo string, issueNumber int, target *githu
 	return githubToolIssueWrite, args
 }
 
+// SupportsCarry returns true: GitHub issues drag between Open /
+// Closed reason columns via the kanban carry-and-drop status
+// switcher, mapping to issue_write state mutations.
+func (p *githubIssueProvider) SupportsCarry() bool { return true }
+
 // IssueRef resolves cwd to "owner/repo" via the same mechanism the
 // rest of the github provider uses (`git remote get-url origin`),
 // then assembles the canonical issueRef for `it`. Returns
@@ -482,24 +487,37 @@ func (p *githubIssueProvider) connect(ctx context.Context, cfg githubMCPConfig) 
 		_ = p.session.Close()
 		p.session = nil
 	}
+	cs, err := dialGitHubMCP(ctx, endpoint, cfg.Token, githubMCPInitTimeout)
+	if err != nil {
+		return nil, err
+	}
+	p.session = cs
+	p.cachedEndpoint = endpoint
+	p.cachedToken = cfg.Token
+	return cs, nil
+}
+
+// dialGitHubMCP performs the bearer-auth Streamable HTTP handshake
+// shared by every GitHub-backed provider (issues, PRs, future). The
+// per-provider connect methods cache the returned session keyed on
+// (endpoint, token); this helper just owns the transport setup so
+// the auth/round-tripper wiring lives in one place.
+func dialGitHubMCP(ctx context.Context, endpoint, token string, timeout time.Duration) (*mcp.ClientSession, error) {
 	httpClient := &http.Client{
-		Transport: &bearerRoundTripper{base: http.DefaultTransport, token: cfg.Token},
-		Timeout:   githubMCPInitTimeout,
+		Transport: &bearerRoundTripper{base: http.DefaultTransport, token: token},
+		Timeout:   timeout,
 	}
 	transport := &mcp.StreamableClientTransport{
 		Endpoint:   endpoint,
 		HTTPClient: httpClient,
 	}
 	cli := mcp.NewClient(&mcp.Implementation{Name: "ask", Version: askIssueClientVersion}, nil)
-	cctx, cancel := context.WithTimeout(ctx, githubMCPInitTimeout)
+	cctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	cs, err := cli.Connect(cctx, transport, nil)
 	if err != nil {
 		return nil, fmt.Errorf("connect %s: %w", endpoint, err)
 	}
-	p.session = cs
-	p.cachedEndpoint = endpoint
-	p.cachedToken = cfg.Token
 	return cs, nil
 }
 

--- a/issue_search.go
+++ b/issue_search.go
@@ -26,11 +26,11 @@ const (
 // owns the cursor and edit state; we layer mode + parseErr +
 // aiNotice around it.
 type issueSearchBox struct {
-	input     textinput.Model
-	mode      searchMode
-	parseErr  string
-	aiNotice  string
-	width     int
+	input    textinput.Model
+	mode     searchMode
+	parseErr string
+	aiNotice string
+	width    int
 }
 
 // newIssueSearchBox builds the overlay with sensible defaults
@@ -151,7 +151,7 @@ func (b *issueSearchBox) submitRaw(s *issuesState) tea.Cmd {
 	}
 	pagination := IssuePagination{Cursor: "", PerPage: githubDefaultPerPage}
 	return loadIssuesPageCmd(
-		ctx, s.tabID, s.provider, s.projectCfg, s.cwd,
+		ctx, s.tabID, s.screen, s.provider, s.projectCfg, s.cwd,
 		q, pagination, s.queryGen,
 	)
 }

--- a/issues.go
+++ b/issues.go
@@ -61,18 +61,22 @@ var issueLoadingSpinnerFrames = []string{
 
 // issueLoadingTickMsg fires every issueLoadingTickInterval while
 // the loader modal is up. tabID lets the handler ignore ticks
-// targeting a different tab; the handler also drops the tick
-// silently when s.loading is false so the animation cleanly stops
-// once the first chunk arrives.
-type issueLoadingTickMsg struct{ tabID int }
+// targeting a different tab; screen lets the handler route to the
+// right state field (m.issues vs m.prs) on a tab that owns both.
+// The handler also drops the tick silently when s.loading is false
+// so the animation cleanly stops once the first chunk arrives.
+type issueLoadingTickMsg struct {
+	tabID  int
+	screen screenID
+}
 
 // issueLoadingTickCmd schedules the next loader animation tick.
-// Returned by every entry path that flips s.loading=true (Ctrl+I
-// screen entry, search-box submit, reloadCurrentQuery) and
+// Returned by every entry path that flips s.loading=true (Ctrl+I /
+// Ctrl+P screen entry, search-box submit, reloadCurrentQuery) and
 // re-emitted by the handler as long as loading is still true.
-func issueLoadingTickCmd(tabID int) tea.Cmd {
+func issueLoadingTickCmd(tabID int, screen screenID) tea.Cmd {
 	return tea.Tick(issueLoadingTickInterval, func(time.Time) tea.Msg {
-		return issueLoadingTickMsg{tabID: tabID}
+		return issueLoadingTickMsg{tabID: tabID, screen: screen}
 	})
 }
 
@@ -163,14 +167,39 @@ func viewIndexForName(name string) int {
 // handler drops the message when gen != s.queryGen (stale
 // supersede) and reads requestedCursor (not page.NextCursor)
 // to identify first-chunk-of-query, since page is zero-valued
-// on error paths.
+// on error paths. screen routes the message to the right state
+// field on a tab that owns both screens (m.issues vs m.prs).
 type issuePageLoadedMsg struct {
 	tabID           int
+	screen          screenID
 	gen             int
 	query           IssueQuery
 	requestedCursor string
 	page            IssueListPage
 	err             error
+}
+
+type issueMergeCheckDoneMsg struct {
+	tabID  int
+	screen screenID
+	item   issue
+	state  mergeableState
+	err    error
+}
+
+type issueMergeDoneMsg struct {
+	tabID  int
+	screen screenID
+	item   issue
+	err    error
+}
+
+type issueDetailLoadedMsg struct {
+	tabID  int
+	screen screenID
+	number int
+	item   issue
+	err    error
 }
 
 // loadIssuesPageCmd dispatches a cursor-based provider call off
@@ -181,14 +210,17 @@ type issuePageLoadedMsg struct {
 //
 // ctx allows the screen to cancel an in-flight request when a
 // new query supersedes it. Pass context.Background() for one-off
-// loads where cancellation isn't needed.
-func loadIssuesPageCmd(ctx context.Context, tabID int, p IssueProvider, pc projectConfig, cwd string, query IssueQuery, pagination IssuePagination, gen int) tea.Cmd {
+// loads where cancellation isn't needed. screen labels the
+// message so the dispatcher routes it back to the originating
+// state (issues or PRs).
+func loadIssuesPageCmd(ctx context.Context, tabID int, screen screenID, p IssueProvider, pc projectConfig, cwd string, query IssueQuery, pagination IssuePagination, gen int) tea.Cmd {
 	return func() tea.Msg {
 		cctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 		page, err := p.ListIssues(cctx, pc, cwd, query, pagination)
 		return issuePageLoadedMsg{
 			tabID:           tabID,
+			screen:          screen,
 			gen:             gen,
 			query:           query,
 			requestedCursor: pagination.Cursor,
@@ -198,10 +230,35 @@ func loadIssuesPageCmd(ctx context.Context, tabID int, p IssueProvider, pc proje
 	}
 }
 
+func loadIssueDetailCmd(tabID int, screen screenID, provider IssueProvider, cfg projectConfig, cwd string, number int) tea.Cmd {
+	if provider == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		it, err := provider.GetIssue(context.Background(), cfg, cwd, number)
+		return issueDetailLoadedMsg{
+			tabID:  tabID,
+			screen: screen,
+			number: number,
+			item:   it,
+			err:    err,
+		}
+	}
+}
+
 type issuesState struct {
 	sort issueSort
 
 	view issueView
+
+	// screen names which top-level surface this state belongs to —
+	// screenIssues for the issues kanban, screenPRs for the PR
+	// kanban. Stamped at construction (newIssuesState / newPRsState)
+	// and read by the message routing in update.go to dispatch
+	// loaded-page / merge / loading-tick messages back to the right
+	// state field on model. Without this discriminator a message
+	// fired by the PR screen would clobber m.issues and vice-versa.
+	screen screenID
 
 	// provider is the active IssueProvider for this tab/cwd.
 	// Captured on screen entry so query fingerprinting and
@@ -369,14 +426,69 @@ type issueView interface {
 // it's resolved which provider the project uses; tests can
 // install a fake provider directly.
 func newIssuesState() *issuesState {
+	return newKanbanState(screenIssues)
+}
+
+// newPRsState builds an empty kanban state for the PR screen. The
+// provider is installed by the Ctrl+P screen-entry path in update.go
+// once the GitHub MCP token is verified configured. The screen
+// discriminator is the only difference from newIssuesState — it
+// drives the message-routing pick-up in update.go.
+func newPRsState() *issuesState {
+	return newKanbanState(screenPRs)
+}
+
+// newKanbanState is the shared constructor for the issues and PRs
+// kanban surfaces. It seeds an empty state with the noneIssueProvider
+// so a render before screen entry doesn't panic; the per-screen
+// dispatch path (Ctrl+I / Ctrl+P) installs the real provider once
+// configuration has been verified.
+func newKanbanState(screen screenID) *issuesState {
 	s := &issuesState{
 		sort:      issueSortByNumber,
 		pageCache: map[string][]issuePageChunk{},
 		provider:  noneIssueProvider{},
 		loadCtx:   context.Background(),
+		screen:    screen,
 	}
 	s.view = issueViewLayers[0].builder(s)
 	return s
+}
+
+func (s *issuesState) title() string {
+	switch s.screen {
+	case screenPRs:
+		return "Pull Requests"
+	default:
+		return "Issues"
+	}
+}
+
+func (s *issuesState) titleLower() string {
+	switch s.screen {
+	case screenPRs:
+		return "pull requests"
+	default:
+		return "issues"
+	}
+}
+
+func (s *issuesState) detailLabel() string {
+	switch s.screen {
+	case screenPRs:
+		return "PR"
+	default:
+		return "Issue"
+	}
+}
+
+func (s *issuesState) mergeLabel() string {
+	switch s.screen {
+	case screenPRs:
+		return "PR"
+	default:
+		return "item"
+	}
 }
 
 // issuePageChunk is one chunk in a query's fetched chain.
@@ -499,8 +611,55 @@ func (s *issuesState) insertIssueIntoCache(q IssueQuery, it issue, index int) {
 	s.pageCache[fp] = chain
 }
 
+func (s *issuesState) replaceIssueSnapshots(updated issue) {
+	if s.pageCache != nil {
+		for fp, chain := range s.pageCache {
+			for ci := range chain {
+				for ii := range chain[ci].issues {
+					if chain[ci].issues[ii].number == updated.number {
+						chain[ci].issues[ii] = updated
+					}
+				}
+			}
+			s.pageCache[fp] = chain
+		}
+	}
+	if kv, ok := s.view.(*kanbanIssueView); ok {
+		replaceKanbanIssueRows(kv, updated)
+		return
+	}
+	if dv, ok := s.view.(*issueDetailView); ok {
+		if dv.issue.number == updated.number {
+			dv.setIssue(updated)
+		}
+		if kv, ok := dv.parent.(*kanbanIssueView); ok {
+			replaceKanbanIssueRows(kv, updated)
+		}
+	}
+}
+
+func (s *issuesState) finishIssueHydration(issueNumber int) {
+	if dv, ok := s.view.(*issueDetailView); ok && dv.issue.number == issueNumber {
+		dv.setHydrating(false)
+	}
+}
+
+func replaceKanbanIssueRows(kv *kanbanIssueView, updated issue) {
+	for ci := range kv.columns {
+		for ii := range kv.columns[ci].loaded {
+			if kv.columns[ci].loaded[ii].number == updated.number {
+				kv.columns[ci].loaded[ii] = updated
+			}
+		}
+	}
+}
+
 func (s *issuesState) hasAnyCachedPage(q IssueQuery) bool {
 	return len(s.cachedChunks(q)) > 0
+}
+
+func shouldHydrateIssueDetail(it issue) bool {
+	return strings.TrimSpace(it.description) == "" || len(it.comments) == 0
 }
 
 // beginLoad cancels any in-flight load and installs a fresh
@@ -579,7 +738,7 @@ func (s *issuesState) reloadCurrentQuery() tea.Cmd {
 		}
 		nv := newKanbanIssueView(s)
 		s.view = nv
-		return tea.Batch(nv.initialLoad(s), issueLoadingTickCmd(s.tabID))
+		return tea.Batch(nv.initialLoad(s), issueLoadingTickCmd(s.tabID, s.screen))
 	}
 	return nil
 }
@@ -870,9 +1029,27 @@ type issuesScreen struct{}
 func (issuesScreen) id() screenID { return screenIssues }
 
 func (issuesScreen) updateKey(m model, msg tea.KeyPressMsg) (model, tea.Cmd, bool) {
-	if m.issues == nil {
-		m.issues = newIssuesState()
-	}
+	return updateIssueScreenKey(m, msg, screenIssues)
+}
+
+func (issuesScreen) view(m model) string {
+	return viewIssueScreen(m, screenIssues)
+}
+
+type prsScreen struct{}
+
+func (prsScreen) id() screenID { return screenPRs }
+
+func (prsScreen) updateKey(m model, msg tea.KeyPressMsg) (model, tea.Cmd, bool) {
+	return updateIssueScreenKey(m, msg, screenPRs)
+}
+
+func (prsScreen) view(m model) string {
+	return viewIssueScreen(m, screenPRs)
+}
+
+func updateIssueScreenKey(m model, msg tea.KeyPressMsg, screen screenID) (model, tea.Cmd, bool) {
+	s := m.ensureIssueState(screen)
 	// Ctrl+D closes the current tab from any screen — keep parity with
 	// askScreen so the user isn't trapped in issues.
 	if msg.Mod == tea.ModCtrl && msg.Code == 'd' {
@@ -911,49 +1088,49 @@ func (issuesScreen) updateKey(m model, msg tea.KeyPressMsg) (model, tea.Cmd, boo
 	// load), and every other key is consumed so a stray press can't
 	// whisk the user past the failure without acknowledgment.
 	isCtrlR := msg.Mod == tea.ModCtrl && msg.Code == 'r'
-	if m.issues.loading {
+	if s.loading {
 		if isCtrlR {
-			return m, m.issues.reloadCurrentQuery(), true
+			return m, s.reloadCurrentQuery(), true
 		}
 		return m, nil, true
 	}
-	if m.issues.loadErr != nil {
+	if s.loadErr != nil {
 		if msg.Mod == 0 && (msg.Code == tea.KeyEnter || msg.Code == tea.KeyEsc) {
 			// Same hygiene as the Ctrl+O path: drop the cache + cancel
 			// in-flight on screen-leave so re-entry doesn't stack
 			// duplicate chunks onto the chain.
-			m.issues.discardOnLeave()
+			s.discardOnLeave()
 			return m.switchScreen(screenAsk), nil, true
 		}
 		if isCtrlR {
 			// Reload from error: clear the error first so
 			// reloadCurrentQuery's loading-modal swap is the active
 			// overlay, not the persistent error modal.
-			m.issues.loadErr = nil
-			return m, m.issues.reloadCurrentQuery(), true
+			s.loadErr = nil
+			return m, s.reloadCurrentQuery(), true
 		}
 		return m, nil, true
 	}
 	// Search box has top-level priority when open: it owns every
 	// keypress until Esc / empty-backspace closes it. Routes the
 	// dispatched search via cmd back through Update.
-	if m.issues.search != nil {
-		closed, cmd := m.issues.search.updateKey(m.issues, msg)
+	if s.search != nil {
+		closed, cmd := s.search.updateKey(s, msg)
 		if closed {
-			m.issues.search = nil
+			s.search = nil
 			// First-page-of-this-query → modal + animation tick.
 			// Subsequent re-fetches of an already-cached query
 			// stay inline.
-			if cmd != nil && !m.issues.hasAnyCachedPage(m.issues.currentQuery) {
-				m.issues.loading = true
-				m.issues.loadingMessage = pickLoadingMessage()
-				m.issues.loadingFrame = 0
-				m.issues.loadErr = nil
-				cmd = tea.Batch(cmd, issueLoadingTickCmd(m.issues.tabID))
+			if cmd != nil && !s.hasAnyCachedPage(s.currentQuery) {
+				s.loading = true
+				s.loadingMessage = pickLoadingMessage()
+				s.loadingFrame = 0
+				s.loadErr = nil
+				cmd = tea.Batch(cmd, issueLoadingTickCmd(s.tabID, s.screen))
 			}
 			// Rebuild the active view against the new query so
 			// kanban columns pick up the new spec query targets.
-			m.issues.view = issueViewLayers[viewIndexForName(m.issues.view.name())].builder(m.issues)
+			s.view = issueViewLayers[viewIndexForName(s.view.name())].builder(s)
 		}
 		return m, cmd, true
 	}
@@ -964,9 +1141,9 @@ func (issuesScreen) updateKey(m model, msg tea.KeyPressMsg) (model, tea.Cmd, boo
 	// so the user can keep editing without the reload yanking the
 	// screen out from under them.
 	if isCtrlR {
-		if kv, ok := m.issues.view.(*kanbanIssueView); ok {
-			kv.cancelCarry(m.issues)
-			return m, m.issues.reloadCurrentQuery(), true
+		if kv, ok := s.view.(*kanbanIssueView); ok {
+			kv.cancelCarry(s)
+			return m, s.reloadCurrentQuery(), true
 		}
 	}
 	// "/" opens the search overlay from kanban (not detail, not
@@ -974,15 +1151,18 @@ func (issuesScreen) updateKey(m model, msg tea.KeyPressMsg) (model, tea.Cmd, boo
 	// the typed "/" doesn't bleed into the kanban layer behind
 	// the box.
 	if msg.Mod == 0 && msg.Code == '/' {
-		if kv, ok := m.issues.view.(*kanbanIssueView); ok {
-			kv.cancelCarry(m.issues)
+		if kv, ok := s.view.(*kanbanIssueView); ok {
+			kv.cancelCarry(s)
 			help := ""
-			if m.issues.provider != nil {
-				help = m.issues.provider.QuerySyntaxHelp()
+			if s.provider != nil {
+				help = s.provider.QuerySyntaxHelp()
 			}
-			m.issues.search = newIssueSearchBox(help)
+			s.search = newIssueSearchBox(help)
 			return m, nil, true
 		}
+	}
+	if screen == screenPRs && msg.Mod == 0 && msg.Code == 'm' {
+		return m.startPRMergeFlow()
 	}
 	// "f" dispatches a workflow run against the focused issue. Works
 	// from kanban (focused card) and the detail view; ignored on any
@@ -991,33 +1171,183 @@ func (issuesScreen) updateKey(m model, msg tea.KeyPressMsg) (model, tea.Cmd, boo
 	// modifier-naked 'f' can never get consumed by something else
 	// downstream (e.g. a future fuzzy-find keybind on a card list).
 	if msg.Mod == 0 && msg.Code == 'f' {
-		return m.dispatchIssueWorkflow()
+		return m.dispatchIssueWorkflow(screen)
 	}
-	v, cmd, handled := m.issues.view.updateKey(m.issues, msg)
+	v, cmd, handled := s.view.updateKey(s, msg)
 	if handled {
-		m.issues.setView(v)
+		s.setView(v)
 	}
 	return m, cmd, handled
+}
+
+func viewIssueScreen(m model, screen screenID) string {
+	s := m.issueStateForScreen(screen)
+	if s == nil {
+		if screen == screenIssues {
+			s = newIssuesState()
+			m.issues = s
+		} else {
+			s = newPRsState()
+			m.prs = s
+		}
+	}
+	width := m.width
+	height := m.height
+	if width <= 0 {
+		width = 80
+	}
+	if height <= 0 {
+		height = 24
+	}
+	if s.loading || s.loadErr != nil {
+		return renderIssuesOverlay(s, width, height)
+	}
+	if m.workflowPicker != nil {
+		return m.renderWorkflowPicker()
+	}
+	contentW := max(20, width-issueScreenIndent-1)
+	contentH := max(4, height-issueScreenChromeHeight(s))
+	s.view.resize(contentW, contentH)
+
+	bodyView := s.view.view(s)
+	bodyLines := strings.Split(bodyView, "\n")
+
+	bodyTopRow := 2
+	if s.search != nil {
+		bodyTopRow++
+	}
+	s.bodyTopRow = bodyTopRow
+	s.bodyContentH = len(bodyLines)
+	s.bodyLeftCol = issueScreenIndent
+	s.scrollbarCol = width - 1
+
+	bodyLines = applyIssuesSelectionHighlight(s, bodyLines)
+
+	yOff, total, viewH := s.view.scroll()
+	if total > viewH {
+		bar := renderIssuesScrollbar(viewH, total, yOff)
+		for i := range bodyLines {
+			if i < len(bar) {
+				bodyLines[i] += bar[i]
+			}
+		}
+	}
+
+	hint := s.view.hint()
+	if kv, ok := s.view.(*kanbanIssueView); ok {
+		hint = kv.hintFor(s)
+	}
+	if dv, ok := s.view.(*issueDetailView); ok {
+		hint = dv.hintFor(s)
+	}
+	if m.exitArmed {
+		hint = dimStyle.Render("Press ctrl+c again to exit")
+	}
+
+	var b strings.Builder
+	b.WriteString(s.view.header(s))
+	b.WriteString("\n\n")
+	if s.search != nil {
+		s.search.resize(width - issueScreenIndent)
+		b.WriteString(s.search.view())
+		b.WriteString("\n")
+	}
+	b.WriteString(strings.Join(bodyLines, "\n"))
+	b.WriteString("\n")
+	b.WriteString(hint)
+	return indentLines(b.String(), issueScreenIndent)
+}
+
+func (m model) enterIssueScreen(screen screenID, provider IssueProvider, pc projectConfig) (model, tea.Cmd) {
+	m = m.switchScreen(screen)
+	s := m.ensureIssueState(screen)
+	s.provider = provider
+	s.projectCfg = pc
+	s.cwd = m.cwd
+	s.tabID = m.id
+	s.view = issueViewLayers[0].builder(s)
+	kv, _ := s.view.(*kanbanIssueView)
+
+	anyLoaded := false
+	if kv != nil {
+		for _, c := range kv.columns {
+			if len(c.loaded) > 0 {
+				anyLoaded = true
+				break
+			}
+		}
+	}
+
+	var cmds []tea.Cmd
+	if !anyLoaded {
+		s.loading = true
+		s.loadingMessage = pickLoadingMessage()
+		s.loadingFrame = 0
+		s.loadErr = nil
+		cmds = append(cmds, issueLoadingTickCmd(m.id, screen))
+	}
+	_ = s.beginLoad()
+	if kv != nil {
+		if c := kv.initialLoad(s); c != nil {
+			cmds = append(cmds, c)
+		}
+	}
+	if len(cmds) == 0 {
+		return m, nil
+	}
+	return m, tea.Batch(cmds...)
+}
+
+func (m model) startPRMergeFlow() (model, tea.Cmd, bool) {
+	s := m.issueStateForScreen(screenPRs)
+	if s == nil {
+		return m, nil, true
+	}
+	merger, ok := s.provider.(IssueMerger)
+	if !ok {
+		return m, m.toast.show("merge not supported for this provider"), true
+	}
+	it, ok := focusedIssue(s.view)
+	if !ok {
+		return m, nil, true
+	}
+	ctx := s.beginLoad()
+	s.loading = true
+	s.loadingMessage = fmt.Sprintf("Checking whether %s #%d can be merged...", s.mergeLabel(), it.number)
+	s.loadingFrame = 0
+	s.loadErr = nil
+	cmd := func() tea.Msg {
+		state, err := merger.Mergeable(ctx, s.projectCfg, s.cwd, it)
+		return issueMergeCheckDoneMsg{
+			tabID:  m.id,
+			screen: s.screen,
+			item:   it,
+			state:  state,
+			err:    err,
+		}
+	}
+	return m, tea.Batch(issueLoadingTickCmd(m.id, s.screen), cmd), true
 }
 
 // dispatchIssueWorkflow resolves the issue currently in focus on the
 // issues screen, then either focuses an existing workflow tab for
 // that issue or pops the workflow picker. Returns (model, cmd,
 // handled=true) — the screen handler always treats `f` as consumed.
-func (m model) dispatchIssueWorkflow() (model, tea.Cmd, bool) {
-	if m.issues == nil {
+func (m model) dispatchIssueWorkflow(screen screenID) (model, tea.Cmd, bool) {
+	s := m.issueStateForScreen(screen)
+	if s == nil {
 		return m, nil, true
 	}
-	it, ok := focusedIssue(m.issues.view)
+	it, ok := focusedIssue(s.view)
 	if !ok {
 		return m, nil, true
 	}
-	if m.issues.provider == nil {
-		return m, m.toast.show("issues provider not configured"), true
+	if s.provider == nil {
+		return m, m.toast.show(s.titleLower() + " provider not configured"), true
 	}
-	ref, err := m.issues.provider.IssueRef(m.issues.projectCfg, m.cwd, it)
+	ref, err := s.provider.IssueRef(s.projectCfg, m.cwd, it)
 	if err != nil {
-		return m, m.toast.show("could not resolve issue ref: " + err.Error()), true
+		return m, m.toast.show("could not resolve " + s.titleLower() + " ref: " + err.Error()), true
 	}
 	if tabID, alive := workflowTracker().activeTabFor(ref.Key()); alive {
 		// A workflow run is already in flight for this issue. Focus
@@ -1066,100 +1396,6 @@ func focusTabCmd(tabID int) tea.Cmd {
 	return func() tea.Msg { return focusTabMsg{tabID: tabID} }
 }
 
-func (issuesScreen) view(m model) string {
-	if m.issues == nil {
-		// Shouldn't happen under normal flow (newTab/newTestModel seed
-		// the state on construction), but a defensive lazy-init keeps
-		// the screen renderable from any entry point.
-		m.issues = newIssuesState()
-	}
-	width := m.width
-	height := m.height
-	if width <= 0 {
-		width = 80
-	}
-	if height <= 0 {
-		height = 24
-	}
-	// Loading or error: replace the whole body area with a centered
-	// modal. The chrome (header + hint) is suppressed too — there is
-	// nothing meaningful to advertise above an unpopulated list, and
-	// the modal carries its own dismissal hint when in error state.
-	if m.issues.loading || m.issues.loadErr != nil {
-		return renderIssuesOverlay(m.issues, width, height)
-	}
-	// Workflow picker takes the whole body on `f`. Same trick as the
-	// loading overlay: replace the body, keep the user's context in
-	// their head. The picker is small (one screen of pipeline names)
-	// and confirm-driven so they always know where they are.
-	if m.workflowPicker != nil {
-		return m.renderWorkflowPicker()
-	}
-	// Reserve one column on the right for the scrollbar — fixed
-	// allocation, even when there's no overflow, so selection /
-	// click-routing math stays stable as content grows or shrinks.
-	contentW := max(20, width-issueScreenIndent-1)
-	contentH := max(4, height-issueScreenChromeHeight(m.issues))
-	m.issues.view.resize(contentW, contentH)
-
-	bodyView := m.issues.view.view(m.issues)
-	bodyLines := strings.Split(bodyView, "\n")
-
-	// Track the screen footprint of the body so mouse handlers can
-	// translate clicks back to (sub-view content row, column). Header
-	// is one line, then a blank; the optional search row sits between
-	// that chrome and the body when active.
-	bodyTopRow := 2
-	if m.issues.search != nil {
-		bodyTopRow++
-	}
-	s := m.issues
-	s.bodyTopRow = bodyTopRow
-	s.bodyContentH = len(bodyLines)
-	s.bodyLeftCol = issueScreenIndent
-	s.scrollbarCol = width - 1
-
-	bodyLines = applyIssuesSelectionHighlight(s, bodyLines)
-
-	yOff, total, viewH := m.issues.view.scroll()
-	if total > viewH {
-		bar := renderIssuesScrollbar(viewH, total, yOff)
-		for i := range bodyLines {
-			if i < len(bar) {
-				bodyLines[i] += bar[i]
-			}
-		}
-	}
-
-	hint := m.issues.view.hint()
-	if m.exitArmed {
-		// Mirror ask's "press ctrl+c again to exit" affordance, but
-		// swap the hint line in place since the issues screen has no
-		// chat history to append a transient message to. The next
-		// keypress disarms (handled in updateKey) and the hint
-		// switches back automatically on the following render.
-		hint = dimStyle.Render("Press ctrl+c again to exit")
-	}
-
-	var b strings.Builder
-	b.WriteString(m.issues.view.header(m.issues))
-	b.WriteString("\n\n")
-	if m.issues.search != nil {
-		m.issues.search.resize(width - issueScreenIndent)
-		b.WriteString(m.issues.search.view())
-		b.WriteString("\n")
-	}
-	b.WriteString(strings.Join(bodyLines, "\n"))
-	b.WriteString("\n")
-	b.WriteString(hint)
-	// Single, uniform left indent applied at the screen level so the
-	// table widget, viewport content, header, and hint all sit at the
-	// same column. Doing it per-piece (outputStyle on each fragment)
-	// produced inconsistent margins where bubbles' table/viewport
-	// rendered flush-left while the header lines were indented.
-	return indentLines(b.String(), issueScreenIndent)
-}
-
 // renderIssuesOverlay draws a centered loading-or-error modal in
 // place of the list/kanban body. The error variant uses an
 // errorFG-tinted border and carries a dismissal hint so a network
@@ -1172,7 +1408,7 @@ func renderIssuesOverlay(s *issuesState, width, height int) string {
 	var box string
 	if s.loadErr != nil {
 		wrapW := max(width-10, 16)
-		title := errStyle.Bold(true).Render("Failed to load issues")
+		title := errStyle.Bold(true).Render("Failed to load " + s.titleLower())
 		wrapped := lipgloss.NewStyle().Width(wrapW).Render(s.loadErr.Error())
 		hint := dimStyle.Render("press enter to go back · esc dismiss")
 		body := lipgloss.JoinVertical(lipgloss.Left, title, "", wrapped, "", hint)
@@ -1180,7 +1416,7 @@ func renderIssuesOverlay(s *issuesState, width, height int) string {
 	} else {
 		msg := s.loadingMessage
 		if msg == "" {
-			msg = "Loading issues..."
+			msg = "Loading " + s.titleLower() + "..."
 		}
 		// Single line: braille glyph + 2 spaces + fun message. The
 		// glyph cycles every tick for the high-FPS "still alive"
@@ -1199,10 +1435,10 @@ func renderIssuesOverlay(s *issuesState, width, height int) string {
 // Returning the model and a tea.Cmd matches the rest of the Update
 // dispatch shape so the routing in update.go is uniform across screens.
 func (m model) issuesHandleMouse(msg tea.Msg) (model, tea.Cmd) {
-	if m.issues == nil {
+	s := m.activeIssueState()
+	if s == nil {
 		return m, nil
 	}
-	s := m.issues
 	// Loading and error states cover the body; mouse events targeting
 	// the (suppressed) list/kanban underneath should be no-ops so the
 	// user can't drag-select against an empty surface or wheel-scroll
@@ -1291,11 +1527,12 @@ func (m model) issuesHandleMouse(msg tea.Msg) (model, tea.Cmd) {
 // highlight, and dispatches the async clipboard write + toast through
 // the same copyTextCmd the chat side uses.
 func (m model) issuesCopySelectionAndClear() (model, tea.Cmd) {
-	if m.issues == nil {
+	s := m.activeIssueState()
+	if s == nil {
 		return m, nil
 	}
-	text := m.issues.buildCopyText()
-	m.issues.clearSelection()
+	text := s.buildCopyText()
+	s.clearSelection()
 	if text == "" {
 		return m, nil
 	}
@@ -1359,6 +1596,7 @@ type issueDetailView struct {
 
 	rendered    string
 	renderedFor int
+	hydrating   bool
 }
 
 func newIssueDetailView(parent issueView, it issue, width, height int) *issueDetailView {
@@ -1369,6 +1607,19 @@ func newIssueDetailView(parent issueView, it issue, width, height int) *issueDet
 	}
 	v.resize(width, height)
 	return v
+}
+
+func (v *issueDetailView) setIssue(it issue) {
+	offset := v.vp.YOffset()
+	v.issue = it
+	v.rendered = ""
+	v.renderedFor = 0
+	v.resize(v.width, v.height)
+	v.vp.SetYOffset(offset)
+}
+
+func (v *issueDetailView) setHydrating(hydrating bool) {
+	v.hydrating = hydrating
 }
 
 func (v *issueDetailView) name() string { return "detail" }
@@ -1464,17 +1715,30 @@ func (v *issueDetailView) view(s *issuesState) string {
 func (v *issueDetailView) header(s *issuesState) string {
 	prefix, hasPrefix := workflowKeyPrefix(s)
 	glyph := workflowStatusForIssue(s, prefix, hasPrefix, v.issue.number)
-	header := promptStyle.Render(fmt.Sprintf("Issue #%d", v.issue.number))
+	header := promptStyle.Render(fmt.Sprintf("%s #%d", s.detailLabel(), v.issue.number))
 	if glyph != "" {
 		header = glyph + " " + header
 	}
-	return header + dimStyle.Render("  · ") + v.issue.title
+	header += dimStyle.Render("  · ") + v.issue.title
+	if v.hydrating {
+		header += dimStyle.Render("  · loading…")
+	}
+	return header
 }
 
 func (v *issueDetailView) hint() string {
 	return dimStyle.Render(
 		"↑/↓ scroll · pgup/pgdn page · f run workflow · esc/backspace back · ctrl+o back to ask",
 	)
+}
+
+func (v *issueDetailView) hintFor(s *issuesState) string {
+	if s != nil && s.screen == screenPRs {
+		return dimStyle.Render(
+			"↑/↓ scroll · pgup/pgdn page · m merge · f run workflow · esc/backspace back · ctrl+o back to ask",
+		)
+	}
+	return v.hint()
 }
 
 func (v *issueDetailView) scroll() (int, int, int) {
@@ -1711,6 +1975,7 @@ func (v *kanbanIssueView) dropCarry(s *issuesState, tabID int) (tea.Cmd, bool) {
 		err := provider.MoveIssue(ctx, pc, cwd, originalSnapshot, target)
 		return issueMoveDoneMsg{
 			tabID:        tabID,
+			screen:       s.screen,
 			issueNumber:  originalSnapshot.number,
 			originSnap:   originalSnapshot,
 			originColIdx: originIdx,
@@ -1761,6 +2026,7 @@ func (v *kanbanIssueView) cancelCarry(s *issuesState) {
 // the underlying provider error.
 type issueMoveDoneMsg struct {
 	tabID        int
+	screen       screenID
 	issueNumber  int
 	originSnap   issue
 	originColIdx int
@@ -1829,7 +2095,7 @@ func (v *kanbanIssueView) initialLoad(s *issuesState) tea.Cmd {
 		}
 		col.fetching = true
 		cmds = append(cmds, loadIssuesPageCmd(
-			s.loadCtx, s.tabID, s.provider, s.projectCfg, s.cwd,
+			s.loadCtx, s.tabID, s.screen, s.provider, s.projectCfg, s.cwd,
 			col.spec.Query, IssuePagination{Cursor: "", PerPage: githubDefaultPerPage},
 			s.queryGen,
 		))
@@ -1854,7 +2120,7 @@ func (v *kanbanIssueView) maybeFetchNextPage(s *issuesState) tea.Cmd {
 	cursor := col.nextCursor
 	col.fetching = true
 	return loadIssuesPageCmd(
-		s.loadCtx, s.tabID, s.provider, s.projectCfg, s.cwd,
+		s.loadCtx, s.tabID, s.screen, s.provider, s.projectCfg, s.cwd,
 		col.spec.Query, IssuePagination{Cursor: cursor, PerPage: githubDefaultPerPage},
 		s.queryGen,
 	)
@@ -1977,7 +2243,7 @@ func (v *kanbanIssueView) maybeFetchToFillViewport(s *issuesState) tea.Cmd {
 	cursor := col.nextCursor
 	col.fetching = true
 	return loadIssuesPageCmd(
-		s.loadCtx, s.tabID, s.provider, s.projectCfg, s.cwd,
+		s.loadCtx, s.tabID, s.screen, s.provider, s.projectCfg, s.cwd,
 		col.spec.Query, IssuePagination{Cursor: cursor, PerPage: githubDefaultPerPage},
 		s.queryGen,
 	)
@@ -2005,17 +2271,31 @@ func (v *kanbanIssueView) header(s *issuesState) string {
 	for _, c := range v.columns {
 		total += len(c.loaded)
 	}
-	return promptStyle.Render("Issues") +
+	return promptStyle.Render(s.title()) +
 		dimStyle.Render(fmt.Sprintf("  (%d) — kanban view", total))
 }
 
-func (v *kanbanIssueView) hint() string {
+func (v *kanbanIssueView) hintFor(s *issuesState) string {
 	if v.carry.active {
 		return dimStyle.Render("space drop · ←/→/tab change column · esc cancel · other keys disabled while carrying")
+	}
+	if s != nil && s.provider != nil && !s.provider.SupportsCarry() {
+		if _, ok := s.provider.(IssueMerger); ok {
+			return dimStyle.Render(
+				"↑/↓ row · pgup/pgdn page · ←/→/tab column · enter open · m merge · f run workflow · / search · ctrl+r reload · ctrl+o back",
+			)
+		}
+		return dimStyle.Render(
+			"↑/↓ row · pgup/pgdn page · ←/→/tab column · enter open · f run workflow · / search · ctrl+r reload · ctrl+o back",
+		)
 	}
 	return dimStyle.Render(
 		"↑/↓ row · pgup/pgdn page · ←/→/tab column · enter open · space pick up · f run workflow · / search · ctrl+r reload · ctrl+o back",
 	)
+}
+
+func (v *kanbanIssueView) hint() string {
+	return v.hintFor(nil)
 }
 
 func (v *kanbanIssueView) updateKey(s *issuesState, msg tea.KeyPressMsg) (issueView, tea.Cmd, bool) {
@@ -2025,7 +2305,7 @@ func (v *kanbanIssueView) updateKey(s *issuesState, msg tea.KeyPressMsg) (issueV
 	// Selection is screen-relative on kanban; any nav key drops the
 	// drag-select highlight so the new layout doesn't keep painting
 	// the old rectangle.
-	if isKanbanNav(msg) {
+	if isKanbanNavForState(s, v.carry.active, msg) {
 		s.clearSelection()
 	}
 	if v.carry.active {
@@ -2033,6 +2313,9 @@ func (v *kanbanIssueView) updateKey(s *issuesState, msg tea.KeyPressMsg) (issueV
 	}
 	switch msg.Code {
 	case ' ':
+		if s.provider == nil || !s.provider.SupportsCarry() {
+			return v, nil, true
+		}
 		v.pickupCarry(s)
 		return v, nil, true
 	case tea.KeyEnter:
@@ -2043,7 +2326,13 @@ func (v *kanbanIssueView) updateKey(s *issuesState, msg tea.KeyPressMsg) (issueV
 		if v.selRowIdx >= len(col.loaded) {
 			return v, nil, true
 		}
-		return newIssueDetailView(v, col.loaded[v.selRowIdx], v.width, v.height), nil, true
+		it := col.loaded[v.selRowIdx]
+		detail := newIssueDetailView(v, it, v.width, v.height)
+		if shouldHydrateIssueDetail(it) {
+			detail.setHydrating(true)
+			return detail, loadIssueDetailCmd(s.tabID, s.screen, s.provider, s.projectCfg, s.cwd, it.number), true
+		}
+		return detail, nil, true
 	case tea.KeyUp, 'k':
 		if v.selRowIdx > 0 {
 			v.selRowIdx--
@@ -2161,12 +2450,18 @@ func (v *kanbanIssueView) updateKeyCarrying(s *issuesState, msg tea.KeyPressMsg)
 // the view's focus state in a way that supersedes any active text
 // selection rectangle.
 func isKanbanNav(msg tea.KeyPressMsg) bool {
+	return isKanbanNavForState(nil, false, msg)
+}
+
+func isKanbanNavForState(s *issuesState, carrying bool, msg tea.KeyPressMsg) bool {
 	switch msg.Code {
 	case tea.KeyUp, tea.KeyDown, tea.KeyLeft, tea.KeyRight,
 		tea.KeyTab, tea.KeyEnter, tea.KeyEsc,
 		tea.KeyPgUp, tea.KeyPgDown,
-		' ', 'h', 'j', 'k', 'l', 'g', 'G':
+		'h', 'j', 'k', 'l', 'g', 'G':
 		return true
+	case ' ':
+		return carrying || (s != nil && s.provider != nil && s.provider.SupportsCarry())
 	}
 	return false
 }

--- a/issues_loading_test.go
+++ b/issues_loading_test.go
@@ -70,6 +70,7 @@ func TestFirstPageError_ClearsLoadingAndShowsModal(t *testing.T) {
 	loadErr := fmt.Errorf("auth: bad token")
 	m, _ = runUpdate(t, m, issuePageLoadedMsg{
 		tabID:           m.id,
+		screen:          screenIssues,
 		gen:             m.issues.queryGen,
 		query:           nil,
 		requestedCursor: "",
@@ -133,7 +134,7 @@ func TestLoaderAnimation_TickAdvancesFrameWhileLoading(t *testing.T) {
 	m.issues.loading = true
 	m.issues.loadingMessage = "Brewing fresh issues..."
 	m.issues.loadingFrame = 0
-	m, cmd := runUpdate(t, m, issueLoadingTickMsg{tabID: m.id})
+	m, cmd := runUpdate(t, m, issueLoadingTickMsg{tabID: m.id, screen: screenIssues})
 	if m.issues.loadingFrame != 1 {
 		t.Errorf("frame should advance on tick: got %d want 1", m.issues.loadingFrame)
 	}
@@ -146,7 +147,7 @@ func TestLoaderAnimation_TickStopsAfterLoadingClears(t *testing.T) {
 	m := enterIssuesScreen(t)
 	m.issues.loading = false
 	startFrame := m.issues.loadingFrame
-	_, cmd := runUpdate(t, m, issueLoadingTickMsg{tabID: m.id})
+	_, cmd := runUpdate(t, m, issueLoadingTickMsg{tabID: m.id, screen: screenIssues})
 	if m.issues.loadingFrame != startFrame {
 		t.Errorf("frame should not advance when not loading: got %d want %d",
 			m.issues.loadingFrame, startFrame)
@@ -160,7 +161,7 @@ func TestLoaderAnimation_TickIgnoresWrongTab(t *testing.T) {
 	m := enterIssuesScreen(t)
 	m.issues.loading = true
 	m.issues.loadingFrame = 5
-	_, cmd := runUpdate(t, m, issueLoadingTickMsg{tabID: m.id + 999})
+	_, cmd := runUpdate(t, m, issueLoadingTickMsg{tabID: m.id + 999, screen: screenIssues})
 	if m.issues.loadingFrame != 5 {
 		t.Errorf("foreign-tab tick should not advance frame")
 	}
@@ -179,7 +180,7 @@ func TestLoaderAnimation_RenderDiffersBetweenFrames(t *testing.T) {
 	m.issues.loadingMessage = "Reticulating splines..."
 	m.issues.loadingFrame = 0
 	first := stripAnsi(m.activeScreen().view(m))
-	m, _ = runUpdate(t, m, issueLoadingTickMsg{tabID: m.id})
+	m, _ = runUpdate(t, m, issueLoadingTickMsg{tabID: m.id, screen: screenIssues})
 	second := stripAnsi(m.activeScreen().view(m))
 	if first == second {
 		t.Errorf("two consecutive frames produced identical output:\nfirst:\n%s\nsecond:\n%s",
@@ -288,10 +289,11 @@ func TestStaleGenResponseDoesNotMutate(t *testing.T) {
 	beforeFingerprint := m.issues.queryFingerprint(m.issues.currentQuery)
 	staleQuery := &fakeQuery{statusMatch: "ghost"}
 	m, _ = runUpdate(t, m, issuePageLoadedMsg{
-		tabID: m.id,
-		gen:   3, // stale!
-		query: staleQuery,
-		page:  IssueListPage{Issues: []issue{{number: 12345}}, HasMore: false},
+		tabID:  m.id,
+		screen: screenIssues,
+		gen:    3, // stale!
+		query:  staleQuery,
+		page:   IssueListPage{Issues: []issue{{number: 12345}}, HasMore: false},
 	})
 	if got := len(issuesAll(m.issues)); got != beforeCount {
 		t.Errorf("nil-query rows mutated by stale msg: %d → %d", beforeCount, got)

--- a/issues_pagination_test.go
+++ b/issues_pagination_test.go
@@ -148,7 +148,7 @@ func TestLoadIssuesPageCmd_EmitsTaggedMsg(t *testing.T) {
 	provider.listIssuesFn = func(ctx context.Context, _ projectConfig, _ string, q IssueQuery, p IssuePagination) (IssueListPage, error) {
 		return IssueListPage{Issues: []issue{{number: 1}}, NextCursor: "1", HasMore: false}, nil
 	}
-	cmd := loadIssuesPageCmd(context.Background(), 42, provider, projectConfig{}, "/tmp", nil, IssuePagination{Cursor: "abc", PerPage: 50}, 7)
+	cmd := loadIssuesPageCmd(context.Background(), 42, screenIssues, provider, projectConfig{}, "/tmp", nil, IssuePagination{Cursor: "abc", PerPage: 50}, 7)
 	msg := cmd().(issuePageLoadedMsg)
 	if msg.tabID != 42 {
 		t.Errorf("tabID=%d want 42", msg.tabID)
@@ -173,10 +173,11 @@ func TestIssuePageLoadedMsg_StaleGenIsDropped(t *testing.T) {
 	beforeRows := len(issuesAll(m.issues))
 	// Send a message with a different gen — must not mutate state.
 	m, _ = runUpdate(t, m, issuePageLoadedMsg{
-		tabID: m.id,
-		gen:   2,
-		query: nil,
-		page:  IssueListPage{Issues: []issue{{number: 999}}, HasMore: false},
+		tabID:  m.id,
+		screen: screenIssues,
+		gen:    2,
+		query:  nil,
+		page:   IssueListPage{Issues: []issue{{number: 999}}, HasMore: false},
 	})
 	if got := len(issuesAll(m.issues)); got != beforeRows {
 		t.Errorf("stale-gen msg mutated state: rows %d → %d", beforeRows, got)
@@ -188,6 +189,7 @@ func TestIssuePageLoadedMsg_FreshGenStoresInCache(t *testing.T) {
 	gen := m.issues.queryGen
 	m, _ = runUpdate(t, m, issuePageLoadedMsg{
 		tabID:           m.id,
+		screen:          screenIssues,
 		gen:             gen,
 		query:           &fakeQuery{statusMatch: "fresh"},
 		requestedCursor: "",
@@ -208,6 +210,7 @@ func TestIssuePageLoadedMsg_FirstChunkErrorSetsLoadErr(t *testing.T) {
 	gen := m.issues.queryGen
 	m, _ = runUpdate(t, m, issuePageLoadedMsg{
 		tabID:           m.id,
+		screen:          screenIssues,
 		gen:             gen,
 		query:           nil,
 		requestedCursor: "",
@@ -229,6 +232,7 @@ func TestIssuePageLoadedMsg_SecondChunkErrorDoesNotShowModal(t *testing.T) {
 	gen := m.issues.queryGen
 	m, _ = runUpdate(t, m, issuePageLoadedMsg{
 		tabID:           m.id,
+		screen:          screenIssues,
 		gen:             gen,
 		query:           nil,
 		requestedCursor: "1",
@@ -293,6 +297,7 @@ func TestKanbanColumn_RoutesPageLoadedToCorrectColumn(t *testing.T) {
 	target := kv.columns[1].spec.Query
 	m, _ = runUpdate(t, m, issuePageLoadedMsg{
 		tabID:           m.id,
+		screen:          screenIssues,
 		gen:             gen,
 		query:           target,
 		requestedCursor: "5",
@@ -321,6 +326,7 @@ func TestKanbanColumn_NextCursorAdvancesOnChunkReceipt(t *testing.T) {
 	gen := m.issues.queryGen
 	m, _ = runUpdate(t, m, issuePageLoadedMsg{
 		tabID:           m.id,
+		screen:          screenIssues,
 		gen:             gen,
 		query:           target,
 		requestedCursor: "",
@@ -384,6 +390,7 @@ func TestKanbanPageLoad_AutoFetchesMoreWhenFirstChunkDoesNotFillViewport(t *test
 
 	m, cmd := runUpdate(t, m, issuePageLoadedMsg{
 		tabID:           s.tabID,
+		screen:          screenIssues,
 		gen:             s.queryGen,
 		query:           kv.columns[0].spec.Query,
 		requestedCursor: "",

--- a/issues_test.go
+++ b/issues_test.go
@@ -1114,6 +1114,7 @@ func TestIssues_PageLoadedMsgWithErrorPopulatesLoadErr(t *testing.T) {
 	loadErr := fmt.Errorf("503 service unavailable")
 	m, _ = runUpdate(t, m, issuePageLoadedMsg{
 		tabID:           m.id,
+		screen:          screenIssues,
 		gen:             m.issues.queryGen,
 		query:           nil,
 		requestedCursor: "",
@@ -1134,6 +1135,7 @@ func TestIssues_PageLoadedMsgWithSuccessClearsBothFlags(t *testing.T) {
 	m.issues.loadErr = fmt.Errorf("stale")
 	m, _ = runUpdate(t, m, issuePageLoadedMsg{
 		tabID:           m.id,
+		screen:          screenIssues,
 		gen:             m.issues.queryGen,
 		query:           nil,
 		requestedCursor: "",

--- a/pr_provider_github.go
+++ b/pr_provider_github.go
@@ -1,0 +1,776 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// githubPRProvider implements IssueProvider + IssueMerger against
+// the same GitHub MCP server the issue provider talks to. It runs
+// alongside githubIssueProvider as a parallel surface — a separate
+// kanban screen with PR-specific columns and an `m` keybind that
+// uses the IssueMerger capability to perform pre-flight + merge.
+//
+// Cwd → owner/repo resolution and MCP session connect/cache are
+// shared with githubIssueProvider via resolveGitHubRepo and
+// connectGitHubMCP — keeping a single session per (endpoint, token)
+// across both providers so a tab on PRs and a tab on issues don't
+// pay double the handshake cost.
+//
+// The four canonical kanban columns (Open / Draft / Merged / Closed)
+// are expressed as search_pull_requests qualifiers so the GitHub
+// backend does the filtering. list_pull_requests is intentionally not
+// used — the bare REST endpoint only exposes state=open|closed|all,
+// which can't separate Open vs Draft or Merged vs Closed-without-merge.
+type githubPRProvider struct {
+	// session is the shared MCP client session, keyed on (endpoint,
+	// token) just like githubIssueProvider. We could centralise
+	// further by lifting the cache up into a package-level helper,
+	// but keeping a per-provider cache mirrors the issues path and
+	// avoids cross-provider coupling on cache invalidation.
+	mu sync.Mutex
+
+	cachedEndpoint string
+	cachedToken    string
+	session        *mcp.ClientSession
+}
+
+// MCP tool names for the GitHub Copilot MCP server's PR surface.
+// pull_request_read is polymorphic via `method`: "get" returns the
+// PR + body + mergeable signals, "get_comments" returns the issue-
+// thread comments. We use both. merge_pull_request executes the
+// merge with a configurable strategy.
+const (
+	githubToolListPullRequests   = "list_pull_requests"
+	githubToolSearchPullRequests = "search_pull_requests"
+	githubToolPullRequestRead    = "pull_request_read"
+	githubToolMergePullRequest   = "merge_pull_request"
+	// githubPRMergeMethod is the default merge strategy. We expose
+	// the value as a constant rather than baking it into the call
+	// site so a future user-facing knob (per-project default merge
+	// method) plugs in here without rewriting the call.
+	githubPRMergeMethod = "merge"
+)
+
+func (p *githubPRProvider) ID() string          { return "github-prs" }
+func (p *githubPRProvider) DisplayName() string { return "GitHub Pull Requests" }
+
+// Configured mirrors the issue provider: the same MCP token slot
+// gates both, the same `git remote get-url origin` resolves the
+// project. If either fails, the screen surfaces the standard
+// "not configured" toast at the Ctrl+P entry point.
+func (p *githubPRProvider) Configured(cfg projectConfig, cwd string) bool {
+	if cfg.MCP.GitHub.Token == "" {
+		return false
+	}
+	if _, _, err := resolveGitHubRepo(cwd); err != nil {
+		return false
+	}
+	return true
+}
+
+// ParseQuery accepts the same surface-level token grammar as the
+// issue provider, with the addition of `is:draft|merged|open|closed`
+// for PR-only state filters. Unrecognised key:value tokens fall
+// through to free-text. nil on empty.
+//
+// Free-form filter is more limited than issues today (the columns
+// already partition by state); the picker / search box still routes
+// through here so the user can type `label:bug` etc. and the search
+// API handles it.
+func (p *githubPRProvider) ParseQuery(text string) (IssueQuery, error) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil, nil
+	}
+	q := &githubPRQuery{}
+	tokens := strings.Fields(text)
+	var freeText []string
+	for _, tok := range tokens {
+		key, val, hasColon := strings.Cut(tok, ":")
+		if !hasColon || key == "" || val == "" {
+			freeText = append(freeText, tok)
+			continue
+		}
+		switch strings.ToLower(key) {
+		case "is":
+			v := strings.ToLower(val)
+			switch v {
+			case "open", "closed", "merged", "draft":
+				q.is = append(q.is, v)
+			default:
+				return nil, fmt.Errorf("is:%s — expected open, closed, merged, or draft", val)
+			}
+		case "label":
+			q.labels = append(q.labels, val)
+		case "assignee":
+			q.assignee = val
+		case "author":
+			q.author = val
+		case "no":
+			if strings.ToLower(val) != "assignee" {
+				return nil, fmt.Errorf("no:%s — only no:assignee is supported", val)
+			}
+			q.noAssignee = true
+		case "sort":
+			v := strings.ToLower(val)
+			switch v {
+			case "created", "updated", "comments":
+				q.sort = v
+			default:
+				return nil, fmt.Errorf("sort:%s — expected created, updated, or comments", val)
+			}
+		case "order":
+			v := strings.ToLower(val)
+			switch v {
+			case "asc", "desc":
+				q.order = v
+			default:
+				return nil, fmt.Errorf("order:%s — expected asc or desc", val)
+			}
+		default:
+			freeText = append(freeText, tok)
+		}
+	}
+	if len(freeText) > 0 {
+		q.freeText = strings.Join(freeText, " ")
+	}
+	return q, nil
+}
+
+// FormatQuery renders a parsed *githubPRQuery back to canonical
+// text. Token order is normalised so ParseQuery(FormatQuery(q))
+// round-trips. nil → empty string.
+func (p *githubPRProvider) FormatQuery(q IssueQuery) string {
+	pq, ok := q.(*githubPRQuery)
+	if !ok || pq == nil {
+		return ""
+	}
+	var parts []string
+	for _, is := range pq.is {
+		parts = append(parts, "is:"+is)
+	}
+	for _, l := range pq.labels {
+		parts = append(parts, "label:"+l)
+	}
+	if pq.assignee != "" {
+		parts = append(parts, "assignee:"+pq.assignee)
+	}
+	if pq.author != "" {
+		parts = append(parts, "author:"+pq.author)
+	}
+	if pq.noAssignee {
+		parts = append(parts, "no:assignee")
+	}
+	if pq.sort != "" {
+		parts = append(parts, "sort:"+pq.sort)
+	}
+	if pq.order != "" {
+		parts = append(parts, "order:"+pq.order)
+	}
+	if pq.freeText != "" {
+		parts = append(parts, pq.freeText)
+	}
+	return strings.Join(parts, " ")
+}
+
+func (p *githubPRProvider) QuerySyntaxHelp() string {
+	return "is:open|closed|merged|draft  label:<v>  assignee:<v>  author:<v>  no:assignee  sort:<v>  order:<v>  + free text"
+}
+
+// KanbanColumns returns the canonical 4-column PR taxonomy:
+//
+//  1. Open    — open PRs that aren't drafts
+//  2. Draft   — draft PRs (open && draft=true)
+//  3. Merged  — closed PRs that were merged
+//  4. Closed  — closed PRs that were NOT merged
+//
+// Each column's Query is a *githubPRQuery built directly so
+// kanban routing never depends on parse-cycle quirks. The `is`
+// values are the qualifiers the search_pull_requests tool
+// understands.
+func (p *githubPRProvider) KanbanColumns() []KanbanColumnSpec {
+	return []KanbanColumnSpec{
+		{Label: "Open", Query: &githubPRQuery{is: []string{"open"}, notDraft: true}},
+		{Label: "Draft", Query: &githubPRQuery{is: []string{"draft"}}},
+		{Label: "Merged", Query: &githubPRQuery{is: []string{"merged"}}},
+		{Label: "Closed", Query: &githubPRQuery{is: []string{"closed"}, notMerged: true}},
+	}
+}
+
+// ListIssues fetches one chunk of PRs for the project rooted at
+// cwd, filtered by query. Always routes through search_pull_requests
+// because the column taxonomy (Open/Draft/Merged/Closed) needs the
+// search qualifiers; list_pull_requests' bare state filter can't
+// express the splits. PerPage defaults to githubDefaultPerPage on 0.
+// Cursor pagination follows the same `after=<endCursor>` contract
+// the issue provider uses.
+func (p *githubPRProvider) ListIssues(ctx context.Context, cfg projectConfig, cwd string, query IssueQuery, page IssuePagination) (IssueListPage, error) {
+	if cfg.MCP.GitHub.Token == "" {
+		return IssueListPage{}, errIssueProviderNotConfigured
+	}
+	owner, repo, err := resolveGitHubRepo(cwd)
+	if err != nil {
+		return IssueListPage{}, fmt.Errorf("resolve repo: %w", err)
+	}
+	if page.PerPage <= 0 {
+		page.PerPage = githubDefaultPerPage
+	}
+	cs, err := p.connect(ctx, cfg.MCP.GitHub)
+	if err != nil {
+		return IssueListPage{}, err
+	}
+	cctx, cancel := context.WithTimeout(ctx, githubMCPCallTimeout)
+	defer cancel()
+
+	pq, _ := query.(*githubPRQuery)
+	args := githubBuildSearchPRsArgs(owner, repo, pq, page)
+
+	res, err := cs.CallTool(cctx, &mcp.CallToolParams{
+		Name:      githubToolSearchPullRequests,
+		Arguments: args,
+	})
+	if err != nil {
+		return IssueListPage{}, fmt.Errorf("%s: %w", githubToolSearchPullRequests, err)
+	}
+	if res.IsError {
+		return IssueListPage{}, fmt.Errorf("%s: %s", githubToolSearchPullRequests, flattenContent(res.Content))
+	}
+	prs, err := parseGitHubPRList(res)
+	if err != nil {
+		return IssueListPage{}, err
+	}
+	nextCursor, hasNext, foundEnvelope := parseGitHubPageInfo(res)
+	hasMore := hasNext
+	if !foundEnvelope {
+		hasMore = len(prs) == page.PerPage
+	}
+	return IssueListPage{
+		Issues:     prs,
+		NextCursor: nextCursor,
+		HasMore:    hasMore,
+	}, nil
+}
+
+// GetIssue hydrates a single PR with description and comments. Uses
+// pull_request_read with method=get for the body, then a best-effort
+// method=get_comments to attach the issue-thread comments. PR review
+// comments (file-line conversations) are intentionally out of scope
+// for this iteration — only the conversation tab.
+func (p *githubPRProvider) GetIssue(ctx context.Context, cfg projectConfig, cwd string, number int) (issue, error) {
+	if cfg.MCP.GitHub.Token == "" {
+		return issue{}, errIssueProviderNotConfigured
+	}
+	owner, repo, err := resolveGitHubRepo(cwd)
+	if err != nil {
+		return issue{}, fmt.Errorf("resolve repo: %w", err)
+	}
+	cs, err := p.connect(ctx, cfg.MCP.GitHub)
+	if err != nil {
+		return issue{}, err
+	}
+	cctx, cancel := context.WithTimeout(ctx, githubMCPCallTimeout)
+	defer cancel()
+	res, err := cs.CallTool(cctx, &mcp.CallToolParams{
+		Name: githubToolPullRequestRead,
+		Arguments: map[string]any{
+			"method":      "get",
+			"owner":       owner,
+			"repo":        repo,
+			"pullNumber":  number,
+			"pull_number": number,
+		},
+	})
+	if err != nil {
+		return issue{}, fmt.Errorf("pull_request_read get: %w", err)
+	}
+	if res.IsError {
+		return issue{}, fmt.Errorf("pull_request_read get: %s", flattenContent(res.Content))
+	}
+	it, err := parseGitHubPR(res)
+	if err != nil {
+		return issue{}, err
+	}
+	if comments, cerr := p.fetchPRComments(ctx, cs, owner, repo, number); cerr == nil {
+		it.comments = comments
+	} else {
+		debugLog("github pull_request_read get_comments err: %v", cerr)
+	}
+	return it, nil
+}
+
+// MoveIssue is a no-op for PRs — they don't drag between columns.
+// SupportsCarry() returns false so the kanban view's pickup keybind
+// short-circuits before this can be reached. We still return a
+// descriptive error so an accidental call surfaces clearly rather
+// than appearing to succeed.
+func (p *githubPRProvider) MoveIssue(context.Context, projectConfig, string, issue, KanbanColumnSpec) error {
+	return fmt.Errorf("PRs do not support column drag — use the merge action instead")
+}
+
+// KanbanIssueStatus returns empty: PRs don't carry, so the carry-and-drop
+// status patch path that consumes this is never invoked. Returning empty
+// matches the noneIssueProvider behaviour for consistency with the
+// "no carry semantics" answer.
+func (p *githubPRProvider) KanbanIssueStatus(KanbanColumnSpec) string { return "" }
+
+// IssueRef builds the canonical ref for a PR. We tag Provider as
+// "github-prs" so workflow-tracker keys can never collide with
+// regular issues that share a number.
+func (p *githubPRProvider) IssueRef(_ projectConfig, cwd string, it issue) (issueRef, error) {
+	owner, repo, err := resolveGitHubRepo(cwd)
+	if err != nil {
+		return issueRef{}, errIssueProviderNotConfigured
+	}
+	return issueRef{
+		Provider: p.ID(),
+		Project:  owner + "/" + repo,
+		Number:   it.number,
+	}, nil
+}
+
+// SupportsCarry returns false: PRs don't drag between Open and
+// Merged. The merge action is explicit (`m` keybind, confirmation
+// modal, then the merge_pull_request call) — never a column drag.
+func (p *githubPRProvider) SupportsCarry() bool { return false }
+
+// Mergeable is the IssueMerger pre-flight: re-fetches the PR via
+// pull_request_read so we operate on the latest mergeable_state
+// rather than a stale cached row, then translates the response into
+// a mergeableState the screen can render.
+//
+// State semantics (per GitHub's REST docs):
+//   - clean       — checks pass, merge can proceed
+//   - unstable    — mergeable but a status is non-passing; we still
+//     allow the user to merge if they confirm
+//   - has_hooks   — same as unstable but for legacy git hooks; allow
+//   - dirty       — merge conflict, user must resolve
+//   - blocked     — branch protection / required reviews not satisfied
+//   - behind      — base branch advanced, must update branch
+//   - draft       — PR is draft, cannot merge
+//   - unknown     — GitHub still computing, ask user to retry
+//
+// canMerge=true is returned for "clean", "unstable", "has_hooks";
+// every other state lands in the toast with a contextual reason.
+func (p *githubPRProvider) Mergeable(ctx context.Context, cfg projectConfig, cwd string, it issue) (mergeableState, error) {
+	if cfg.MCP.GitHub.Token == "" {
+		return mergeableState{}, errIssueProviderNotConfigured
+	}
+	owner, repo, err := resolveGitHubRepo(cwd)
+	if err != nil {
+		return mergeableState{}, fmt.Errorf("resolve repo: %w", err)
+	}
+	cs, err := p.connect(ctx, cfg.MCP.GitHub)
+	if err != nil {
+		return mergeableState{}, err
+	}
+	cctx, cancel := context.WithTimeout(ctx, githubMCPCallTimeout)
+	defer cancel()
+	res, err := cs.CallTool(cctx, &mcp.CallToolParams{
+		Name: githubToolPullRequestRead,
+		Arguments: map[string]any{
+			"method":      "get",
+			"owner":       owner,
+			"repo":        repo,
+			"pullNumber":  it.number,
+			"pull_number": it.number,
+		},
+	})
+	if err != nil {
+		return mergeableState{}, fmt.Errorf("pull_request_read get: %w", err)
+	}
+	if res.IsError {
+		return mergeableState{}, fmt.Errorf("pull_request_read get: %s", flattenContent(res.Content))
+	}
+	state, err := parseGitHubPRMergeable(res)
+	if err != nil {
+		return mergeableState{}, err
+	}
+	return state, nil
+}
+
+// Merge performs the actual merge via merge_pull_request. The merge
+// strategy is fixed today (githubPRMergeMethod = "merge") to keep the
+// surface tight; a per-project knob can land later. Errors from the
+// MCP server (conflicts that snuck in between Mergeable and Merge,
+// branch protection regressions, network issues) surface verbatim.
+func (p *githubPRProvider) Merge(ctx context.Context, cfg projectConfig, cwd string, it issue) error {
+	if cfg.MCP.GitHub.Token == "" {
+		return errIssueProviderNotConfigured
+	}
+	owner, repo, err := resolveGitHubRepo(cwd)
+	if err != nil {
+		return fmt.Errorf("resolve repo: %w", err)
+	}
+	cs, err := p.connect(ctx, cfg.MCP.GitHub)
+	if err != nil {
+		return err
+	}
+	cctx, cancel := context.WithTimeout(ctx, githubMCPCallTimeout)
+	defer cancel()
+	args := githubBuildMergePRArgs(owner, repo, it.number, githubPRMergeMethod)
+	res, err := cs.CallTool(cctx, &mcp.CallToolParams{
+		Name:      githubToolMergePullRequest,
+		Arguments: args,
+	})
+	if err != nil {
+		return fmt.Errorf("%s: %w", githubToolMergePullRequest, err)
+	}
+	if res.IsError {
+		return fmt.Errorf("%s: %s", githubToolMergePullRequest, flattenContent(res.Content))
+	}
+	return nil
+}
+
+func (p *githubPRProvider) fetchPRComments(ctx context.Context, cs *mcp.ClientSession, owner, repo string, number int) ([]issueComment, error) {
+	cctx, cancel := context.WithTimeout(ctx, githubMCPCallTimeout)
+	defer cancel()
+	res, err := cs.CallTool(cctx, &mcp.CallToolParams{
+		Name: githubToolPullRequestRead,
+		Arguments: map[string]any{
+			"method":      "get_comments",
+			"owner":       owner,
+			"repo":        repo,
+			"pullNumber":  number,
+			"pull_number": number,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if res.IsError {
+		return nil, fmt.Errorf("%s", flattenContent(res.Content))
+	}
+	return parseGitHubComments(res)
+}
+
+// connect mirrors githubIssueProvider.connect: cache (endpoint,
+// token), serialise on p.mu, swap the bearer auth into the
+// transport. We could share the underlying cache between the two
+// providers, but each having its own keeps the lifecycle reasoning
+// local — closing one provider's session can't break the other.
+func (p *githubPRProvider) connect(ctx context.Context, cfg githubMCPConfig) (*mcp.ClientSession, error) {
+	endpoint := githubMCPEndpointOrDefault(cfg)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.session != nil && p.cachedEndpoint == endpoint && p.cachedToken == cfg.Token {
+		return p.session, nil
+	}
+	if p.session != nil {
+		_ = p.session.Close()
+		p.session = nil
+	}
+	cs, err := dialGitHubMCP(ctx, endpoint, cfg.Token, githubMCPInitTimeout)
+	if err != nil {
+		return nil, err
+	}
+	p.session = cs
+	p.cachedEndpoint = endpoint
+	p.cachedToken = cfg.Token
+	return cs, nil
+}
+
+// githubPRQuery is the PR-specific filter shape. Carried through
+// the rest of the app as an opaque IssueQuery. Empty fields are
+// "no filter".
+//
+// `is` is multi-valued so a column query can carry both an open
+// and an explicit non-draft qualifier (notDraft) without losing
+// either. notDraft / notMerged are sugar for the negated `is:`
+// qualifiers — kept as bool fields so the formatter can render
+// the canonical syntax (`-is:draft`, `-is:merged`) without
+// re-parsing.
+type githubPRQuery struct {
+	is         []string // open|closed|merged|draft (multi)
+	notDraft   bool
+	notMerged  bool
+	sort       string
+	order      string
+	labels     []string
+	assignee   string
+	author     string
+	noAssignee bool
+	freeText   string
+}
+
+// githubBuildSearchPRsArgs is the pure args-builder for the
+// search_pull_requests MCP call. Pulled out so the column-spec
+// search-q matrix is covered by a unit test without spinning an
+// httptest MCP loop. Mirrors githubBuildListIssuesArgs.
+func githubBuildSearchPRsArgs(owner, repo string, pq *githubPRQuery, page IssuePagination) map[string]any {
+	args := map[string]any{
+		"query":   githubBuildSearchPRQ(owner, repo, pq),
+		"perPage": page.PerPage,
+	}
+	if page.Cursor != "" {
+		args["after"] = page.Cursor
+	}
+	return args
+}
+
+// githubBuildSearchPRQ assembles the GitHub search expression.
+// Always scoped to the project's repo and `type:pr` so we never
+// accidentally pull issues into the PR screen.
+func githubBuildSearchPRQ(owner, repo string, q *githubPRQuery) string {
+	parts := []string{
+		"repo:" + owner + "/" + repo,
+		"type:pr",
+	}
+	if q == nil {
+		return strings.Join(parts, " ")
+	}
+	for _, is := range q.is {
+		parts = append(parts, "is:"+is)
+	}
+	if q.notDraft {
+		parts = append(parts, "-is:draft")
+	}
+	if q.notMerged {
+		parts = append(parts, "-is:merged")
+	}
+	for _, l := range q.labels {
+		parts = append(parts, "label:"+quoteIfSpaces(l))
+	}
+	if q.assignee != "" {
+		parts = append(parts, "assignee:"+q.assignee)
+	}
+	if q.author != "" {
+		parts = append(parts, "author:"+q.author)
+	}
+	if q.noAssignee {
+		parts = append(parts, "no:assignee")
+	}
+	if q.sort != "" {
+		parts = append(parts, "sort:"+q.sort)
+	}
+	if q.order != "" {
+		parts = append(parts, "order:"+q.order)
+	}
+	if q.freeText != "" {
+		parts = append(parts, q.freeText)
+	}
+	return strings.Join(parts, " ")
+}
+
+// githubBuildMergePRArgs is the pure args-builder for the
+// merge_pull_request MCP call. The GitHub Copilot MCP server
+// accepts both `pullNumber` (camelCase) and `pull_number` (REST
+// snake_case); we send both so the call works against either
+// server build.
+func githubBuildMergePRArgs(owner, repo string, prNumber int, mergeMethod string) map[string]any {
+	args := map[string]any{
+		"owner":       owner,
+		"repo":        repo,
+		"pullNumber":  prNumber,
+		"pull_number": prNumber,
+	}
+	if mergeMethod != "" {
+		args["mergeMethod"] = mergeMethod
+		args["merge_method"] = mergeMethod
+	}
+	return args
+}
+
+// githubAPIPR is the trim of the GitHub REST PR payload we care
+// about. Mirrors githubAPIIssue but adds the merge-related fields
+// (draft, merged, mergeable, mergeable_state). User and assignee
+// shapes are reused from the issue side.
+type githubAPIPR struct {
+	Number         int                  `json:"number"`
+	Title          string               `json:"title"`
+	Body           string               `json:"body"`
+	State          string               `json:"state"`
+	Draft          bool                 `json:"draft"`
+	Merged         bool                 `json:"merged"`
+	MergedAt       *time.Time           `json:"merged_at"`
+	Mergeable      *bool                `json:"mergeable"`
+	MergeableState string               `json:"mergeable_state"`
+	CreatedAt      time.Time            `json:"created_at"`
+	User           *githubAPIUserField  `json:"user"`
+	Assignee       *githubAPIUserField  `json:"assignee"`
+	Assignees      []githubAPIUserField `json:"assignees"`
+}
+
+// parseGitHubPRList unmarshals the search_pull_requests response
+// into a slice of issue. Accepts the same envelope shapes the issue
+// list parser does — bare array, {"items": [...]}, {"pull_requests":
+// [...]} — falling through to the first array field probe so future
+// server tweaks degrade gracefully.
+func parseGitHubPRList(res *mcp.CallToolResult) ([]issue, error) {
+	raw := pickJSONPayload(res)
+	if raw == nil {
+		return nil, fmt.Errorf("search_pull_requests: empty payload")
+	}
+	arr, err := unmarshalPRArray(raw)
+	if err != nil {
+		return nil, fmt.Errorf("search_pull_requests: parse: %w", err)
+	}
+	out := make([]issue, 0, len(arr))
+	for _, pr := range arr {
+		out = append(out, githubAPIPRToIssue(pr))
+	}
+	return out, nil
+}
+
+// unmarshalPRArray accepts:
+//   - a bare JSON array of PRs
+//   - {"pull_requests":[...]}, {"pullRequests":[...]} — both
+//     spellings the GitHub Copilot MCP server has been observed to use
+//   - {"items":[...]} — the search_issues / search_pull_requests
+//     wrapper
+//   - any other object with exactly one array-of-PRs field
+func unmarshalPRArray(raw []byte) ([]githubAPIPR, error) {
+	var arr []githubAPIPR
+	if err := json.Unmarshal(raw, &arr); err == nil {
+		return arr, nil
+	}
+	var wrapper map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &wrapper); err != nil {
+		return nil, err
+	}
+	for _, key := range []string{"pull_requests", "pullRequests", "items", "prs"} {
+		field, ok := wrapper[key]
+		if !ok {
+			continue
+		}
+		var inner []githubAPIPR
+		if err := json.Unmarshal(field, &inner); err == nil {
+			return inner, nil
+		}
+	}
+	for _, field := range wrapper {
+		var inner []githubAPIPR
+		if err := json.Unmarshal(field, &inner); err == nil && len(inner) > 0 {
+			return inner, nil
+		}
+	}
+	return nil, nil
+}
+
+// parseGitHubPR unmarshals a single pull_request_read get result.
+func parseGitHubPR(res *mcp.CallToolResult) (issue, error) {
+	raw := pickJSONPayload(res)
+	if raw == nil {
+		return issue{}, fmt.Errorf("pull_request_read get: empty payload")
+	}
+	var pr githubAPIPR
+	if err := json.Unmarshal(raw, &pr); err != nil {
+		return issue{}, fmt.Errorf("pull_request_read get: parse: %w", err)
+	}
+	return githubAPIPRToIssue(pr), nil
+}
+
+// parseGitHubPRMergeable extracts the merge signal from a
+// pull_request_read get response and translates it into a
+// mergeableState the screen can act on. The translation is:
+//
+//   - clean / unstable / has_hooks → canMerge=true
+//   - dirty                        → canMerge=false, "merge conflict — resolve before merging"
+//   - blocked                      → canMerge=false, "blocked — required reviews/checks not met"
+//   - behind                       → canMerge=false, "branch is behind base — update before merging"
+//   - draft (or .Draft == true)    → canMerge=false, "draft — mark ready for review before merging"
+//   - unknown                      → canMerge=false, "GitHub is still computing — try again in a moment"
+//   - merged (already)             → canMerge=false, "already merged"
+//   - everything else              → canMerge=false, "<state> — refusing to merge"
+//
+// Falls back to .Mergeable when mergeable_state is absent so newer
+// server builds that drop the legacy field still produce a usable
+// signal.
+func parseGitHubPRMergeable(res *mcp.CallToolResult) (mergeableState, error) {
+	raw := pickJSONPayload(res)
+	if raw == nil {
+		return mergeableState{}, fmt.Errorf("pull_request_read get: empty payload")
+	}
+	var pr githubAPIPR
+	if err := json.Unmarshal(raw, &pr); err != nil {
+		return mergeableState{}, fmt.Errorf("pull_request_read get: parse: %w", err)
+	}
+	if pr.Merged {
+		return mergeableState{canMerge: false, reason: "already merged", state: "merged"}, nil
+	}
+	if pr.Draft {
+		return mergeableState{canMerge: false, reason: "draft PR — mark ready for review before merging", state: "draft"}, nil
+	}
+	state := strings.ToLower(strings.TrimSpace(pr.MergeableState))
+	switch state {
+	case "clean":
+		return mergeableState{canMerge: true, state: state}, nil
+	case "unstable":
+		return mergeableState{canMerge: true, reason: "checks failing but mergeable", state: state}, nil
+	case "has_hooks":
+		return mergeableState{canMerge: true, reason: "non-passing hooks but mergeable", state: state}, nil
+	case "dirty":
+		return mergeableState{canMerge: false, reason: "merge conflict — resolve before merging", state: state}, nil
+	case "blocked":
+		return mergeableState{canMerge: false, reason: "blocked — required reviews or checks not met", state: state}, nil
+	case "behind":
+		return mergeableState{canMerge: false, reason: "branch is behind base — update before merging", state: state}, nil
+	case "draft":
+		return mergeableState{canMerge: false, reason: "draft PR — mark ready for review before merging", state: state}, nil
+	case "unknown", "":
+		// Fall back to the legacy `mergeable` bool when state is
+		// missing/unknown — older servers don't always populate
+		// mergeable_state.
+		if pr.Mergeable != nil && *pr.Mergeable {
+			return mergeableState{canMerge: true, reason: "mergeable signal indeterminate", state: state}, nil
+		}
+		return mergeableState{canMerge: false, reason: "GitHub is still computing mergeability — try again shortly", state: state}, nil
+	}
+	return mergeableState{canMerge: false, reason: state + " — refusing to merge", state: state}, nil
+}
+
+// githubAPIPRToIssue maps the trimmed REST PR shape into the
+// app-internal issue. Status reflects the canonical kanban column
+// label for the PR's current state so the kanban renderer doesn't
+// need a PR-aware codepath:
+//
+//   - draft (open && draft=true)   → "draft"
+//   - open  (open && !draft)       → "open"
+//   - merged (closed && merged=t)  → "merged"
+//   - closed (closed && !merged)   → "closed"
+//
+// assignee follows the same precedence as issues (assignee field,
+// then assignees[0], then "unassigned").
+func githubAPIPRToIssue(pr githubAPIPR) issue {
+	assignee := "unassigned"
+	switch {
+	case pr.Assignee != nil && pr.Assignee.Login != "":
+		assignee = pr.Assignee.Login
+	case len(pr.Assignees) > 0 && pr.Assignees[0].Login != "":
+		assignee = pr.Assignees[0].Login
+	}
+	state := strings.ToLower(strings.TrimSpace(pr.State))
+	status := state
+	switch {
+	case pr.Merged:
+		status = "merged"
+	case state == "open" && pr.Draft:
+		status = "draft"
+	case state == "closed":
+		// Search results don't always carry the merged bool; treat
+		// any closed PR without a merged_at timestamp as closed-
+		// without-merge so the column count adds up sensibly.
+		if pr.MergedAt != nil {
+			status = "merged"
+		} else {
+			status = "closed"
+		}
+	}
+	if status == "" {
+		status = "open"
+	}
+	return issue{
+		number:      pr.Number,
+		title:       pr.Title,
+		assignee:    assignee,
+		status:      status,
+		createdAt:   pr.CreatedAt,
+		description: pr.Body,
+	}
+}

--- a/pr_provider_github_test.go
+++ b/pr_provider_github_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestGitHubPRProvider_KanbanColumns(t *testing.T) {
+	cols := (&githubPRProvider{}).KanbanColumns()
+	if len(cols) != 4 {
+		t.Fatalf("PR kanban should expose 4 canonical columns, got %d", len(cols))
+	}
+	cases := []struct {
+		idx        int
+		label      string
+		wantIs     []string
+		wantNotDft bool
+		wantNotMrg bool
+	}{
+		{0, "Open", []string{"open"}, true, false},
+		{1, "Draft", []string{"draft"}, false, false},
+		{2, "Merged", []string{"merged"}, false, false},
+		{3, "Closed", []string{"closed"}, false, true},
+	}
+	for _, tc := range cases {
+		got := cols[tc.idx]
+		if got.Label != tc.label {
+			t.Fatalf("column %d label=%q want %q", tc.idx, got.Label, tc.label)
+		}
+		q, ok := got.Query.(*githubPRQuery)
+		if !ok {
+			t.Fatalf("column %d query type=%T want *githubPRQuery", tc.idx, got.Query)
+		}
+		if len(q.is) != len(tc.wantIs) || q.is[0] != tc.wantIs[0] {
+			t.Fatalf("column %d is=%v want %v", tc.idx, q.is, tc.wantIs)
+		}
+		if q.notDraft != tc.wantNotDft || q.notMerged != tc.wantNotMrg {
+			t.Fatalf("column %d flags=(notDraft=%v notMerged=%v) want (%v %v)", tc.idx, q.notDraft, q.notMerged, tc.wantNotDft, tc.wantNotMrg)
+		}
+	}
+}
+
+func TestGitHubBuildSearchPRQ(t *testing.T) {
+	got := githubBuildSearchPRQ("Cidan", "ask", &githubPRQuery{
+		is:         []string{"open"},
+		notDraft:   true,
+		labels:     []string{"needs review"},
+		assignee:   "antonio",
+		author:     "octocat",
+		noAssignee: true,
+		sort:       "updated",
+		order:      "desc",
+		freeText:   "login bug",
+	})
+	want := `repo:Cidan/ask type:pr is:open -is:draft label:"needs review" assignee:antonio author:octocat no:assignee sort:updated order:desc login bug`
+	if got != want {
+		t.Fatalf("search query mismatch:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestParseGitHubPRMergeable(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		canMerge  bool
+		wantState string
+		wantText  string
+	}{
+		{"clean", `{"number": 1, "state": "open", "mergeable_state": "clean"}`, true, "clean", ""},
+		{"dirty", `{"number": 1, "state": "open", "mergeable_state": "dirty"}`, false, "dirty", "merge conflict"},
+		{"draft", `{"number": 1, "state": "open", "draft": true}`, false, "draft", "draft PR"},
+		{"unknown-mergeable-bool", `{"number": 1, "state": "open", "mergeable": true}`, true, "", "indeterminate"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: tc.body}},
+			}
+			got, err := parseGitHubPRMergeable(res)
+			if err != nil {
+				t.Fatalf("parse err: %v", err)
+			}
+			if got.canMerge != tc.canMerge {
+				t.Fatalf("canMerge=%v want %v", got.canMerge, tc.canMerge)
+			}
+			if got.state != tc.wantState {
+				t.Fatalf("state=%q want %q", got.state, tc.wantState)
+			}
+			if tc.wantText != "" && !containsInsensitive(got.reason, tc.wantText) {
+				t.Fatalf("reason=%q want substring %q", got.reason, tc.wantText)
+			}
+		})
+	}
+}
+
+func TestGitHubBuildMergePRArgs(t *testing.T) {
+	args := githubBuildMergePRArgs("Cidan", "ask", 42, "squash")
+	if args["owner"] != "Cidan" || args["repo"] != "ask" {
+		t.Fatalf("owner/repo mismatch: %+v", args)
+	}
+	if args["pullNumber"] != 42 || args["pull_number"] != 42 {
+		t.Fatalf("PR number aliases missing: %+v", args)
+	}
+	if args["mergeMethod"] != "squash" || args["merge_method"] != "squash" {
+		t.Fatalf("merge method aliases missing: %+v", args)
+	}
+}
+
+func TestGitHubAPIPRToIssue_StatusAndAssigneeMapping(t *testing.T) {
+	cases := []struct {
+		name         string
+		pr           githubAPIPR
+		wantStatus   string
+		wantAssignee string
+	}{
+		{
+			name: "draft stays draft",
+			pr: githubAPIPR{
+				Number: 1,
+				Title:  "draft",
+				State:  "open",
+				Draft:  true,
+				User:   &githubAPIUserField{Login: "author"},
+			},
+			wantStatus:   "draft",
+			wantAssignee: "unassigned",
+		},
+		{
+			name: "merged beats closed",
+			pr: githubAPIPR{
+				Number:   2,
+				Title:    "merged",
+				State:    "closed",
+				Merged:   true,
+				Assignee: &githubAPIUserField{Login: "antonio"},
+			},
+			wantStatus:   "merged",
+			wantAssignee: "antonio",
+		},
+		{
+			name: "closed without merge stays closed",
+			pr: githubAPIPR{
+				Number: 3,
+				Title:  "closed",
+				State:  "closed",
+			},
+			wantStatus:   "closed",
+			wantAssignee: "unassigned",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := githubAPIPRToIssue(tc.pr)
+			if got.status != tc.wantStatus {
+				t.Fatalf("status=%q want %q", got.status, tc.wantStatus)
+			}
+			if got.assignee != tc.wantAssignee {
+				t.Fatalf("assignee=%q want %q", got.assignee, tc.wantAssignee)
+			}
+		})
+	}
+}
+
+func containsInsensitive(s, sub string) bool {
+	return strings.Contains(strings.ToLower(s), strings.ToLower(sub))
+}

--- a/prs_test.go
+++ b/prs_test.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func enterPRsScreen(t *testing.T, prov *fakeMergerIssueProvider, loaded issue) model {
+	t.Helper()
+	if len(prov.columns) == 0 {
+		prov.columns = []KanbanColumnSpec{{Label: "Open", Query: &fakeQuery{statusMatch: "open"}}}
+	}
+	m := newTestModel(t, newFakeProvider())
+	m.width = 100
+	m.height = 30
+	m.toast = NewToastModel(40, time.Second)
+	m.screen = screenPRs
+	m.prs = newPRsState()
+	m.prs.tabID = m.id
+	m.prs.cwd = m.cwd
+	m.prs.projectCfg = projectConfig{}
+	m.prs.provider = prov
+	kv := newKanbanIssueView(m.prs)
+	kv.columns = []kanbanColumn{{
+		spec:   prov.columns[0],
+		loaded: []issue{loaded},
+	}}
+	m.prs.view = kv
+	_ = m.activeScreen().view(m)
+	return m
+}
+
+func findIssueDetailLoadedMsg(t *testing.T, msgs []tea.Msg) issueDetailLoadedMsg {
+	t.Helper()
+	for _, msg := range msgs {
+		if got, ok := msg.(issueDetailLoadedMsg); ok {
+			return got
+		}
+	}
+	t.Fatalf("issueDetailLoadedMsg not found in %#v", msgs)
+	return issueDetailLoadedMsg{}
+}
+
+func findIssueMergeCheckDoneMsg(t *testing.T, msgs []tea.Msg) issueMergeCheckDoneMsg {
+	t.Helper()
+	for _, msg := range msgs {
+		if got, ok := msg.(issueMergeCheckDoneMsg); ok {
+			return got
+		}
+	}
+	t.Fatalf("issueMergeCheckDoneMsg not found in %#v", msgs)
+	return issueMergeCheckDoneMsg{}
+}
+
+func findIssueMergeDoneMsg(t *testing.T, msgs []tea.Msg) issueMergeDoneMsg {
+	t.Helper()
+	for _, msg := range msgs {
+		if got, ok := msg.(issueMergeDoneMsg); ok {
+			return got
+		}
+	}
+	t.Fatalf("issueMergeDoneMsg not found in %#v", msgs)
+	return issueMergeDoneMsg{}
+}
+
+func TestPRs_SpaceDoesNotStartCarry(t *testing.T) {
+	prov := newFakeMergerIssueProvider()
+	m := enterPRsScreen(t, prov, issue{number: 7, title: "Fix auth", status: "open"})
+
+	m, _ = runUpdate(t, m, tea.KeyPressMsg{Code: ' '})
+
+	kv, ok := m.prs.view.(*kanbanIssueView)
+	if !ok {
+		t.Fatalf("expected kanban view, got %T", m.prs.view)
+	}
+	if kv.carry.active {
+		t.Fatalf("space should not activate carry on PRs")
+	}
+}
+
+func TestPRs_EnterHydratesDetailFromProvider(t *testing.T) {
+	prov := newFakeMergerIssueProvider()
+	prov.getIssueFn = func(_ context.Context, _ projectConfig, _ string, number int) (issue, error) {
+		return issue{
+			number:      number,
+			title:       "Fix auth",
+			status:      "open",
+			description: "# Full body\n\nNeeds comments.",
+			comments: []issueComment{{
+				author:    "octocat",
+				createdAt: time.Unix(1700000000, 0).UTC(),
+				body:      "Looks good.",
+			}},
+		}, nil
+	}
+	m := enterPRsScreen(t, prov, issue{number: 17, title: "Fix auth", status: "open"})
+
+	m, cmd := runUpdate(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if got := m.prs.view.name(); got != "detail" {
+		t.Fatalf("Enter should open detail, got %q", got)
+	}
+	dv, ok := m.prs.view.(*issueDetailView)
+	if !ok {
+		t.Fatalf("expected issueDetailView, got %T", m.prs.view)
+	}
+	if !dv.hydrating {
+		t.Fatalf("detail view should mark itself hydrating while GetIssue is in flight")
+	}
+	msg := findIssueDetailLoadedMsg(t, drainBatch(t, cmd))
+	if msg.number != 17 {
+		t.Fatalf("hydration msg number=%d want 17", msg.number)
+	}
+
+	m, _ = runUpdate(t, m, msg)
+	dv = m.prs.view.(*issueDetailView)
+	if dv.hydrating {
+		t.Fatalf("detail hydration flag should clear after the provider response lands")
+	}
+	if !strings.Contains(dv.issue.description, "Full body") {
+		t.Fatalf("detail description was not replaced with the hydrated body: %q", dv.issue.description)
+	}
+	if len(dv.issue.comments) != 1 || dv.issue.comments[0].author != "octocat" {
+		t.Fatalf("detail comments were not hydrated: %+v", dv.issue.comments)
+	}
+	parent, ok := dv.parent.(*kanbanIssueView)
+	if !ok {
+		t.Fatalf("detail parent should remain the kanban view, got %T", dv.parent)
+	}
+	if len(parent.columns[0].loaded) != 1 || len(parent.columns[0].loaded[0].comments) != 1 {
+		t.Fatalf("hydrated issue should also replace the cached kanban snapshot: %+v", parent.columns[0].loaded)
+	}
+}
+
+func TestPRs_MergeKeyRunsPreflightAndOpensConfirm(t *testing.T) {
+	prov := newFakeMergerIssueProvider()
+	m := enterPRsScreen(t, prov, issue{number: 31, title: "Merge me", status: "open"})
+
+	m, cmd := runUpdate(t, m, tea.KeyPressMsg{Code: 'm'})
+	if !m.prs.loading {
+		t.Fatalf("merge preflight should raise the loader")
+	}
+	if !strings.Contains(m.prs.loadingMessage, "Checking whether PR #31 can be merged") {
+		t.Fatalf("unexpected merge preflight message: %q", m.prs.loadingMessage)
+	}
+	msg := findIssueMergeCheckDoneMsg(t, drainBatch(t, cmd))
+	if len(prov.mergeableCalls) != 1 || prov.mergeableCalls[0].number != 31 {
+		t.Fatalf("merge preflight did not call provider with the focused PR: %+v", prov.mergeableCalls)
+	}
+
+	m, _ = runUpdate(t, m, msg)
+	if !m.mergePRConfirming {
+		t.Fatalf("successful preflight should open the merge confirmation modal")
+	}
+	if m.mergePRChoice != 0 {
+		t.Fatalf("confirmation should default to No, got choice=%d", m.mergePRChoice)
+	}
+	if m.mergePRItem.number != 31 {
+		t.Fatalf("confirmation should target PR #31, got %+v", m.mergePRItem)
+	}
+}
+
+func TestPRs_MergeRefusalShowsToastWithoutOpeningConfirm(t *testing.T) {
+	prov := newFakeMergerIssueProvider()
+	m := enterPRsScreen(t, prov, issue{number: 31, title: "Blocked", status: "open"})
+	m.prs.loading = true
+
+	m, cmd := runUpdate(t, m, issueMergeCheckDoneMsg{
+		tabID:  m.id,
+		screen: screenPRs,
+		item:   issue{number: 31, title: "Blocked"},
+		state:  mergeableState{canMerge: false, reason: "blocked — required reviews or checks not met", state: "blocked"},
+	})
+	if m.mergePRConfirming {
+		t.Fatalf("refused merge should not open a confirmation modal")
+	}
+	if m.prs.loading {
+		t.Fatalf("refused merge should clear the loader")
+	}
+	if cmd == nil {
+		t.Fatalf("refused merge should surface a toast")
+	}
+}
+
+func TestPRs_MergeConfirmYesDispatchesMergeAndReload(t *testing.T) {
+	prov := newFakeMergerIssueProvider()
+	m := enterPRsScreen(t, prov, issue{number: 44, title: "Ship it", status: "open"})
+	m.mergePRConfirming = true
+	m.mergePRChoice = 1
+	m.mergePRItem = issue{number: 44, title: "Ship it", status: "open"}
+
+	m, cmd := runUpdate(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.mergePRConfirming {
+		t.Fatalf("Enter on Yes should dismiss the confirmation modal")
+	}
+	if !m.prs.loading {
+		t.Fatalf("confirmed merge should raise the loader")
+	}
+	msg := findIssueMergeDoneMsg(t, drainBatch(t, cmd))
+	if len(prov.mergeCalls) != 1 || prov.mergeCalls[0].number != 44 {
+		t.Fatalf("merge call mismatch: %+v", prov.mergeCalls)
+	}
+
+	m, reloadCmd := runUpdate(t, m, msg)
+	if got := m.prs.view.name(); got != "kanban" {
+		t.Fatalf("successful merge should reset the PR screen to kanban before reloading, got %q", got)
+	}
+	if !m.prs.loading {
+		t.Fatalf("successful merge should kick off a reload")
+	}
+	if reloadCmd == nil {
+		t.Fatalf("successful merge should dispatch reload work")
+	}
+}

--- a/screens.go
+++ b/screens.go
@@ -14,7 +14,22 @@ const (
 	screenAsk screenID = iota
 	screenIssues
 	screenWorkflows
+	// screenPRs is the GitHub Pull Requests kanban surface. It reuses
+	// the entire issues kanban machinery (kanbanIssueView,
+	// issueDetailView, page cache, scrollbar, mouse, search) but
+	// installs a different IssueProvider (githubPRProvider) on its
+	// per-tab state and adds an `m` keybind for the merge action.
+	screenPRs
 )
+
+func isIssueScreen(id screenID) bool {
+	switch id {
+	case screenIssues, screenPRs:
+		return true
+	default:
+		return false
+	}
+}
 
 // screen is the per-tab top-level UI handler. Implementations are
 // stateless dispatchers — screen-specific state lives on model in
@@ -51,6 +66,7 @@ func newScreenRegistry() map[screenID]screen {
 		screenAsk:       askScreen{},
 		screenIssues:    issuesScreen{},
 		screenWorkflows: workflowsScreen{},
+		screenPRs:       prsScreen{},
 	}
 }
 
@@ -59,6 +75,49 @@ func (m model) activeScreen() screen {
 		return s
 	}
 	return askScreen{}
+}
+
+func (m model) issueStateForScreen(screen screenID) *issuesState {
+	switch screen {
+	case screenIssues:
+		return m.issues
+	case screenPRs:
+		return m.prs
+	default:
+		return nil
+	}
+}
+
+func (m *model) ensureIssueState(screen screenID) *issuesState {
+	switch screen {
+	case screenIssues:
+		if m.issues == nil {
+			m.issues = newIssuesState()
+		}
+		return m.issues
+	case screenPRs:
+		if m.prs == nil {
+			m.prs = newPRsState()
+		}
+		return m.prs
+	default:
+		return nil
+	}
+}
+
+func (m model) activeIssueState() *issuesState {
+	return m.issueStateForScreen(m.screen)
+}
+
+func (m *model) discardIssueScreenState(screen screenID) {
+	s := m.issueStateForScreen(screen)
+	if s == nil {
+		return
+	}
+	if kv, ok := s.view.(*kanbanIssueView); ok {
+		kv.cancelCarry(s)
+	}
+	s.discardOnLeave()
 }
 
 // modalOpen reports whether a modal/picker is currently blocking
@@ -74,7 +133,7 @@ func (m model) modalOpen() bool {
 	if m.mode != modeInput {
 		return true
 	}
-	if m.cancelTurnConfirming || m.closeTabConfirming {
+	if m.cancelTurnConfirming || m.closeTabConfirming || m.mergePRConfirming {
 		return true
 	}
 	return false
@@ -99,6 +158,9 @@ func (m model) switchScreen(target screenID) model {
 	// state (cursor position, future filters) persists across flips.
 	if target == screenIssues && m.issues == nil {
 		m.issues = newIssuesState()
+	}
+	if target == screenPRs && m.prs == nil {
+		m.prs = newPRsState()
 	}
 	// Clear the chat-view text selection on the way out of ask — the
 	// selection's anchor coordinates are tied to the chat viewport,

--- a/screens_test.go
+++ b/screens_test.go
@@ -46,6 +46,49 @@ func TestScreens_CtrlIBlockedWhenUnconfigured(t *testing.T) {
 	}
 }
 
+func TestScreens_CtrlPBlockedWhenUnconfigured(t *testing.T) {
+	prev := githubPRScreenProvider
+	prov := newFakeIssueProvider()
+	prov.configured = false
+	githubPRScreenProvider = prov
+	t.Cleanup(func() { githubPRScreenProvider = prev })
+
+	m := newTestModel(t, newFakeProvider())
+	m.toast = NewToastModel(40, time.Second)
+	m2, cmd := runUpdate(t, m, ctrlKey('p'))
+	if m2.screen != screenAsk {
+		t.Errorf("Ctrl+P unconfigured should leave us on ask, got %v", m2.screen)
+	}
+	if cmd == nil {
+		t.Errorf("Ctrl+P unconfigured should produce a toast command")
+	}
+}
+
+func TestScreens_CtrlPConfiguredEntersPRScreen(t *testing.T) {
+	prev := githubPRScreenProvider
+	prov := newFakeIssueProvider()
+	prov.configured = true
+	prov.columns = []KanbanColumnSpec{{Label: "Open", Query: &fakeQuery{statusMatch: "open"}}}
+	githubPRScreenProvider = prov
+	t.Cleanup(func() { githubPRScreenProvider = prev })
+
+	m := newTestModel(t, newFakeProvider())
+	m.toast = NewToastModel(40, time.Second)
+	m2, cmd := runUpdate(t, m, ctrlKey('p'))
+	if m2.screen != screenPRs {
+		t.Fatalf("Ctrl+P should switch to PR screen, got %v", m2.screen)
+	}
+	if m2.prs == nil {
+		t.Fatalf("Ctrl+P should seed PR state")
+	}
+	if m2.prs.provider != prov {
+		t.Fatalf("PR state provider mismatch: got %T want fake provider", m2.prs.provider)
+	}
+	if cmd == nil {
+		t.Fatalf("Ctrl+P should dispatch initial screen work")
+	}
+}
+
 func TestScreens_CtrlOFlipsBackToAsk(t *testing.T) {
 	m := newTestModel(t, newFakeProvider())
 	m = onIssuesDirect(m)
@@ -67,6 +110,7 @@ func TestScreens_BlockedWhileModalOpen(t *testing.T) {
 		{"provider switch", func(m *model) { m.mode = modeProviderSwitch }},
 		{"cancel-turn confirm", func(m *model) { m.cancelTurnConfirming = true }},
 		{"close-tab confirm", func(m *model) { m.closeTabConfirming = true }},
+		{"merge-pr confirm", func(m *model) { m.mergePRConfirming = true }},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -144,7 +188,7 @@ func TestScreens_ViewBodyDispatchesToActiveScreen(t *testing.T) {
 }
 
 func TestScreens_RegistryRoundTrip(t *testing.T) {
-	for _, id := range []screenID{screenAsk, screenIssues} {
+	for _, id := range []screenID{screenAsk, screenIssues, screenPRs} {
 		m := newTestModel(t, newFakeProvider())
 		m.screen = id
 		got := m.activeScreen().id()

--- a/types.go
+++ b/types.go
@@ -372,6 +372,34 @@ type model struct {
 	// render correctly.
 	issues *issuesState
 
+	// prs holds the per-tab state for the PR screen. Same shape as
+	// `issues` (issuesState is provider-agnostic — the kanban view
+	// only consults the IssueProvider interface) but installs
+	// githubPRProvider, draws against m.prs in the screen handler,
+	// and gates the `m` merge keybind on the IssueMerger capability
+	// interface. Splitting the state field means flipping between
+	// Ctrl+I and Ctrl+P preserves each screen's filter / cursor /
+	// page cache independently.
+	prs *issuesState
+
+	// mergePRConfirming gates the merge confirmation modal on the
+	// PR screen. Same mode-gated pattern as cancelTurnConfirming:
+	// modalOpen() returns true while it's set; the screen handler
+	// only opens the modal after a successful Mergeable() pre-flight
+	// reports canMerge=true.
+	mergePRConfirming bool
+	// mergePRChoice is the selection cursor in the modal. 0=No
+	// (default — merge is destructive), 1=Yes.
+	mergePRChoice int
+	// mergePRItem snapshots the PR being merged at confirm time so
+	// the dispatched Merge() call doesn't re-read a possibly-mutated
+	// row from the cache. Cleared once the action resolves.
+	mergePRItem issue
+	// mergePRReason carries the optional pre-flight warning shown
+	// in the confirm modal subtitle (e.g. "checks failing but
+	// mergeable" for unstable). Empty when the state is clean.
+	mergePRReason string
+
 	pathMatches []string
 	pathIdx     int
 
@@ -634,7 +662,7 @@ type workflowRunState struct {
 
 	// failed flips true if any step errors out. The banner shows the
 	// error and the chain aborts at this step.
-	failed bool
+	failed       bool
 	failedReason string
 }
 

--- a/update.go
+++ b/update.go
@@ -62,26 +62,27 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 		if msg.tabID != m.id {
 			return m, nil
 		}
-		if m.issues == nil || !m.issues.loading {
+		s := m.issueStateForScreen(msg.screen)
+		if s == nil || !s.loading {
 			return m, nil
 		}
-		m.issues.loadingFrame++
-		return m, issueLoadingTickCmd(m.id)
+		s.loadingFrame++
+		return m, issueLoadingTickCmd(m.id, msg.screen)
 
 	case issuePageLoadedMsg:
 		if msg.tabID != m.id {
 			return m, nil
 		}
-		if m.issues == nil {
-			m.issues = newIssuesState()
+		s := m.issueStateForScreen(msg.screen)
+		if s == nil {
+			return m, nil
 		}
 		// Stale-gen drop: the user changed the query while this fetch
 		// was in flight. Silently discard so the new query's data
 		// can't be polluted by the old one.
-		if msg.gen != m.issues.queryGen {
+		if msg.gen != s.queryGen {
 			return m, nil
 		}
-		s := m.issues
 		// requestedCursor=="" is the first-chunk sentinel; reading
 		// it (not msg.page) means error paths still clear loading.
 		isFirstChunk := msg.requestedCursor == ""
@@ -136,16 +137,19 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 		return m, nil
 
 	case issueMoveDoneMsg:
-		if msg.tabID != m.id || m.issues == nil {
+		if msg.tabID != m.id {
 			return m, nil
 		}
 		if msg.err == nil {
 			return m, nil
 		}
-		s := m.issues
+		s := m.issueStateForScreen(msg.screen)
+		if s == nil {
+			return m, nil
+		}
 		kv, ok := s.view.(*kanbanIssueView)
 		if !ok {
-			return m, m.toast.show("issues: move failed: " + msg.err.Error())
+			return m, m.toast.show(s.titleLower() + ": move failed: " + msg.err.Error())
 		}
 		// Defensive rollback: locate the issue by number rather than
 		// blindly indexing the target column. A reload between drop
@@ -186,7 +190,73 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 			}
 		}
 		kv.clampSelection()
-		return m, m.toast.show("issues: move failed: " + msg.err.Error())
+		return m, m.toast.show(s.titleLower() + ": move failed: " + msg.err.Error())
+
+	case issueDetailLoadedMsg:
+		if msg.tabID != m.id {
+			return m, nil
+		}
+		s := m.issueStateForScreen(msg.screen)
+		if s == nil {
+			return m, nil
+		}
+		s.finishIssueHydration(msg.number)
+		if msg.err != nil {
+			if dv, ok := s.view.(*issueDetailView); ok && dv.issue.number == msg.number {
+				return m, m.toast.show("could not load " + s.titleLower() + " details: " + msg.err.Error())
+			}
+			return m, nil
+		}
+		s.replaceIssueSnapshots(msg.item)
+		return m, nil
+
+	case issueMergeCheckDoneMsg:
+		if msg.tabID != m.id {
+			return m, nil
+		}
+		s := m.issueStateForScreen(msg.screen)
+		if s == nil || !s.loading {
+			return m, nil
+		}
+		s.loading = false
+		if msg.err != nil {
+			return m, m.toast.show("merge check failed: " + msg.err.Error())
+		}
+		if !msg.state.canMerge {
+			reason := msg.state.reason
+			if reason == "" {
+				reason = "merge refused"
+			}
+			return m, m.toast.show(reason)
+		}
+		m.mergePRConfirming = true
+		m.mergePRChoice = 0
+		m.mergePRItem = msg.item
+		m.mergePRReason = msg.state.reason
+		return m, nil
+
+	case issueMergeDoneMsg:
+		if msg.tabID != m.id {
+			return m, nil
+		}
+		s := m.issueStateForScreen(msg.screen)
+		if s == nil || !s.loading {
+			return m, nil
+		}
+		s.loading = false
+		if msg.err != nil {
+			return m, m.toast.show("merge failed: " + msg.err.Error())
+		}
+		s.view = issueViewLayers[0].builder(s)
+		reload := s.reloadCurrentQuery()
+		toast := m.toast.show(fmt.Sprintf("%s #%d merged", s.mergeLabel(), msg.item.number))
+		if reload != nil && toast != nil {
+			return m, tea.Batch(reload, toast)
+		}
+		if reload != nil {
+			return m, reload
+		}
+		return m, toast
 
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
@@ -199,7 +269,11 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 		// wrappedFor != width inside ensureEntryWrapped, which also
 		// owns rebuilding m.renderer at the new width.
 		m.lastContentFP = ""
-		if m.screen == screenIssues && m.issues != nil {
+		if isIssueScreen(m.screen) {
+			s := m.activeIssueState()
+			if s == nil {
+				return m, nil
+			}
 			width := msg.Width
 			height := msg.Height
 			if width <= 0 {
@@ -209,10 +283,10 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 				height = 24
 			}
 			contentW := max(20, width-issueScreenIndent-1)
-			contentH := max(4, height-issueScreenChromeHeight(m.issues))
-			m.issues.view.resize(contentW, contentH)
-			if kv, ok := m.issues.view.(*kanbanIssueView); ok {
-				return m, kv.maybeFetchToFillViewport(m.issues)
+			contentH := max(4, height-issueScreenChromeHeight(s))
+			s.view.resize(contentW, contentH)
+			if kv, ok := s.view.(*kanbanIssueView); ok {
+				return m, kv.maybeFetchToFillViewport(s)
 			}
 		}
 		return m, nil
@@ -798,7 +872,7 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 			m.chat, cmd = m.chat.Update(msg)
 			m.lastContentFP = ""
 			return m, cmd
-		case screenIssues:
+		case screenIssues, screenPRs:
 			return m.issuesHandleMouse(msg)
 		}
 		return m, nil
@@ -807,7 +881,7 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 		if m.mode != modeInput {
 			return m, nil
 		}
-		if m.screen == screenIssues {
+		if isIssueScreen(m.screen) {
 			return m.issuesHandleMouse(msg)
 		}
 		if m.screen != screenAsk {
@@ -840,7 +914,7 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 		return m, nil
 
 	case tea.MouseMotionMsg:
-		if m.screen == screenIssues {
+		if isIssueScreen(m.screen) {
 			return m.issuesHandleMouse(msg)
 		}
 		if m.scrollbarDragging {
@@ -857,7 +931,7 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 		return m, nil
 
 	case tea.MouseReleaseMsg:
-		if m.screen == screenIssues {
+		if isIssueScreen(m.screen) {
 			return m.issuesHandleMouse(msg)
 		}
 		if m.scrollbarDragging {
@@ -901,7 +975,7 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 		// Inline confirms overlay the input area and intercept typed
 		// keys so they don't bleed into the textarea — paste must
 		// follow the same rule or it becomes a side-channel write.
-		if m.cancelTurnConfirming || m.closeTabConfirming {
+		if m.cancelTurnConfirming || m.closeTabConfirming || m.mergePRConfirming {
 			return m, nil
 		}
 		// No !m.busy gate: typed keys, image pastes, and shell-mode
@@ -999,7 +1073,11 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 		if m.workflowRun != nil {
 			return m.workflowTabHandleKey(msg)
 		}
-		// Screen-switching keys (Ctrl+I → issues, Ctrl+O → ask) are
+		if m.mergePRConfirming {
+			return m.updateMergePRConfirm(msg)
+		}
+		// Screen-switching keys (Ctrl+I → issues, Ctrl+P → PRs,
+		// Ctrl+O → ask) are
 		// global within a tab but blocked while a modal/confirm overlay
 		// is up. They must run before the active screen's updateKey so a
 		// screen handler can't shadow them by accident. Background work
@@ -1015,15 +1093,15 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 		// surprising a user mid-read.
 		if msg.Mod == tea.ModCtrl && msg.Code == 'i' && !m.modalOpen() {
 			if m.screen == screenIssues {
-				if m.issues != nil {
-					m.issues.cycleView()
+				if s := m.issueStateForScreen(screenIssues); s != nil {
+					s.cycleView()
 					// Landing on kanban kicks off N parallel column
 					// loads if columns are empty. The same call is a
 					// no-op when columns are already loaded (returning
 					// to kanban after a previous fetch shows the
 					// cached data immediately).
-					if kv, ok := m.issues.view.(*kanbanIssueView); ok {
-						return m, kv.initialLoad(m.issues)
+					if kv, ok := s.view.(*kanbanIssueView); ok {
+						return m, kv.initialLoad(s)
 					}
 				}
 				return m, nil
@@ -1040,69 +1118,33 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 				return m, m.toast.show(
 					"Issues not configured for this project: " + shortCwdOf(projectKey(m.cwd)))
 			}
-			m = m.switchScreen(screenIssues)
-			// Flip the loading flag and pick a fun message before
-			// dispatching the provider call. The screen renders a
-			// centered animated modal whenever loading is true, so
-			// the user sees activity instead of a blank kanban
-			// during the network round-trip. Any prior loadErr is
-			// cleared so the new attempt starts fresh.
-			if m.issues == nil {
-				m.issues = newIssuesState()
-			}
-			// Install the resolved provider so query fingerprinting
-			// and kanban column lookups operate against the right
-			// backend. Resetting the active sub-view rebuilds it
-			// against the freshly-installed provider (which the
-			// kanban view needs to construct columns).
-			m.issues.provider = provider
-			m.issues.projectCfg = pc
-			m.issues.cwd = m.cwd
-			m.issues.tabID = m.id
-			m.issues.view = issueViewLayers[0].builder(m.issues)
-			kv, _ := m.issues.view.(*kanbanIssueView)
-			// Show the loader modal on first entry — when no kanban
-			// column has data yet. Re-entry after a previous load
-			// (cache hit) skips the modal so the user sees content
-			// immediately.
-			anyLoaded := false
-			if kv != nil {
-				for _, c := range kv.columns {
-					if len(c.loaded) > 0 {
-						anyLoaded = true
-						break
+			return m.enterIssueScreen(screenIssues, provider, pc)
+		}
+		if msg.Mod == tea.ModCtrl && msg.Code == 'p' && !m.modalOpen() {
+			if m.screen == screenPRs {
+				if s := m.issueStateForScreen(screenPRs); s != nil {
+					s.cycleView()
+					if kv, ok := s.view.(*kanbanIssueView); ok {
+						return m, kv.initialLoad(s)
 					}
 				}
-			}
-			cmds := []tea.Cmd{}
-			if !anyLoaded {
-				m.issues.loading = true
-				m.issues.loadingMessage = pickLoadingMessage()
-				m.issues.loadingFrame = 0
-				m.issues.loadErr = nil
-				cmds = append(cmds, issueLoadingTickCmd(m.id))
-			}
-			_ = m.issues.beginLoad()
-			if kv != nil {
-				if c := kv.initialLoad(m.issues); c != nil {
-					cmds = append(cmds, c)
-				}
-			}
-			if len(cmds) == 0 {
 				return m, nil
 			}
-			return m, tea.Batch(cmds...)
+			cfg, _ := loadConfig()
+			provider, pc := activePRProvider(cfg, m.cwd)
+			if !provider.Configured(pc, m.cwd) {
+				return m, m.toast.show(
+					"Pull requests not configured for this project: " + shortCwdOf(projectKey(m.cwd)))
+			}
+			return m.enterIssueScreen(screenPRs, provider, pc)
 		}
 		if msg.Mod == tea.ModCtrl && msg.Code == 'w' && !m.modalOpen() {
 			// Ctrl+W opens the workflows builder. Going to the
 			// builder from the issues screen mirrors Ctrl+I's
 			// "drop the cache + cancel in-flight" hygiene so a
 			// later return to issues re-fetches cleanly.
-			if m.screen == screenIssues && m.issues != nil {
-				if kv, ok := m.issues.view.(*kanbanIssueView); ok {
-					kv.cancelCarry(m.issues)
-				}
-				m.issues.discardOnLeave()
+			if isIssueScreen(m.screen) {
+				m.discardIssueScreenState(m.screen)
 			}
 			m = m.switchScreen(screenWorkflows)
 			if m.workflowsBuilder == nil {
@@ -1118,11 +1160,8 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 			// state lives on the kanban view, so we re-insert the
 			// in-flight card before discardOnLeave wipes the cache —
 			// otherwise the row would silently disappear next entry.
-			if m.screen == screenIssues && m.issues != nil {
-				if kv, ok := m.issues.view.(*kanbanIssueView); ok {
-					kv.cancelCarry(m.issues)
-				}
-				m.issues.discardOnLeave()
+			if isIssueScreen(m.screen) {
+				m.discardIssueScreenState(m.screen)
 			}
 			return m.switchScreen(screenAsk), nil
 		}
@@ -1158,6 +1197,9 @@ func (m model) updateInput(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 	if m.closeTabConfirming {
 		return m.updateCloseTabConfirm(msg)
+	}
+	if m.mergePRConfirming {
+		return m.updateMergePRConfirm(msg)
 	}
 	isCtrlC := msg.Mod == tea.ModCtrl && msg.Code == 'c'
 	if !isCtrlC {
@@ -1580,6 +1622,71 @@ func (m model) updateCloseTabConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m model) updateMergePRConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch {
+	case msg.Code == tea.KeyEsc, msg.Code == 'n' && msg.Mod == 0:
+		m.mergePRConfirming = false
+		m.mergePRChoice = 0
+		m.mergePRReason = ""
+		m.mergePRItem = issue{}
+		return m, nil
+	case msg.Code == 'y' && msg.Mod == 0:
+		return m.applyPRMergeConfirm()
+	case msg.Code == tea.KeyLeft, msg.Code == 'h' && msg.Mod == 0:
+		m.mergePRChoice = 0
+		return m, nil
+	case msg.Code == tea.KeyRight, msg.Code == 'l' && msg.Mod == 0:
+		m.mergePRChoice = 1
+		return m, nil
+	case msg.Code == tea.KeyTab:
+		m.mergePRChoice = 1 - m.mergePRChoice
+		return m, nil
+	case msg.Code == tea.KeyEnter:
+		if m.mergePRChoice == 1 {
+			return m.applyPRMergeConfirm()
+		}
+		m.mergePRConfirming = false
+		m.mergePRChoice = 0
+		m.mergePRReason = ""
+		m.mergePRItem = issue{}
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m model) applyPRMergeConfirm() (tea.Model, tea.Cmd) {
+	s := m.issueStateForScreen(screenPRs)
+	m.mergePRConfirming = false
+	m.mergePRChoice = 0
+	reason := m.mergePRReason
+	m.mergePRReason = ""
+	it := m.mergePRItem
+	m.mergePRItem = issue{}
+	if s == nil {
+		return m, nil
+	}
+	merger, ok := s.provider.(IssueMerger)
+	if !ok {
+		return m, m.toast.show("merge not supported for this provider")
+	}
+	_ = reason
+	ctx := s.beginLoad()
+	s.loading = true
+	s.loadingMessage = fmt.Sprintf("Merging %s #%d...", s.mergeLabel(), it.number)
+	s.loadingFrame = 0
+	s.loadErr = nil
+	cmd := func() tea.Msg {
+		err := merger.Merge(ctx, s.projectCfg, s.cwd, it)
+		return issueMergeDoneMsg{
+			tabID:  m.id,
+			screen: s.screen,
+			item:   it,
+			err:    err,
+		}
+	}
+	return m, tea.Batch(issueLoadingTickCmd(m.id, s.screen), cmd)
+}
+
 func (m model) updatePicker(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if msg.Mod == tea.ModCtrl && msg.Code == 'd' {
 		return m, closeTabCmd(m.id)
@@ -1811,11 +1918,8 @@ func (m model) handleCommand(line string) (tea.Model, tea.Cmd) {
 		// /workflows opens the builder. Same flow as Ctrl+W: drop
 		// any in-flight issues query so re-entry to the issues
 		// screen later doesn't stack chunks.
-		if m.screen == screenIssues && m.issues != nil {
-			if kv, ok := m.issues.view.(*kanbanIssueView); ok {
-				kv.cancelCarry(m.issues)
-			}
-			m.issues.discardOnLeave()
+		if isIssueScreen(m.screen) {
+			m.discardIssueScreenState(m.screen)
 		}
 		m = m.switchScreen(screenWorkflows)
 		if m.workflowsBuilder == nil {

--- a/view.go
+++ b/view.go
@@ -171,12 +171,12 @@ func (m *model) contentFingerprint() string {
 	// animation isn't masked by the cache while the modal is up.
 	issueCursor := -1
 	loadingFrame := 0
-	if m.issues != nil {
-		if v, ok := m.issues.view.(*kanbanIssueView); ok {
+	if s := m.activeIssueState(); s != nil {
+		if v, ok := s.view.(*kanbanIssueView); ok {
 			issueCursor = v.selColIdx*1_000_000 + v.selRowIdx
 		}
-		if m.issues.loading {
-			loadingFrame = m.issues.loadingFrame + 1
+		if s.loading {
+			loadingFrame = s.loadingFrame + 1
 		}
 	}
 	return fmt.Sprintf("%d|%d|%d|%d|%d|%d", len(m.history), m.width, shellLen, int(m.screen), issueCursor, loadingFrame)
@@ -584,8 +584,9 @@ func (m model) View() tea.View {
 	needSwitch := m.mode == modeProviderSwitch
 	needCancelConfirm := m.cancelTurnConfirming && m.mode == modeInput
 	needCloseTabConfirm := m.closeTabConfirming && m.mode == modeInput
+	needMergeConfirm := m.mergePRConfirming && m.mode == modeInput
 
-	if (needBox || needModal || needApproval || needConfig || needSwitch || needCancelConfirm || needCloseTabConfirm) && m.width > 0 && m.height > 0 {
+	if (needBox || needModal || needApproval || needConfig || needSwitch || needCancelConfirm || needCloseTabConfirm || needMergeConfirm) && m.width > 0 && m.height > 0 {
 		cbStart := time.Now()
 		canvas := uv.NewScreenBuffer(m.width, m.height)
 		uv.NewStyledString(body).Draw(canvas, image.Rectangle{
@@ -830,6 +831,23 @@ func (m model) View() tea.View {
 		}
 		if needCloseTabConfirm {
 			confirm := m.viewCloseTabConfirm()
+			cW := lipgloss.Width(confirm)
+			cH := lipgloss.Height(confirm)
+			cX := (m.width - cW) / 2
+			cY := (m.height - cH) / 2
+			if cX < 0 {
+				cX = 0
+			}
+			if cY < 0 {
+				cY = 0
+			}
+			uv.NewStyledString(confirm).Draw(canvas, image.Rectangle{
+				Min: image.Pt(cX, cY),
+				Max: image.Pt(cX+cW, cY+cH),
+			})
+		}
+		if needMergeConfirm {
+			confirm := m.viewMergePRConfirm()
 			cW := lipgloss.Width(confirm)
 			cH := lipgloss.Height(confirm)
 			cX := (m.width - cW) / 2


### PR DESCRIPTION
## Summary

This PR adds a full Pull Request screen (`Ctrl+P`) that reuses the entire existing kanban + detail + search + pagination + loading machinery — no duplicate view implementation. The only new surface-level behavior is the `m` merge hotkey and the PR-specific column taxonomy.

### What's new

- **`Ctrl+P`** opens the PR screen from anywhere, symmetric with `Ctrl+I` for issues. `Ctrl+I` / `Ctrl+P` cross-switch between the two screens; `Ctrl+O` returns to chat.
- **Kanban columns**: Open / Draft / Merged / Closed (closed-not-merged). Lazy-loaded with the same pagination and loading spinner as issues.
- **Enter to detail**: opens the PR detail view with body and comments. A background hydration fetch replaces the cached list-row snapshot with full body + issue-thread comments so the detail is always fresh — same reactive flow as issues.
- **`m` to merge**: works from both the kanban card and the detail view.
  1. A pre-flight `pull_request_read` re-fetches `mergeable_state` with a spinner overlay ("Checking if PR can be merged…").
  2. If mergeable, a confirmation modal appears (default cursor **No**) showing the PR number and title.
  3. On confirm: async merge via `merge_pull_request` MCP tool with a "Merging…" spinner.
  4. On success: toast + Open/Draft columns reload (PR re-appears in Merged column on next page).
  5. On failure: verbatim API error in the toast; row stays put.
- **Carry/drop disabled**: `Space` is a silent no-op on the PR kanban. PRs don't drag between state columns.

### Edge cases handled

| Scenario | Behavior |
|---|---|
| `mergeable_state = dirty` (conflicts) | Pre-flight blocks with a toast naming the reason; no API call |
| `mergeable_state = blocked` (required checks / reviews) | Same pre-flight block |
| `mergeable_state = behind` | Pre-flight block; toast says "branch is behind base" |
| `mergeable_state = unknown` | Pre-flight warns and still shows confirm (GitHub hasn't computed it yet) |
| `merge_pull_request` API error | Verbatim error surfaced as toast; row stays in its column |
| Screen-leave during pre-flight or merge | `loadCtx` cancel propagates; late replies are dropped |
| GitHub MCP not configured | Same `errIssueProviderNotConfigured` toast as issues |
| PR already merged | Reload shows it in Merged column; `m` on a Merged card is a no-op |

### Architecture

The key design constraint was **one kanban view, two data sources**. Rather than forking the view:

- `SupportsCarry() bool` on `IssueProvider` lets the kanban conditionally enable Space carry. Issues return `true`; PRs return `false`.
- `IssueMerger` is a capability interface (`Mergeable`, `Merge`) that only `githubPRProvider` implements. The screen probes it via type-assertion at the `m` keypress; no merge logic leaks into the shared kanban.
- `issuesState` is reused verbatim for `m.prs`. Async messages (`issuePageLoadedMsg`, `issueLoadingTickMsg`, etc.) carry a `screen` tag so the routing layer dispatches to the correct state without coupling to `m.screen`.
- Workflow `f` dispatch was fixed to use explicit screen ownership instead of `m.screen`, eliminating a latent coupling bug.

### Files changed

| File | Change |
|---|---|
| `pr_provider_github.go` | New: GitHub PR provider — `list_pull_requests`, `pull_request_read`, `merge_pull_request`, `SupportsCarry`, `IssueMerger` |
| `issue_provider.go` | Add `SupportsCarry()` to interface; add `IssueMerger` capability interface |
| `issue_provider_github.go` | Implement `SupportsCarry() = true`; extract `dialGitHubMCP` shared helper |
| `screens.go` | Add `screenPRs`; `newPRsState`; Ctrl+P dispatch |
| `types.go` | `m.prs *issuesState`; merge confirm overlay fields |
| `update.go` | Screen-aware async routing; pre-flight + merge message handlers; background detail hydration |
| `issues.go` | Screen-owned workflow dispatch; hydration handler; screen tag threading |
| `view.go` | Merge confirm overlay render; PR tab glyph |
| `ask_question.go` | Minor type-assertion tightening |
| `issue_search.go` | Screen tag propagation |
| `pr_provider_github_test.go` | New: parser tests — status mapping, assignee/author, comments, column assignment |
| `prs_test.go` | New: screen bootstrap, Ctrl+P dispatch, no-carry semantics, merge flow (happy + error + dirty pre-flight), detail hydration |
| `issues_loading_test.go` / `issues_pagination_test.go` | Updated for explicit `screen` tag on async messages |
| `issue_provider_fake_test.go` | `SupportsCarry`, `fakeMergerProvider`, PR-shaped card fixtures |
| `issues_test.go` / `screens_test.go` | Minor fixture updates |

## Test plan

- [ ] `go build ./...` — passes
- [ ] `go vet ./...` — passes
- [ ] `go test ./...` — passes (all new `prs_test.go` + `pr_provider_github_test.go` cases green)
- [ ] Manual: `Ctrl+P` opens PR kanban with Open/Draft/Merged/Closed columns
- [ ] Manual: Enter on a PR card shows description and comments
- [ ] Manual: `m` on a clean PR shows pre-flight spinner → confirm modal → merges → reloads column
- [ ] Manual: `m` on a conflicted PR shows pre-flight block toast, no modal
- [ ] Manual: carry (`Space`) on the PR kanban is a no-op
- [ ] Manual: `Ctrl+I` ↔ `Ctrl+P` cross-switch preserves each screen's scroll state
- [ ] Manual: `Ctrl+O` from PR screen returns to chat

🤖 Generated with [Claude Code](https://claude.ai/claude-code)