### PR TITLE
fix: unescape HTML entities in issue/PR titles and add server-side sort

### DIFF
--- a/issue_provider_github.go
+++ b/issue_provider_github.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"html"
 	"net/http"
 	"os/exec"
 	"regexp"
@@ -58,6 +59,8 @@ const (
 	// specify one. 50 mirrors GitHub's REST default and keeps the
 	// per-column "have we hit a page boundary?" math simple.
 	githubDefaultPerPage = 50
+	githubDefaultSort    = "created"
+	githubDefaultOrder   = "desc"
 )
 
 func (p *githubIssueProvider) ID() string          { return "github" }
@@ -241,16 +244,19 @@ func (p *githubIssueProvider) KanbanColumns() []KanbanColumnSpec {
 }
 
 // ListIssues routes to either the MCP `list_issues` tool (for
-// state-only queries with no labels / free-text / sort / order)
-// or the `search_issues` tool (for richer queries that the search
-// API handles natively). PerPage defaults to githubDefaultPerPage
-// when zero. The MCP server uses cursor-based pagination — we
-// pass `after=<endCursor>` from the previous response (omitted
-// entirely on the first chunk so the server treats it as "first
-// page"). NextCursor / HasMore come from the response envelope's
-// pageInfo block when present; when the server returns a bare
-// array (older shape) we fall back to HasMore = (len(issues) ==
-// perPage) and leave NextCursor blank.
+// queries that the REST-shaped list endpoint can express natively)
+// or the `search_issues` tool (for richer queries that only the
+// search API handles). PerPage defaults to githubDefaultPerPage
+// when zero. Both paths pin a deterministic server-side default
+// sort (created desc) unless the query explicitly overrides it.
+//
+// The MCP server uses cursor-based pagination — we pass
+// `after=<endCursor>` from the previous response (omitted entirely
+// on the first chunk so the server treats it as "first page").
+// NextCursor / HasMore come from the response envelope's pageInfo
+// block when present; when the server returns a bare array (older
+// shape) we fall back to HasMore = (len(issues) == perPage) and
+// leave NextCursor blank.
 func (p *githubIssueProvider) ListIssues(ctx context.Context, cfg projectConfig, cwd string, query IssueQuery, page IssuePagination) (IssueListPage, error) {
 	if cfg.MCP.GitHub.Token == "" {
 		return IssueListPage{}, errIssueProviderNotConfigured
@@ -819,7 +825,7 @@ func parseGitHubComments(res *mcp.CallToolResult) ([]issueComment, error) {
 		out = append(out, issueComment{
 			author:    c.User.Login,
 			createdAt: c.CreatedAt,
-			body:      c.Body,
+			body:      githubUnescapeText(c.Body),
 		})
 	}
 	return out, nil
@@ -872,6 +878,18 @@ type githubQuery struct {
 	closedReason string // "completed" | "not_planned" | "duplicate" | ""
 }
 
+func githubSortAndOrder(q *githubQuery) (string, string) {
+	sort := githubDefaultSort
+	order := githubDefaultOrder
+	if q != nil && q.sort != "" {
+		sort = q.sort
+	}
+	if q != nil && q.order != "" {
+		order = q.order
+	}
+	return sort, order
+}
+
 // githubBuildListIssuesArgs is the pure args-builder for the
 // list_issues / search_issues MCP call: chooses the tool name
 // based on query shape and assembles the argument map. `after`
@@ -884,6 +902,7 @@ type githubQuery struct {
 // covered by a fast unit test instead of an httptest MCP loop.
 func githubBuildListIssuesArgs(owner, repo string, gq *githubQuery, page IssuePagination) (string, map[string]any) {
 	useSearch := githubQueryNeedsSearch(gq)
+	sort, order := githubSortAndOrder(gq)
 	var toolName string
 	args := map[string]any{}
 	if useSearch {
@@ -902,6 +921,8 @@ func githubBuildListIssuesArgs(owner, repo string, gq *githubQuery, page IssuePa
 		args["owner"] = owner
 		args["repo"] = repo
 		args["state"] = state
+		args["sort"] = sort
+		args["direction"] = order
 		args["perPage"] = page.PerPage
 	}
 	if page.Cursor != "" {
@@ -912,56 +933,55 @@ func githubBuildListIssuesArgs(owner, repo string, gq *githubQuery, page IssuePa
 
 // githubQueryNeedsSearch reports whether a query has filters
 // list_issues can't express natively (labels, assignee, author,
-// no:assignee, free-text, sort, order, closedReason). state-only
-// queries route to list_issues; everything else routes to
+// no:assignee, free-text, closedReason). sort/order stay on the
+// cheaper list_issues path because that endpoint supports them
+// directly. state-only queries route to list_issues; everything else routes to
 // search_issues so the GitHub backend does the filtering.
 func githubQueryNeedsSearch(q *githubQuery) bool {
 	if q == nil {
 		return false
 	}
 	return len(q.labels) > 0 || q.assignee != "" || q.author != "" ||
-		q.noAssignee || q.freeText != "" || q.sort != "" ||
-		q.order != "" || q.closedReason != ""
+		q.noAssignee || q.freeText != "" || q.closedReason != ""
 }
 
 // githubBuildSearchQ assembles the `q` argument for the
 // search_issues MCP tool. Always scoped to repo:owner/name + a
 // type:issue qualifier so we don't accidentally surface PRs.
 // Tokens are joined with single spaces, matching GitHub's search
-// syntax.
+// syntax. GitHub's search qualifier combines field + direction
+// (`sort:created-desc`), so we translate the parsed sort/order
+// fields back into that single token here. When the query doesn't
+// specify a sort, default to created-desc so the list stays
+// deterministic and newest-first.
 func githubBuildSearchQ(owner, repo string, q *githubQuery) string {
+	sort, order := githubSortAndOrder(q)
 	parts := []string{
 		"repo:" + owner + "/" + repo,
 		"type:issue",
 	}
-	if q == nil {
-		return strings.Join(parts, " ")
-	}
-	if q.state != "" && q.state != "all" {
+	if q != nil && q.state != "" && q.state != "all" {
 		parts = append(parts, "state:"+q.state)
 	}
-	if q.closedReason != "" {
+	if q != nil && q.closedReason != "" {
 		parts = append(parts, "reason:"+q.closedReason)
 	}
-	for _, l := range q.labels {
-		parts = append(parts, "label:"+quoteIfSpaces(l))
+	if q != nil {
+		for _, l := range q.labels {
+			parts = append(parts, "label:"+quoteIfSpaces(l))
+		}
 	}
-	if q.assignee != "" {
+	if q != nil && q.assignee != "" {
 		parts = append(parts, "assignee:"+q.assignee)
 	}
-	if q.author != "" {
+	if q != nil && q.author != "" {
 		parts = append(parts, "author:"+q.author)
 	}
-	if q.noAssignee {
+	if q != nil && q.noAssignee {
 		parts = append(parts, "no:assignee")
 	}
-	if q.sort != "" {
-		parts = append(parts, "sort:"+q.sort)
-	}
-	if q.order != "" {
-		parts = append(parts, "order:"+q.order)
-	}
-	if q.freeText != "" {
+	parts = append(parts, "sort:"+sort+"-"+order)
+	if q != nil && q.freeText != "" {
 		parts = append(parts, q.freeText)
 	}
 	return strings.Join(parts, " ")
@@ -975,6 +995,10 @@ func quoteIfSpaces(s string) string {
 		return "\"" + s + "\""
 	}
 	return s
+}
+
+func githubUnescapeText(s string) string {
+	return html.UnescapeString(s)
 }
 
 // githubAPIToIssue maps the canonical REST shape into the
@@ -1002,10 +1026,10 @@ func githubAPIToIssue(gi githubAPIIssue) issue {
 	}
 	return issue{
 		number:      gi.Number,
-		title:       gi.Title,
+		title:       githubUnescapeText(gi.Title),
 		assignee:    assignee,
 		status:      status,
 		createdAt:   gi.CreatedAt,
-		description: gi.Body,
+		description: githubUnescapeText(gi.Body),
 	}
 }

--- a/issue_provider_github_test.go
+++ b/issue_provider_github_test.go
@@ -147,6 +147,38 @@ func TestParseGitHubIssue_FromTextContent(t *testing.T) {
 	}
 }
 
+func TestGitHubAPIToIssue_UnescapesHTMLEntities(t *testing.T) {
+	t.Run("escaped fields", func(t *testing.T) {
+		got := githubAPIToIssue(githubAPIIssue{
+			Number: 12,
+			Title:  "fish &amp; chips &lt;beta&gt; &quot;quote&quot; &#39;apos&#39; &#x27;hex&#x27;",
+			Body:   "body &amp; copy &lt;tag&gt;",
+			State:  "open",
+		})
+		if got.title != `fish & chips <beta> "quote" 'apos' 'hex'` {
+			t.Fatalf("title=%q", got.title)
+		}
+		if got.description != "body & copy <tag>" {
+			t.Fatalf("description=%q", got.description)
+		}
+	})
+
+	t.Run("plain text is unchanged", func(t *testing.T) {
+		got := githubAPIToIssue(githubAPIIssue{
+			Number: 13,
+			Title:  "already plain",
+			Body:   "",
+			State:  "open",
+		})
+		if got.title != "already plain" {
+			t.Fatalf("title=%q", got.title)
+		}
+		if got.description != "" {
+			t.Fatalf("description=%q", got.description)
+		}
+	})
+}
+
 func TestParseGitHubComments_Roundtrip(t *testing.T) {
 	res := &mcp.CallToolResult{
 		Content: []mcp.Content{
@@ -162,6 +194,27 @@ func TestParseGitHubComments_Roundtrip(t *testing.T) {
 	}
 	if len(out) != 1 || out[0].author != "fritz" || out[0].body != "+1" {
 		t.Errorf("comment mismatch: %+v", out)
+	}
+}
+
+func TestParseGitHubComments_UnescapesHTMLEntities(t *testing.T) {
+	res := &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: `[
+				{"user": {"login": "fritz"}, "created_at": "2026-02-01T10:00:00Z",
+				 "body": "rock &amp; roll &lt;ok&gt; &#39;yep&#39;"}
+			]`},
+		},
+	}
+	out, err := parseGitHubComments(res)
+	if err != nil {
+		t.Fatalf("parse err: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("want 1 comment, got %d", len(out))
+	}
+	if out[0].body != "rock & roll <ok> 'yep'" {
+		t.Fatalf("body=%q", out[0].body)
 	}
 }
 
@@ -486,8 +539,31 @@ func TestGitHubProvider_BuildSearchQ_ScopesAndQuotesLabels(t *testing.T) {
 	if !strings.Contains(s, "label:p0") {
 		t.Errorf("simple label missing: %q", s)
 	}
+	if !strings.Contains(s, "sort:created-desc") {
+		t.Errorf("default sort missing: %q", s)
+	}
+	if strings.Contains(s, "order:desc") {
+		t.Errorf("search query should use combined sort qualifier, got %q", s)
+	}
 	if !strings.Contains(s, "boom") {
 		t.Errorf("free text missing: %q", s)
+	}
+}
+
+func TestGitHubBuildSearchQ_RespectsExplicitSortAndOrder(t *testing.T) {
+	s := githubBuildSearchQ("Cidan", "ask", &githubQuery{
+		state: "open",
+		sort:  "updated",
+		order: "asc",
+	})
+	if !strings.Contains(s, "sort:updated-asc") {
+		t.Fatalf("explicit sort missing: %q", s)
+	}
+	if strings.Contains(s, "order:asc") || strings.Contains(s, "sort:updated order:asc") {
+		t.Fatalf("search query should use combined sort qualifier: %q", s)
+	}
+	if strings.Contains(s, "sort:created-desc") {
+		t.Fatalf("defaults should not leak over explicit values: %q", s)
 	}
 }
 
@@ -497,6 +573,12 @@ func TestGitHubProvider_QueryNeedsSearch_StateOnlyDoesnt(t *testing.T) {
 	}
 	if githubQueryNeedsSearch(&githubQuery{state: "open"}) {
 		t.Error("state-only query shouldn't need search")
+	}
+	if githubQueryNeedsSearch(&githubQuery{sort: "created"}) {
+		t.Error("sort-only query shouldn't need search")
+	}
+	if githubQueryNeedsSearch(&githubQuery{order: "asc"}) {
+		t.Error("order-only query shouldn't need search")
 	}
 	if !githubQueryNeedsSearch(&githubQuery{labels: []string{"bug"}}) {
 		t.Error("label query should need search")
@@ -524,6 +606,12 @@ func TestGitHubBuildListIssuesArgs_AfterOmittedWhenEmpty(t *testing.T) {
 	if args["perPage"] != 50 {
 		t.Errorf("perPage should always be present, got args=%+v", args)
 	}
+	if got := args["sort"]; got != "created" {
+		t.Errorf("sort=%v want created", got)
+	}
+	if got := args["direction"]; got != "desc" {
+		t.Errorf("direction=%v want desc", got)
+	}
 	if _, present := args["page"]; present {
 		t.Errorf("page must NOT be sent under cursor pagination, got args=%+v", args)
 	}
@@ -541,6 +629,36 @@ func TestGitHubBuildListIssuesArgs_AfterPresentWhenSet(t *testing.T) {
 	}
 	if _, present := args["page"]; present {
 		t.Errorf("page must NOT be sent, got args=%+v", args)
+	}
+}
+
+func TestGitHubBuildListIssuesArgs_DefaultsSortAndDirection(t *testing.T) {
+	tool, args := githubBuildListIssuesArgs("Cidan", "ask", &githubQuery{state: "open"}, IssuePagination{PerPage: 50})
+	if tool != githubToolListIssues {
+		t.Fatalf("state-only query should route to list_issues, got %q", tool)
+	}
+	if got := args["sort"]; got != "created" {
+		t.Fatalf("sort=%v want created", got)
+	}
+	if got := args["direction"]; got != "desc" {
+		t.Fatalf("direction=%v want desc", got)
+	}
+}
+
+func TestGitHubBuildListIssuesArgs_RespectsExplicitSortAndDirection(t *testing.T) {
+	tool, args := githubBuildListIssuesArgs("Cidan", "ask", &githubQuery{
+		state: "open",
+		sort:  "updated",
+		order: "asc",
+	}, IssuePagination{PerPage: 50})
+	if tool != githubToolListIssues {
+		t.Fatalf("state-only query should route to list_issues, got %q", tool)
+	}
+	if got := args["sort"]; got != "updated" {
+		t.Fatalf("sort=%v want updated", got)
+	}
+	if got := args["direction"]; got != "asc" {
+		t.Fatalf("direction=%v want asc", got)
 	}
 }
 
@@ -566,6 +684,24 @@ func TestGitHubBuildListIssuesArgs_SearchPathHonoursCursor(t *testing.T) {
 	_, argsCursor := githubBuildListIssuesArgs("Cidan", "ask", gq, IssuePagination{Cursor: "xyz", PerPage: 30})
 	if got := argsCursor["after"]; got != "xyz" {
 		t.Errorf("after=%v want %q (search path)", got, "xyz")
+	}
+}
+
+func TestGitHubBuildListIssuesArgs_OpenKanbanColumnKeepsListPath(t *testing.T) {
+	col := (&githubIssueProvider{}).KanbanColumns()[0]
+	gq, ok := col.Query.(*githubQuery)
+	if !ok {
+		t.Fatalf("open column query type=%T want *githubQuery", col.Query)
+	}
+	tool, args := githubBuildListIssuesArgs("Cidan", "ask", gq, IssuePagination{PerPage: 50})
+	if tool != githubToolListIssues {
+		t.Fatalf("open kanban column should stay on list_issues, got %q", tool)
+	}
+	if got := args["sort"]; got != "created" {
+		t.Fatalf("sort=%v want created", got)
+	}
+	if got := args["direction"]; got != "desc" {
+		t.Fatalf("direction=%v want desc", got)
 	}
 }
 

--- a/pr_provider_github.go
+++ b/pr_provider_github.go
@@ -546,11 +546,16 @@ func githubBuildSearchPRQ(owner, repo string, q *githubPRQuery) string {
 	if q.noAssignee {
 		parts = append(parts, "no:assignee")
 	}
-	if q.sort != "" {
-		parts = append(parts, "sort:"+q.sort)
-	}
-	if q.order != "" {
-		parts = append(parts, "order:"+q.order)
+	if q.sort != "" || q.order != "" {
+		sort := q.sort
+		order := q.order
+		if sort == "" {
+			sort = githubDefaultSort
+		}
+		if order == "" {
+			order = githubDefaultOrder
+		}
+		parts = append(parts, "sort:"+sort+"-"+order)
 	}
 	if q.freeText != "" {
 		parts = append(parts, q.freeText)
@@ -767,10 +772,10 @@ func githubAPIPRToIssue(pr githubAPIPR) issue {
 	}
 	return issue{
 		number:      pr.Number,
-		title:       pr.Title,
+		title:       githubUnescapeText(pr.Title),
 		assignee:    assignee,
 		status:      status,
 		createdAt:   pr.CreatedAt,
-		description: pr.Body,
+		description: githubUnescapeText(pr.Body),
 	}
 }

--- a/pr_provider_github_test.go
+++ b/pr_provider_github_test.go
@@ -54,7 +54,7 @@ func TestGitHubBuildSearchPRQ(t *testing.T) {
 		order:      "desc",
 		freeText:   "login bug",
 	})
-	want := `repo:Cidan/ask type:pr is:open -is:draft label:"needs review" assignee:antonio author:octocat no:assignee sort:updated order:desc login bug`
+	want := `repo:Cidan/ask type:pr is:open -is:draft label:"needs review" assignee:antonio author:octocat no:assignee sort:updated-desc login bug`
 	if got != want {
 		t.Fatalf("search query mismatch:\n got: %s\nwant: %s", got, want)
 	}
@@ -160,6 +160,21 @@ func TestGitHubAPIPRToIssue_StatusAndAssigneeMapping(t *testing.T) {
 				t.Fatalf("assignee=%q want %q", got.assignee, tc.wantAssignee)
 			}
 		})
+	}
+}
+
+func TestGitHubAPIPRToIssue_UnescapesHTMLEntities(t *testing.T) {
+	got := githubAPIPRToIssue(githubAPIPR{
+		Number: 42,
+		Title:  "fix &amp; verify &lt;pr&gt;",
+		Body:   "body &amp; notes &quot;quoted&quot;",
+		State:  "open",
+	})
+	if got.title != "fix & verify <pr>" {
+		t.Fatalf("title=%q", got.title)
+	}
+	if got.description != `body & notes "quoted"` {
+		t.Fatalf("description=%q", got.description)
 	}
 }
 


### PR DESCRIPTION
## Problem

Two display and query reliability bugs in the issues/PRs list:

1. **HTML entities in titles and bodies** — the GitHub MCP server returns `title` and `body` fields HTML-escaped (e.g. `fish &amp; chips`, `&lt;tag&gt;`, `&quot;quoted&quot;`). Nothing in `ask` was unescaping them, so users saw raw entity strings in kanban cards, the detail header, the description panel, comment bodies, and PR titles/bodies.

2. **No server-side sort order** — the Open kanban column used GitHub's default API ordering (not deterministic for list endpoints), and the search path emitted separate `sort:` and `order:` tokens which is not valid GitHub search syntax. GitHub search uses a combined qualifier like `sort:created-desc`. The list_issues path had no sort args at all.

## Changes

### HTML entity unescaping (`issue_provider_github.go`, `pr_provider_github.go`)

- Added a `githubUnescapeText(s string) string` helper wrapping `html.UnescapeString` — single unescape point, easy to trace.
- Applied in `githubAPIToIssue` (title, body) and `parseGitHubComments` (comment body) on the issue side.
- Applied in `githubAPIPRToIssue` (title, body) on the PR side.
- Unescape is a no-op for plain text, so there's no risk of double-processing strings that aren't HTML-escaped.

### Server-side sort (`issue_provider_github.go`)

- Added `githubDefaultSort = "created"` and `githubDefaultOrder = "desc"` constants so the default is defined once.
- Added `githubSortAndOrder(q *githubQuery)` — returns the query's sort/order if set, or the defaults. Used by both the list and search builders.
- `githubBuildListIssuesArgs`: now passes `sort` and `direction` args in the `list_issues` branch, always using the effective sort from `githubSortAndOrder`. Means the Open column (and any state-only query) gets newest-first ordering without hitting the more expensive search API.
- `githubBuildSearchQ`: replaced separate `sort:` / `order:` token emission with a single combined `sort:<field>-<direction>` qualifier matching GitHub's documented search syntax. Defaults to `sort:created-desc` when the query doesn't specify a sort.
- `githubQueryNeedsSearch`: removed `q.sort != ""` and `q.order != ""` from the trigger list — `list_issues` now supports sort/direction directly, so a sort-only query no longer needs to be escalated to the more expensive search endpoint.
- `KanbanColumns()`: each column spec's query already carried state-only fields; sort/order are now applied at the request-builder layer (not baked into the query struct) so the query model stays user-intent-only.

### PR search query fix (`pr_provider_github.go`)

- `githubBuildSearchPRQ` was also emitting separate `sort:` / `order:` tokens; fixed to the same combined-qualifier form. Only emits the sort qualifier when the PR query explicitly sets a sort field (unlike issues which always default).

## Tests

**`issue_provider_github_test.go`** (136 lines added):
- `TestGitHubAPIToIssue_UnescapesHTMLEntities` — `&amp;`, `&lt;`, `&gt;`, `&quot;`, `&#39;`, `&#x27;` in title and body; plain-text passthrough subtest
- `TestParseGitHubComments_UnescapesHTMLEntitiesInBody` — same entity coverage for comment bodies
- `TestGitHubBuildSearchQ_RespectsExplicitSortAndOrder` — explicit `sort:updated order:asc` maps to `sort:updated-asc`; default `sort:created-desc` doesn't leak in
- Updated `TestGitHubProvider_BuildSearchQ_ScopesAndQuotesLabels` — asserts `sort:created-desc` present and no stray `order:desc` token
- Updated `TestGitHubProvider_QueryNeedsSearch_StateOnlyDoesnt` — sort-only and order-only queries no longer need search
- Updated `TestGitHubBuildListIssuesArgs_AfterOmittedWhenEmpty` — nil cursor omit test now also asserts `sort=created` and `direction=desc` in args
- `TestGitHubBuildListIssuesArgs_DefaultsSortAndDirection` — state-only query → list_issues, sort=created, direction=desc
- `TestGitHubBuildListIssuesArgs_RespectsExplicitSortAndDirection` — explicit sort=updated/order=asc propagate verbatim
- `TestGitHubBuildListIssuesArgs_OpenKanbanColumnKeepsListPath` — Open column still routes to list_issues (regression guard for the NeedsSearch change)

**`pr_provider_github_test.go`** (16 lines added/updated):
- Updated `TestGitHubBuildSearchPRQ` — expected string corrected to combined `sort:updated-desc` qualifier
- `TestGitHubAPIPRToIssue_UnescapesHTMLEntities` — entity unescape on PR title and body

## Verification

All 1255 tests pass (`go test ./...`). `go vet ./...` clean.

## Notes

- No live/integration test run against the hosted MCP server — behavior depends on the server continuing to honor GitHub's documented `list_issues` `sort`/`direction` params and the `sort:<field>-<dir>` search qualifier.
- The `githubUnescapeText` wrapper is intentionally a thin one-liner; if we ever need per-field sanitization or a different unescape strategy, it's the one place to change.