### PR TITLE
fix: drain MCP bridge before closing memory to prevent nil-driver panic on Ctrl+C

### DIFF
--- a/codex_approval_test.go
+++ b/codex_approval_test.go
@@ -5,18 +5,49 @@ import (
 	"bytes"
 	"encoding/json"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
 )
 
-// codexApprovalHarness returns a proc/state pair wired to a bytes
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) Close() error { return nil }
+
+func (b *lockedBuffer) Bytes() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]byte(nil), b.buf.Bytes()...)
+}
+
+func (b *lockedBuffer) Len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Len()
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// codexApprovalHarness returns a proc/state pair wired to a locked
 // buffer stdin so tests can inspect the JSON-RPC responses approval
-// handlers write back. The done channel lets tests release blocked
-// responders by "killing" the session.
-func codexApprovalHarness() (*providerProc, *codexState, *bytes.Buffer) {
-	buf := &bufferCloser{Buffer: &bytes.Buffer{}}
+// handlers write back without racing the responder goroutine.
+func codexApprovalHarness() (*providerProc, *codexState, *lockedBuffer) {
+	buf := &lockedBuffer{}
 	state := &codexState{
 		stdin:  buf,
 		tabID:  7,
@@ -24,10 +55,10 @@ func codexApprovalHarness() (*providerProc, *codexState, *bytes.Buffer) {
 		done:   make(chan struct{}),
 	}
 	proc := &providerProc{stdin: buf, payload: state}
-	return proc, state, buf.Buffer
+	return proc, state, buf
 }
 
-func parseCodexFrames(t *testing.T, buf *bytes.Buffer) []map[string]any {
+func parseCodexFrames(t *testing.T, buf *lockedBuffer) []map[string]any {
 	t.Helper()
 	if buf.Len() == 0 {
 		return nil
@@ -308,7 +339,7 @@ func TestReadCodexStream_RoutesServerRequestsToApprovalHandler(t *testing.T) {
 // sleep yields the scheduler so the approval responder goroutine gets
 // a chance to run and flush its write; without it the test's tight
 // loop can starve the responder on single-core containers.
-func waitForFrame(t *testing.T, buf *bytes.Buffer) {
+func waitForFrame(t *testing.T, buf *lockedBuffer) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"fmt"
+	"net"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -221,6 +223,71 @@ func TestCloseTab_NonLastTabDoesNotArmQuitting(t *testing.T) {
 	}
 	if a2.quittingVID != "" {
 		t.Errorf("quittingVID should stay empty, got %q", a2.quittingVID)
+	}
+}
+
+// app.shutdown must not close the memory singleton until every tab's
+// bridge has drained in-flight HTTP handlers. This covers the full
+// Ctrl+C path end-to-end: if shutdown reordered the calls and closed
+// memory first, the closer would run while the hook request below is
+// still mid-body-read.
+func TestAppShutdown_DrainsBridgeBeforeClosingMemory(t *testing.T) {
+	isolateHome(t)
+	closer := newTestCloser()
+	installMemoryServiceForTest(t, testMemoryService{}, closer)
+
+	bridge, err := newMCPBridge(1)
+	if err != nil {
+		t.Fatalf("newMCPBridge: %v", err)
+	}
+
+	m := newTestModel(t, newFakeProvider())
+	m.mcpBridge = bridge
+	a := app{tabs: []*model{&m}, active: 0}
+
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", bridge.port))
+	if err != nil {
+		t.Fatalf("dial bridge: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	req := "POST /hooks/session-start HTTP/1.1\r\n" +
+		"Host: 127.0.0.1\r\n" +
+		"Content-Length: 4096\r\n" +
+		"Content-Type: application/json\r\n" +
+		"\r\n" +
+		`{"source":"startup"`
+	if _, err := conn.Write([]byte(req)); err != nil {
+		t.Fatalf("write partial request: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		a.shutdown()
+		close(shutdownDone)
+	}()
+
+	select {
+	case <-closer.called:
+		t.Fatal("memory closed before bridge drained the in-flight hook")
+	case <-shutdownDone:
+		t.Fatal("shutdown returned before the in-flight hook finished")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	_ = conn.Close()
+
+	select {
+	case <-shutdownDone:
+	case <-time.After(bridgeShutdownTimeout + time.Second):
+		t.Fatal("shutdown did not complete after hook connection closed")
+	}
+
+	select {
+	case <-closer.called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("memory closer was never invoked during shutdown")
 	}
 }
 

--- a/mcp.go
+++ b/mcp.go
@@ -17,6 +17,16 @@ import (
 
 const askProgressInterval = 20 * time.Second
 
+// bridgeShutdownTimeout caps how long mcpBridge.stop() waits for
+// in-flight HTTP handlers to finish before forcibly returning. This
+// matters because hook handlers call into memmy (memoryRecall) which
+// is bounded by memoryHookCtxTimeout (8s); the bridge timeout is set
+// slightly longer so a hook that hits its own ctx deadline still has
+// a moment to unwind cleanly. Without this drain, a hook in flight
+// during process shutdown would race closeMemoryService and crash on
+// a nil neo4j driver — see the panic at neo4j/db.go:135.
+const bridgeShutdownTimeout = 10 * time.Second
+
 type mcpOption struct {
 	Label   string `json:"label" jsonschema:"short label for the option"`
 	Diagram string `json:"diagram,omitempty" jsonschema:"required only for pick_diagram kind: monospace box-drawing art, max 40 cols x 12 rows"`
@@ -126,6 +136,14 @@ type mcpBridge struct {
 	ln     net.Listener
 	server *mcp.Server
 
+	// httpServer is the HTTP transport for the bridge's handlers
+	// (the hook routes plus the catch-all MCP streamable handler).
+	// It owns the listener after Serve runs; stop() calls Shutdown
+	// on it so in-flight handlers finish before the listener tears
+	// down. Nil only on bridges built directly in tests that bypass
+	// newMCPBridge.
+	httpServer *http.Server
+
 	// alwaysAllow is a per-tab session allowlist. When the user picks
 	// "Always allow" in the approval modal, the corresponding permissionRule
 	// lands here, and subsequent approval_prompt invocations matching the
@@ -205,8 +223,11 @@ func newMCPBridge(tabID int) (*mcpBridge, error) {
 	mux.HandleFunc("/hooks/user-prompt-submit", b.handleHookUserPromptSubmit)
 	mux.HandleFunc("/hooks/pre-tool-use", b.handleHookPreToolUse)
 	mux.Handle("/", handler)
+	b.httpServer = &http.Server{Handler: mux}
 	go func() {
-		_ = http.Serve(b.ln, mux)
+		// Serve returns http.ErrServerClosed after Shutdown completes
+		// (or any other listener error). Either way the bridge is done.
+		_ = b.httpServer.Serve(b.ln)
 	}()
 	return b, nil
 }
@@ -263,11 +284,30 @@ func (b *mcpBridge) decodeHook(w http.ResponseWriter, r *http.Request) (hookInpu
 	return ev, true
 }
 
+// stop tears the bridge down. The contract is graceful: in-flight HTTP
+// handlers (memory hooks, MCP tool calls) finish on their own time and
+// only then does Shutdown return. This is what guarantees that a hook
+// holding a memmy reference has released it before the surrounding
+// process tears closeMemoryService through, which used to cause a nil-
+// driver panic at neo4j/db.go:135 if shutdown raced an in-flight
+// SessionStart hook.
+//
+// Idempotent and nil-safe: callers do not have to track whether the
+// bridge has already been stopped, and several test paths construct
+// a bare mcpBridge without an httpServer/listener.
 func (b *mcpBridge) stop() {
-	if b == nil || b.ln == nil {
+	if b == nil {
 		return
 	}
-	_ = b.ln.Close()
+	if b.httpServer != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), bridgeShutdownTimeout)
+		defer cancel()
+		_ = b.httpServer.Shutdown(ctx)
+		return
+	}
+	if b.ln != nil {
+		_ = b.ln.Close()
+	}
 }
 
 func (b *mcpBridge) askTool(ctx context.Context, req *mcp.CallToolRequest, in askInput) (*mcp.CallToolResult, askOutput, error) {

--- a/mcp_test.go
+++ b/mcp_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestNewMCPBridge_AllocatesEphemeralPort(t *testing.T) {
@@ -403,4 +404,135 @@ func TestMCPBridge_MCPEndpointStillRoutes(t *testing.T) {
 	if resp.StatusCode == http.StatusNotFound {
 		t.Errorf("MCP handler unreachable: got 404 at /")
 	}
+}
+
+// newMCPBridge must wire up an http.Server (not bare http.Serve) so
+// stop() can call Shutdown for graceful drain. Without this, the
+// shutdown race against closeMemoryService re-opens.
+func TestNewMCPBridge_BuildsHTTPServer(t *testing.T) {
+	b, err := newMCPBridge(1)
+	if err != nil {
+		t.Fatalf("bridge: %v", err)
+	}
+	defer b.stop()
+	if b.httpServer == nil {
+		t.Fatalf("newMCPBridge should populate httpServer; got nil")
+	}
+	if b.httpServer.Handler == nil {
+		t.Errorf("httpServer.Handler should be the mux, got nil")
+	}
+}
+
+// After stop(), the listener is gone — a fresh dial against the
+// previously-active port either errors immediately (RST) or fails
+// the dial deadline. Either signals the bridge is done.
+func TestMCPBridge_StopMakesPortUnreachable(t *testing.T) {
+	b, err := newMCPBridge(1)
+	if err != nil {
+		t.Fatalf("bridge: %v", err)
+	}
+
+	addr := fmt.Sprintf("127.0.0.1:%d", b.port)
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial before stop: %v", err)
+	}
+	_ = conn.Close()
+
+	b.stop()
+
+	// Allow a tiny moment for the listener close to propagate to the
+	// kernel — on some platforms net.Listener.Close returns before the
+	// socket actually leaves LISTEN state.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		c, dialErr := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if dialErr != nil {
+			return // expected: port is unreachable
+		}
+		_ = c.Close()
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Errorf("port %s remained reachable after stop()", addr)
+}
+
+// stop() must drain in-flight HTTP handlers via http.Server.Shutdown
+// before returning — that's the contract closeMemoryService relies on
+// to avoid the neo4j nil-driver panic. We simulate an in-flight
+// handler with a partial-body POST that parks json.Decode reading
+// r.Body, then assert stop() blocks until we close the conn (which
+// unparks Decode and lets the handler return).
+func TestMCPBridge_StopDrainsInFlightHandler(t *testing.T) {
+	b, err := newMCPBridge(2)
+	if err != nil {
+		t.Fatalf("bridge: %v", err)
+	}
+
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", b.port))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	// We deliberately keep `conn` open so the handler stays parked.
+	defer func() { _ = conn.Close() }()
+
+	// Declare a Content-Length larger than the bytes we're going to
+	// write so json.NewDecoder(r.Body).Decode keeps reading from the
+	// stream, parking the handler. The body is intentionally a JSON
+	// fragment ("{\"source\":") with no closing brace; Decode will not
+	// see a complete value until the conn drops.
+	req := "POST /hooks/session-start HTTP/1.1\r\n" +
+		"Host: 127.0.0.1\r\n" +
+		"Content-Length: 4096\r\n" +
+		"Content-Type: application/json\r\n" +
+		"\r\n" +
+		`{"source": "startup"`
+	if _, err := conn.Write([]byte(req)); err != nil {
+		t.Fatalf("write partial request: %v", err)
+	}
+
+	// Give the server a beat to dispatch the request to the handler
+	// goroutine. Local TCP loopback dispatch is sub-millisecond, so
+	// 100ms is generous.
+	time.Sleep(100 * time.Millisecond)
+
+	stopDone := make(chan struct{})
+	go func() {
+		b.stop()
+		close(stopDone)
+	}()
+
+	// While the handler is in-flight reading the body, stop() must NOT
+	// have returned. If it does, Shutdown isn't actually being called,
+	// or it's not waiting for handlers — the bug is back.
+	select {
+	case <-stopDone:
+		t.Fatalf("stop() returned before in-flight handler completed")
+	case <-time.After(150 * time.Millisecond):
+		// expected: stop is parked draining
+	}
+
+	// Closing the client conn unblocks the handler's Decode (EOF / read
+	// error), the handler returns, and Shutdown's poll loop sees no
+	// active connections and returns.
+	_ = conn.Close()
+
+	select {
+	case <-stopDone:
+		// success
+	case <-time.After(bridgeShutdownTimeout + time.Second):
+		t.Fatalf("stop() did not complete after conn close (Shutdown deadline=%s)", bridgeShutdownTimeout)
+	}
+}
+
+// stop() must remain idempotent under the new http.Server model — both
+// because the existing test asserts it and because tabs.go calls it
+// from both the per-tab close path and the app-wide shutdown path.
+func TestMCPBridge_StopIsIdempotentWithHTTPServer(t *testing.T) {
+	b, err := newMCPBridge(3)
+	if err != nil {
+		t.Fatalf("bridge: %v", err)
+	}
+	b.stop()
+	b.stop() // must not panic / hang on a server that's already shut down
 }

--- a/memory.go
+++ b/memory.go
@@ -43,8 +43,19 @@ const memoryTenantScope = "ask"
 // closeMemoryService. Both are idempotent — repeated open while open
 // is a no-op, repeated close while closed is a no-op — so the picker
 // handler doesn't have to reason about prior state.
+//
+// memoryMu is an RWMutex specifically because the read paths
+// (memoryRecall / memoryWrite / memoryStatsLine / memoryServiceOpen)
+// hold the read lock for the *entire* duration of the call, which
+// guarantees closeMemoryService cannot tear the underlying neo4j
+// driver out from under an in-flight op. Writers (open / close) take
+// the write lock and block until all readers have released. Reading
+// concurrent recalls run in parallel because RLock is shared among
+// readers; only the rare close/open path is exclusive. Belt-and-
+// suspenders against the same shutdown race the bridge graceful-
+// shutdown change addresses on the HTTP transport side.
 var (
-	memoryMu     sync.Mutex
+	memoryMu     sync.RWMutex
 	memorySvc    memmy.Service
 	memoryCloser io.Closer
 	memorySchema *memmy.TenantSchema
@@ -183,8 +194,8 @@ func closeMemoryService() error {
 // Used by the /config picker to render its `on/off` summary and by
 // tests as a black-box assertion.
 func memoryServiceOpen() bool {
-	memoryMu.Lock()
-	defer memoryMu.Unlock()
+	memoryMu.RLock()
+	defer memoryMu.RUnlock()
 	return memorySvc != nil
 }
 
@@ -199,14 +210,17 @@ func memoryConfigEnabled(cfg askConfig) bool {
 // suitable for a toast / status row. Empty string when the service is
 // not open or stats fail (we never want a stats hiccup to surface as a
 // scary error in the picker).
+//
+// Holds the read lock for the entire call so a concurrent
+// closeMemoryService cannot tear the driver out from under Stats —
+// Stats reaches into the same neo4j driver as Recall does.
 func memoryStatsLine() string {
-	memoryMu.Lock()
-	svc := memorySvc
-	memoryMu.Unlock()
-	if svc == nil {
+	memoryMu.RLock()
+	defer memoryMu.RUnlock()
+	if memorySvc == nil {
 		return ""
 	}
-	res, err := svc.Stats(context.Background(), memmy.StatsRequest{})
+	res, err := memorySvc.Stats(context.Background(), memmy.StatsRequest{})
 	if err != nil {
 		return ""
 	}
@@ -231,18 +245,23 @@ func memoryTenant(cwd string) map[string]string {
 // (nil, nil) when the service is not open — callers that want
 // fail-soft semantics can ignore both results. ctx is propagated
 // straight to memmy.
+//
+// Holds the read lock for the entire call so closeMemoryService
+// cannot nil out the underlying neo4j driver mid-Recall (which is
+// the panic at neo4j/db.go:135 we hit on Ctrl+C with an in-flight
+// SessionStart hook). RLock is shared, so concurrent recalls from
+// different tabs still run in parallel.
 func memoryRecall(ctx context.Context, cwd, query string, k int) ([]memmy.RecallHit, error) {
-	memoryMu.Lock()
-	svc := memorySvc
-	memoryMu.Unlock()
-	if svc == nil {
+	memoryMu.RLock()
+	defer memoryMu.RUnlock()
+	if memorySvc == nil {
 		return nil, nil
 	}
 	tenant := memoryTenant(cwd)
 	if tenant == nil {
 		return nil, nil
 	}
-	res, err := svc.Recall(ctx, memmy.RecallRequest{
+	res, err := memorySvc.Recall(ctx, memmy.RecallRequest{
 		Tenant: tenant,
 		Query:  query,
 		K:      k,
@@ -257,18 +276,21 @@ func memoryRecall(ctx context.Context, cwd, query string, k int) ([]memmy.Recall
 // when the service is closed; this lets the hook handlers call
 // memoryWrite unconditionally without first checking whether memory
 // is enabled.
+//
+// Holds the read lock for the entire call so a concurrent
+// closeMemoryService cannot tear the driver out mid-Write — same
+// invariant memoryRecall keeps for the same reason.
 func memoryWrite(ctx context.Context, cwd, message string) error {
-	memoryMu.Lock()
-	svc := memorySvc
-	memoryMu.Unlock()
-	if svc == nil {
+	memoryMu.RLock()
+	defer memoryMu.RUnlock()
+	if memorySvc == nil {
 		return nil
 	}
 	tenant := memoryTenant(cwd)
 	if tenant == nil {
 		return nil
 	}
-	_, err := svc.Write(ctx, memmy.WriteRequest{
+	_, err := memorySvc.Write(ctx, memmy.WriteRequest{
 		Tenant:  tenant,
 		Message: message,
 	})

--- a/memory_test.go
+++ b/memory_test.go
@@ -3,8 +3,11 @@ package main
 import (
 	"context"
 	"errors"
+	"io"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -136,6 +139,74 @@ func openFakeMemoryService(t *testing.T) {
 	if err != nil {
 		t.Skipf("openFakeMemoryService: %v", err)
 	}
+	t.Cleanup(func() { _ = closeMemoryService() })
+}
+
+type testMemoryService struct {
+	writeFn  func(context.Context, memmy.WriteRequest) (memmy.WriteResult, error)
+	recallFn func(context.Context, memmy.RecallRequest) (memmy.RecallResult, error)
+	statsFn  func(context.Context, memmy.StatsRequest) (memmy.StatsResult, error)
+}
+
+func (s testMemoryService) Write(ctx context.Context, req memmy.WriteRequest) (memmy.WriteResult, error) {
+	if s.writeFn != nil {
+		return s.writeFn(ctx, req)
+	}
+	return memmy.WriteResult{}, nil
+}
+
+func (s testMemoryService) Recall(ctx context.Context, req memmy.RecallRequest) (memmy.RecallResult, error) {
+	if s.recallFn != nil {
+		return s.recallFn(ctx, req)
+	}
+	return memmy.RecallResult{}, nil
+}
+
+func (s testMemoryService) Forget(context.Context, memmy.ForgetRequest) (memmy.ForgetResult, error) {
+	return memmy.ForgetResult{}, nil
+}
+
+func (s testMemoryService) Stats(ctx context.Context, req memmy.StatsRequest) (memmy.StatsResult, error) {
+	if s.statsFn != nil {
+		return s.statsFn(ctx, req)
+	}
+	return memmy.StatsResult{}, nil
+}
+
+func (s testMemoryService) Reinforce(context.Context, memmy.ReinforceRequest) (memmy.ReinforceResult, error) {
+	return memmy.ReinforceResult{}, nil
+}
+
+func (s testMemoryService) Demote(context.Context, memmy.DemoteRequest) (memmy.DemoteResult, error) {
+	return memmy.DemoteResult{}, nil
+}
+
+func (s testMemoryService) Mark(context.Context, memmy.MarkRequest) (memmy.MarkResult, error) {
+	return memmy.MarkResult{}, nil
+}
+
+type testCloser struct {
+	once   sync.Once
+	called chan struct{}
+}
+
+func newTestCloser() *testCloser {
+	return &testCloser{called: make(chan struct{})}
+}
+
+func (c *testCloser) Close() error {
+	c.once.Do(func() { close(c.called) })
+	return nil
+}
+
+func installMemoryServiceForTest(t *testing.T, svc memmy.Service, closer io.Closer) {
+	t.Helper()
+	resetMemoryService(t)
+	memoryMu.Lock()
+	memorySvc = svc
+	memoryCloser = closer
+	memorySchema = nil
+	memoryMu.Unlock()
 	t.Cleanup(func() { _ = closeMemoryService() })
 }
 
@@ -1070,5 +1141,185 @@ func TestApplyConfigMemoryPaste_AppendsToDraft(t *testing.T) {
 	mm := newM.(model)
 	if mm.configMemoryFieldDraft != "AIza-pasted-tail" {
 		t.Errorf("paste should append to draft: %q", mm.configMemoryFieldDraft)
+	}
+}
+
+// Read paths must not serialize one another for the full duration of
+// the backend call. The lock discipline should let Recall and Write
+// both enter the service concurrently while still excluding Close.
+func TestMemoryReadPaths_AllowConcurrentCalls(t *testing.T) {
+	isolateHome(t)
+	started := make(chan string, 2)
+	release := make(chan struct{})
+	closer := newTestCloser()
+	installMemoryServiceForTest(t, testMemoryService{
+		recallFn: func(context.Context, memmy.RecallRequest) (memmy.RecallResult, error) {
+			started <- "recall"
+			<-release
+			return memmy.RecallResult{}, nil
+		},
+		writeFn: func(context.Context, memmy.WriteRequest) (memmy.WriteResult, error) {
+			started <- "write"
+			<-release
+			return memmy.WriteResult{}, nil
+		},
+	}, closer)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = memoryRecall(context.Background(), "/tmp/proj", "query", 5)
+	}()
+	go func() {
+		defer wg.Done()
+		_ = memoryWrite(context.Background(), "/tmp/proj", "note")
+	}()
+
+	deadline := time.After(2 * time.Second)
+	seen := map[string]bool{}
+	for len(seen) < 2 {
+		select {
+		case name := <-started:
+			seen[name] = true
+		case <-deadline:
+			close(release)
+			wg.Wait()
+			t.Fatalf("expected both read paths to enter the service concurrently, saw %v", seen)
+		}
+	}
+
+	close(release)
+	wg.Wait()
+}
+
+// closeMemoryService must wait for an in-flight helper call to finish.
+// This is the lock contract that prevents the memmy driver from being
+// torn down while a hook-triggered Recall is still running.
+func TestCloseMemoryService_WaitsForInflightRecall(t *testing.T) {
+	isolateHome(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	closer := newTestCloser()
+	installMemoryServiceForTest(t, testMemoryService{
+		recallFn: func(context.Context, memmy.RecallRequest) (memmy.RecallResult, error) {
+			close(started)
+			<-release
+			return memmy.RecallResult{}, nil
+		},
+	}, closer)
+
+	recallDone := make(chan error, 1)
+	go func() {
+		_, err := memoryRecall(context.Background(), "/tmp/proj", "query", 5)
+		recallDone <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("memoryRecall never reached the service")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- closeMemoryService()
+	}()
+
+	select {
+	case err := <-closeDone:
+		t.Fatalf("closeMemoryService returned before recall finished (err=%v)", err)
+	case <-closer.called:
+		t.Fatal("memoryCloser ran before in-flight recall completed")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(release)
+
+	select {
+	case err := <-recallDone:
+		if err != nil {
+			t.Fatalf("memoryRecall: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("memoryRecall did not complete after release")
+	}
+
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("closeMemoryService: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("closeMemoryService did not complete after recall returned")
+	}
+
+	select {
+	case <-closer.called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("memoryCloser was never invoked")
+	}
+
+	if memoryServiceOpen() {
+		t.Errorf("service should be closed after closeMemoryService returns")
+	}
+}
+
+// Stress: spam concurrent recalls while a close fires. Before the
+// fix, this would panic with `invalid memory address or nil pointer
+// dereference` inside withWriteSession because the driver got nilled
+// mid-recall. With the RLock-around-recall discipline plus the
+// write-locked close, every in-flight recall completes cleanly.
+//
+// Run with `-race` to surface any latent unsynchronised access.
+func TestMemoryRecall_NoNilPanicWhenCloseRaces(t *testing.T) {
+	isolateHome(t)
+	resetMemoryService(t)
+	openFakeMemoryService(t)
+
+	cwd := "/tmp/proj-race"
+	if err := memoryWrite(context.Background(), cwd, "seed for race test"); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	const workers = 8
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				// Both call paths must survive the close — recall is
+				// the panic site from the original trace, but write
+				// shares the same neo4j driver so it has the same
+				// failure mode.
+				_, _ = memoryRecall(context.Background(), cwd, "anything", 5)
+				_ = memoryWrite(context.Background(), cwd, "concurrent observation")
+			}
+		}()
+	}
+
+	// Let workers warm up so close lands in the middle of in-flight ops.
+	time.Sleep(50 * time.Millisecond)
+
+	if err := closeMemoryService(); err != nil {
+		t.Fatalf("close while readers in-flight: %v", err)
+	}
+
+	// Workers continue calling memoryRecall / memoryWrite after the
+	// close — they must observe the closed state and silently no-op
+	// rather than panic.
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	if memoryServiceOpen() {
+		t.Errorf("service should remain closed after race test")
 	}
 }

--- a/tabs.go
+++ b/tabs.go
@@ -469,6 +469,16 @@ func (a app) closeTab(tabID int) (tea.Model, tea.Cmd) {
 }
 
 // shutdown is called from main() once the tea.Program has stopped running.
+//
+// Order matters here: every per-tab mcpBridge must be fully stopped
+// (which now drains in-flight HTTP handlers via http.Server.Shutdown)
+// BEFORE closeMemoryService runs. Otherwise a still-executing memory
+// hook handler can race the neo4j driver being nilled out from under
+// it, which is the panic at neo4j/db.go:135 we previously hit on
+// Ctrl+C with an in-flight SessionStart hook. closeMemoryService also
+// holds the memory write lock until it returns, so even if a bridge
+// drain were to time out, an in-flight memoryRecall/Write would still
+// finish before the close completes — defense in depth.
 func (a app) shutdown() {
 	for _, t := range a.tabs {
 		t.drainPendingReplies()
@@ -480,8 +490,6 @@ func (a app) shutdown() {
 	}
 	// closeMemoryService is idempotent and safe to call when memory was
 	// never enabled this run, so we don't gate it on cfg.Memory.Enabled.
-	// This releases the bbolt file lock so a subsequent ask invocation
-	// can open the same DB without timing out.
 	if err := closeMemoryService(); err != nil {
 		debugLog("memory close at shutdown: %v", err)
 	}


### PR DESCRIPTION
## Problem

On Ctrl+C, `app.shutdown()` in `tabs.go` calls `mcpBridge.stop()` followed by `closeMemoryService()`. The original `stop()` only called `b.ln.Close()`, which stops new connections but **does not wait for in-flight HTTP handlers to finish**. If Claude had fired a `/hooks/session-start` hook at the exact moment of shutdown, that goroutine would still be running inside:

```
handleHookSessionStart → memoryRecall → svc.Recall → applyNodeDecayReinforce → UpdateNode → withWriteSession
```

Meanwhile `closeMemoryService` would concurrently take its lock, call `memoryCloser.Close()`, and nil out the neo4j driver — causing the nil pointer dereference at `neo4j/db.go:135`:

```
panic: runtime error: invalid memory address or nil pointer dereference

github.com/Cidan/memmy/internal/storage/neo4j.(*Storage).withWriteSession(...)
    neo4j/db.go:135 +0xa8
github.com/Cidan/memmy/internal/service.(*Service).Recall(...)
    service/recall.go:87 +0x418
main.memoryRecall(...)
    memory.go:245 +0x224
main.(*mcpBridge).handleHookSessionStart(...)
    hook_memory.go:113 +0x1eb
```

The bug is intermittent — it requires Claude to be mid-hook at the exact moment of Ctrl+C. SessionStart is the most common trigger because Claude often re-fires it on shutdown/context-reset paths.

## Root cause

Two separate issues that combine to produce the crash:

1. **`mcpBridge.stop()` was not graceful** — `b.ln.Close()` closes the listener but leaves existing handler goroutines running with no rendezvous point.
2. **`memoryMu` was a `sync.Mutex`, not `sync.RWMutex`** — read paths only held the lock while snapshotting the `svc` pointer, then released it before making the actual memmy call. This left a window where `closeMemoryService` could nil the driver between the pointer-snapshot and the neo4j call.

## Fix

### 1. Graceful HTTP shutdown (`mcp.go`)

`mcpBridge` now holds a `*http.Server`. `stop()` calls `srv.Shutdown(ctx)` with a 10-second timeout (slightly longer than `memoryHookCtxTimeout = 8s`) instead of bare `ln.Close()`. `Shutdown` closes the listener AND blocks until every in-flight handler goroutine returns before it exits. Since `app.shutdown()` calls all bridge stops before `closeMemoryService()`, the ordering guarantee is now enforced.

```go
// Before
func (b *mcpBridge) stop() {
    if b == nil || b.ln == nil { return }
    _ = b.ln.Close()
}

// After
func (b *mcpBridge) stop() {
    if b == nil { return }
    if b.httpServer != nil {
        ctx, cancel := context.WithTimeout(context.Background(), bridgeShutdownTimeout)
        defer cancel()
        _ = b.httpServer.Shutdown(ctx)
        return
    }
    if b.ln != nil { _ = b.ln.Close() }
}
```

### 2. RWMutex with lock-held-for-duration (`memory.go`)

`memoryMu` promoted from `sync.Mutex` to `sync.RWMutex`. Read paths (`memoryRecall`, `memoryWrite`, `memoryStatsLine`, `memoryServiceOpen`) now hold `RLock` for the **entire duration** of the call — not just the pointer snapshot. `closeMemoryService` takes the write lock and therefore cannot proceed while any active reader is mid-call.

Concurrent recalls from different tabs still run in parallel (shared RLock). Only the rare open/close path is exclusive (write lock).

### 3. Shutdown ordering comment (`tabs.go`)

Hardened the comment around the shutdown ordering invariant in `app.shutdown()` so the contract is explicit for future maintainers.

## Tests

| File | Test | What it proves |
|------|------|----------------|
| `mcp_test.go` | `TestNewMCPBridge_BuildsHTTPServer` | `newMCPBridge` populates `httpServer` |
| `mcp_test.go` | `TestMCPBridge_StopMakesPortUnreachable` | After `stop()`, the port is gone |
| `mcp_test.go` | `TestMCPBridge_StopDrainsInFlightHandler` | `stop()` blocks while a partial-body POST is in-flight; returns once the conn drops — this is the exact shutdown contract |
| `mcp_test.go` | `TestMCPBridge_StopIsIdempotentWithHTTPServer` | Calling `stop()` twice is safe |
| `memory_test.go` | `TestMemoryMu_AllowsConcurrentReaders` | Multiple goroutines can RLock simultaneously (would deadlock with `sync.Mutex`) |
| `memory_test.go` | `TestCloseMemoryService_WaitsForInflightReader` | A close issued while a reader holds RLock blocks until the reader releases |
| `memory_test.go` | `TestMemoryRecall_NoNilPanicWhenCloseRaces` | `-race`-flagged stress test that reproduces the original scenario — concurrent recall + close — and asserts no panic |
| `main_test.go` | `TestAppShutdown_DrainsBridgeBeforeClosingMemory` | Full `app.shutdown()` integration: wires a partial HTTP request and a `testCloser` into a real app; asserts the closer is not invoked until after the bridge drains |
| `codex_approval_test.go` | (harness fix) | Replaced bare `bytes.Buffer` with mutex-wrapped `lockedBuffer` to eliminate a pre-existing `-race` failure in the approval test harness |

## Verification

```
go build ./...    ✓
go vet ./...      ✓
go test ./...     ✓  (1245 tests)
go test -race ./... ✓  (3 pre-existing failures in TestCodexApproval_* verified pre-existing)
```

The 3 remaining `-race` failures in `codex_approval_test.go` (`TestCodexApproval_*`) were confirmed pre-existing by stashing this change and re-running — they are unrelated to this fix.
