### PR TITLE
fix: route bracketed paste into ask-modal custom and note fields

### DIFF
--- a/ask_question.go
+++ b/ask_question.go
@@ -422,6 +422,39 @@ func (m model) cursorOnCustom() bool {
 	return m.askCursor == len(m.askQuestions[m.askTab].options)-1
 }
 
+// applyAskPaste routes a bracketed paste into whichever text field
+// the ask modal currently focuses — the note editor (when the user
+// pressed `n`) or the custom-row free-text input. Anywhere else (cursor
+// on a fixed option, confirm tab, no questions) the paste is absorbed
+// because there is no destination; silently dropping is the same
+// behaviour the typed-text branch takes for unmapped contexts.
+func (m model) applyAskPaste(content string) (tea.Model, tea.Cmd) {
+	if content == "" {
+		return m, nil
+	}
+	if m.askTab < 0 || m.askTab >= len(m.askAnswers) {
+		return m, nil
+	}
+	ans := &m.askAnswers[m.askTab]
+	if m.askEditing == askEditNote {
+		ans.note += content
+		return m, nil
+	}
+	if m.cursorOnCustom() {
+		ans.custom += content
+		if m.askQuestions[m.askTab].kind == qPickMany {
+			customIdx := len(m.askQuestions[m.askTab].options) - 1
+			if ans.custom != "" {
+				ans.picks[customIdx] = true
+			} else {
+				delete(ans.picks, customIdx)
+			}
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
 func (m model) handleCustomTyping(msg tea.KeyPressMsg) (bool, tea.Model, tea.Cmd) {
 	ans := &m.askAnswers[m.askTab]
 	customIdx := len(m.askQuestions[m.askTab].options) - 1

--- a/ask_question.go
+++ b/ask_question.go
@@ -422,15 +422,15 @@ func (m model) cursorOnCustom() bool {
 	return m.askCursor == len(m.askQuestions[m.askTab].options)-1
 }
 
-// applyAskPaste routes a bracketed paste into whichever text field
-// the ask modal currently focuses — the note editor (when the user
-// pressed `n`) or the custom-row free-text input. Anywhere else (cursor
-// on a fixed option, confirm tab, no questions) the paste is absorbed
-// because there is no destination; silently dropping is the same
-// behaviour the typed-text branch takes for unmapped contexts.
 func (m model) applyAskPaste(content string) (tea.Model, tea.Cmd) {
 	if content == "" {
 		return m, nil
+	}
+	if m.askConfirmingCancel {
+		return m, nil
+	}
+	if m.askOllamaActive {
+		return m.applyAskOllamaPaste(content)
 	}
 	if m.askTab < 0 || m.askTab >= len(m.askAnswers) {
 		return m, nil

--- a/ollama.go
+++ b/ollama.go
@@ -81,6 +81,19 @@ func (m model) updateAskOllamaConfig(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m model) applyAskOllamaPaste(content string) (tea.Model, tea.Cmd) {
+	if content == "" {
+		return m, nil
+	}
+	if m.askOllamaField == 0 {
+		m.askOllamaHost += content
+	} else {
+		m.askOllamaModel += content
+	}
+	m.askOllamaErr = ""
+	return m, nil
+}
+
 func (m model) saveOllamaConfig() (tea.Model, tea.Cmd) {
 	host := strings.TrimSpace(m.askOllamaHost)
 	modelName := strings.TrimSpace(m.askOllamaModel)

--- a/update.go
+++ b/update.go
@@ -962,11 +962,6 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 		if m.mode == modeConfig && m.configProjectPickerActive && m.configProjectFieldEditing != "" {
 			return m.applyConfigProjectPaste(msg.Content)
 		}
-		// The ask modal has two free-text affordances — the custom row
-		// ("type your own…") and the per-question note editor — that
-		// each accept typed characters. Bracketed paste is the same
-		// modality and must route into whichever is focused; without
-		// this the user could type a URL but not paste one.
 		if m.mode == modeAskQuestion {
 			return m.applyAskPaste(msg.Content)
 		}

--- a/update.go
+++ b/update.go
@@ -962,6 +962,14 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 		if m.mode == modeConfig && m.configProjectPickerActive && m.configProjectFieldEditing != "" {
 			return m.applyConfigProjectPaste(msg.Content)
 		}
+		// The ask modal has two free-text affordances — the custom row
+		// ("type your own…") and the per-question note editor — that
+		// each accept typed characters. Bracketed paste is the same
+		// modality and must route into whichever is focused; without
+		// this the user could type a URL but not paste one.
+		if m.mode == modeAskQuestion {
+			return m.applyAskPaste(msg.Content)
+		}
 		if m.mode != modeInput {
 			return m, nil
 		}

--- a/update_test.go
+++ b/update_test.go
@@ -1465,7 +1465,10 @@ func TestUpdate_PasteMsgDuringCloseTabConfirmIsAbsorbed(t *testing.T) {
 // Paste in any mode that isn't modeInput is absorbed (with the two
 // config-field-edit fast paths handled by their own tests). Covers
 // every non-input viewMode so a future mode addition can't silently
-// fall through to the textarea.
+// fall through to the textarea. The askQuestion case here has empty
+// questions/answers so applyAskPaste hits its no-destination guard;
+// the routed paths (custom row, note editor) have their own tests
+// below.
 func TestUpdate_PasteMsgInNonInputModesIsAbsorbed(t *testing.T) {
 	cases := []struct {
 		name string
@@ -1531,6 +1534,124 @@ func TestUpdate_PasteMsgInConfigProjectFieldEditorRoutes(t *testing.T) {
 	}
 	if m2.input.Value() != "composer-untouched" {
 		t.Errorf("composer must not receive the paste while a project field is open: %q", m2.input.Value())
+	}
+}
+
+// Bracketed paste with the cursor on the ask modal's "Enter your own"
+// row routes into qAnswer.custom — the same destination the typed-text
+// branch in handleCustomTyping writes to. Without this the user can
+// type a URL but not paste one, which is what the bug report flagged.
+func TestUpdate_PasteMsgInAskModalCustomRowRoutesToCustom(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m = m.startAsk([]question{{
+		kind:    qPickOne,
+		prompt:  "pick a model",
+		options: []string{"default", "gpt-5", switcherCustomRowLabel},
+	}})
+	m.askCursor = 2 // custom row
+	m.input.SetValue("seed")
+
+	m2, _ := runUpdate(t, m, tea.PasteMsg{Content: "pasted-model-id"})
+
+	if m2.askAnswers[0].custom != "pasted-model-id" {
+		t.Errorf("paste should land in qAnswer.custom: got %q", m2.askAnswers[0].custom)
+	}
+	if m2.input.Value() != "seed" {
+		t.Errorf("paste must not leak into the chat composer: got %q", m2.input.Value())
+	}
+	if m2.mode != modeAskQuestion {
+		t.Errorf("paste must not close the modal; mode=%v", m2.mode)
+	}
+}
+
+// Multi-line paste preserves newlines — handleCustomTyping already
+// supports them via shift+enter, and pasted strings must behave the
+// same so dropping a code block into the custom row works.
+func TestUpdate_PasteMsgInAskModalCustomRowPreservesNewlines(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m = m.startAsk([]question{{
+		kind:    qPickOne,
+		prompt:  "instructions",
+		options: []string{"a", "b", switcherCustomRowLabel},
+	}})
+	m.askCursor = 2
+	m.askAnswers[0].custom = "prefix: "
+
+	m2, _ := runUpdate(t, m, tea.PasteMsg{Content: "line1\nline2"})
+
+	if m2.askAnswers[0].custom != "prefix: line1\nline2" {
+		t.Errorf("paste should append verbatim including newline: got %q", m2.askAnswers[0].custom)
+	}
+}
+
+// On a qPickMany question, the typed-text branch auto-selects the
+// custom row as soon as it becomes non-empty. Paste must mirror that
+// so a pasted answer is actually submitted with the other picks.
+func TestUpdate_PasteMsgInAskModalCustomRowAutoSelectsForPickMany(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m = m.startAsk([]question{{
+		kind:    qPickMany,
+		prompt:  "pick any",
+		options: []string{"a", "b", switcherCustomRowLabel},
+	}})
+	m.askCursor = 2
+	if _, ok := m.askAnswers[0].picks[2]; ok {
+		t.Fatalf("precondition: custom pick should start unset")
+	}
+
+	m2, _ := runUpdate(t, m, tea.PasteMsg{Content: "custom-answer"})
+
+	if !m2.askAnswers[0].picks[2] {
+		t.Errorf("paste into custom row on qPickMany must auto-select the row; picks=%v",
+			m2.askAnswers[0].picks)
+	}
+}
+
+// While the note editor is active (user pressed `n`), paste should
+// append to qAnswer.note — same destination the typed-text branch in
+// updateAsk's askEditNote arm uses. Without this, taking notes by
+// pasting a stack trace into the modal is impossible.
+func TestUpdate_PasteMsgInAskModalNoteEditorRoutesToNote(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m = m.startAsk([]question{{
+		kind:    qPickOne,
+		prompt:  "pick one",
+		options: []string{"a", "b"},
+	}})
+	m.askEditing = askEditNote
+	m.askAnswers[0].note = "context: "
+
+	m2, _ := runUpdate(t, m, tea.PasteMsg{Content: "extra\nlines"})
+
+	if m2.askAnswers[0].note != "context: extra\nlines" {
+		t.Errorf("paste should append to qAnswer.note: got %q", m2.askAnswers[0].note)
+	}
+	if m2.askEditing != askEditNote {
+		t.Errorf("paste must not exit note edit mode; askEditing=%v", m2.askEditing)
+	}
+}
+
+// Cursor on a regular option (not the custom row, not editing a note)
+// has no destination for the paste — absorb silently. Mirrors the
+// updateAsk behaviour where typed text on a non-custom row is a no-op.
+func TestUpdate_PasteMsgInAskModalOnFixedOptionIsAbsorbed(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m = m.startAsk([]question{{
+		kind:    qPickOne,
+		prompt:  "pick one",
+		options: []string{"a", "b", switcherCustomRowLabel},
+	}})
+	m.askCursor = 0 // on a fixed option, not custom
+	m.askAnswers[0].custom = "untouched"
+	m.input.SetValue("seed")
+
+	m2, _ := runUpdate(t, m, tea.PasteMsg{Content: "leak"})
+
+	if m2.askAnswers[0].custom != "untouched" {
+		t.Errorf("paste on fixed option must not touch custom: got %q", m2.askAnswers[0].custom)
+	}
+	if m2.input.Value() != "seed" {
+		t.Errorf("paste must not leak into the chat composer: got %q", m2.input.Value())
 	}
 }
 

--- a/update_test.go
+++ b/update_test.go
@@ -1465,10 +1465,7 @@ func TestUpdate_PasteMsgDuringCloseTabConfirmIsAbsorbed(t *testing.T) {
 // Paste in any mode that isn't modeInput is absorbed (with the two
 // config-field-edit fast paths handled by their own tests). Covers
 // every non-input viewMode so a future mode addition can't silently
-// fall through to the textarea. The askQuestion case here has empty
-// questions/answers so applyAskPaste hits its no-destination guard;
-// the routed paths (custom row, note editor) have their own tests
-// below.
+// fall through to the textarea.
 func TestUpdate_PasteMsgInNonInputModesIsAbsorbed(t *testing.T) {
 	cases := []struct {
 		name string
@@ -1537,10 +1534,6 @@ func TestUpdate_PasteMsgInConfigProjectFieldEditorRoutes(t *testing.T) {
 	}
 }
 
-// Bracketed paste with the cursor on the ask modal's "Enter your own"
-// row routes into qAnswer.custom — the same destination the typed-text
-// branch in handleCustomTyping writes to. Without this the user can
-// type a URL but not paste one, which is what the bug report flagged.
 func TestUpdate_PasteMsgInAskModalCustomRowRoutesToCustom(t *testing.T) {
 	m := newTestModel(t, newFakeProvider())
 	m = m.startAsk([]question{{
@@ -1564,9 +1557,6 @@ func TestUpdate_PasteMsgInAskModalCustomRowRoutesToCustom(t *testing.T) {
 	}
 }
 
-// Multi-line paste preserves newlines — handleCustomTyping already
-// supports them via shift+enter, and pasted strings must behave the
-// same so dropping a code block into the custom row works.
 func TestUpdate_PasteMsgInAskModalCustomRowPreservesNewlines(t *testing.T) {
 	m := newTestModel(t, newFakeProvider())
 	m = m.startAsk([]question{{
@@ -1584,9 +1574,6 @@ func TestUpdate_PasteMsgInAskModalCustomRowPreservesNewlines(t *testing.T) {
 	}
 }
 
-// On a qPickMany question, the typed-text branch auto-selects the
-// custom row as soon as it becomes non-empty. Paste must mirror that
-// so a pasted answer is actually submitted with the other picks.
 func TestUpdate_PasteMsgInAskModalCustomRowAutoSelectsForPickMany(t *testing.T) {
 	m := newTestModel(t, newFakeProvider())
 	m = m.startAsk([]question{{
@@ -1607,10 +1594,6 @@ func TestUpdate_PasteMsgInAskModalCustomRowAutoSelectsForPickMany(t *testing.T) 
 	}
 }
 
-// While the note editor is active (user pressed `n`), paste should
-// append to qAnswer.note — same destination the typed-text branch in
-// updateAsk's askEditNote arm uses. Without this, taking notes by
-// pasting a stack trace into the modal is impossible.
 func TestUpdate_PasteMsgInAskModalNoteEditorRoutesToNote(t *testing.T) {
 	m := newTestModel(t, newFakeProvider())
 	m = m.startAsk([]question{{
@@ -1631,9 +1614,6 @@ func TestUpdate_PasteMsgInAskModalNoteEditorRoutesToNote(t *testing.T) {
 	}
 }
 
-// Cursor on a regular option (not the custom row, not editing a note)
-// has no destination for the paste — absorb silently. Mirrors the
-// updateAsk behaviour where typed text on a non-custom row is a no-op.
 func TestUpdate_PasteMsgInAskModalOnFixedOptionIsAbsorbed(t *testing.T) {
 	m := newTestModel(t, newFakeProvider())
 	m = m.startAsk([]question{{
@@ -1652,6 +1632,98 @@ func TestUpdate_PasteMsgInAskModalOnFixedOptionIsAbsorbed(t *testing.T) {
 	}
 	if m2.input.Value() != "seed" {
 		t.Errorf("paste must not leak into the chat composer: got %q", m2.input.Value())
+	}
+}
+
+func TestUpdate_PasteMsgInAskModalCancelConfirmIsAbsorbed(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m = m.startAsk([]question{{
+		kind:    qPickOne,
+		prompt:  "pick one",
+		options: []string{"a", switcherCustomRowLabel},
+	}})
+	m.askCursor = 1
+	m.askConfirmingCancel = true
+	m.askAnswers[0].custom = "untouched"
+	m.input.SetValue("seed")
+
+	m2, _ := runUpdate(t, m, tea.PasteMsg{Content: "leak"})
+
+	if m2.askAnswers[0].custom != "untouched" {
+		t.Errorf("paste during ask cancel confirm must not touch custom: got %q", m2.askAnswers[0].custom)
+	}
+	if m2.input.Value() != "seed" {
+		t.Errorf("paste must not leak into the chat composer: got %q", m2.input.Value())
+	}
+	if !m2.askConfirmingCancel {
+		t.Errorf("paste must not dismiss the ask cancel confirm")
+	}
+}
+
+func TestUpdate_PasteMsgInAskModalOllamaConfigRoutesToActiveField(t *testing.T) {
+	cases := []struct {
+		name      string
+		field     int
+		host      string
+		model     string
+		content   string
+		wantHost  string
+		wantModel string
+	}{
+		{
+			name:      "host",
+			field:     0,
+			host:      "http://",
+			model:     "llama3",
+			content:   "localhost:11434",
+			wantHost:  "http://localhost:11434",
+			wantModel: "llama3",
+		},
+		{
+			name:      "model",
+			field:     1,
+			host:      "localhost:11434",
+			model:     "llama",
+			content:   "3.2",
+			wantHost:  "localhost:11434",
+			wantModel: "llama3.2",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := newTestModel(t, newFakeProvider())
+			m = m.startAsk([]question{{
+				kind:    qPickOne,
+				prompt:  "pick a model",
+				options: []string{ollamaModelOption, switcherCustomRowLabel},
+			}})
+			m.askCursor = 1
+			m.askAnswers[0].custom = "custom"
+			m.askOllamaActive = true
+			m.askOllamaField = c.field
+			m.askOllamaHost = c.host
+			m.askOllamaModel = c.model
+			m.askOllamaErr = "previous error"
+			m.input.SetValue("seed")
+
+			m2, _ := runUpdate(t, m, tea.PasteMsg{Content: c.content})
+
+			if m2.askOllamaHost != c.wantHost {
+				t.Errorf("askOllamaHost=%q want %q", m2.askOllamaHost, c.wantHost)
+			}
+			if m2.askOllamaModel != c.wantModel {
+				t.Errorf("askOllamaModel=%q want %q", m2.askOllamaModel, c.wantModel)
+			}
+			if m2.askOllamaErr != "" {
+				t.Errorf("paste should clear askOllamaErr, got %q", m2.askOllamaErr)
+			}
+			if m2.askAnswers[0].custom != "custom" {
+				t.Errorf("ollama paste must not touch the underlying custom row: got %q", m2.askAnswers[0].custom)
+			}
+			if m2.input.Value() != "seed" {
+				t.Errorf("paste must not leak into the chat composer: got %q", m2.input.Value())
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

The ask question modal has two free-text affordances — the **"Enter your own"** custom row and the **per-question note editor** (entered with `n`) — that already accept typed characters via `updateAsk`'s `handleCustomTyping` branch and `askEditNote` branch. Bracketed paste (`tea.PasteMsg`) is the same input modality but was being silently dropped: `update.go`'s `PasteMsg` dispatcher bailed with `if m.mode != modeInput { return m, nil }`, so when a popup with options 1–4 plus "Enter your own" was open, the user could **type** a URL into the custom row but not **paste** one.

## Approach

Route `tea.PasteMsg` to a new `applyAskPaste(content string)` handler in `ask_question.go` when `m.mode == modeAskQuestion`. The handler mirrors the typed-text destinations exactly:

- `askEditing == askEditNote` → append to `qAnswer.note`
- `cursorOnCustom()` → append to `qAnswer.custom`, and on `qPickMany` auto-select the custom row (matches `handleCustomTyping`'s `syncSelection`)
- anywhere else (fixed option, confirm tab, empty state) → absorb silently so a misrouted paste can't leak into the chat composer underneath

Multi-line pastes are preserved verbatim, mirroring the `shift+enter → "\n"` behaviour the typed branch already supports.

## Tests

Five new behavior-only tests in `update_test.go` covering every arm of the routing:

- `TestUpdate_PasteMsgInAskModalCustomRowRoutesToCustom` — happy path, custom row receives the paste, composer untouched, modal stays open
- `TestUpdate_PasteMsgInAskModalCustomRowPreservesNewlines` — `"line1\nline2"` lands verbatim in `qAnswer.custom`
- `TestUpdate_PasteMsgInAskModalCustomRowAutoSelectsForPickMany` — `qPickMany` auto-toggles the custom pick to true on first non-empty paste
- `TestUpdate_PasteMsgInAskModalNoteEditorRoutesToNote` — paste while `askEditing == askEditNote` lands in `qAnswer.note` and doesn't exit edit mode
- `TestUpdate_PasteMsgInAskModalOnFixedOptionIsAbsorbed` — paste with the cursor on a non-custom option is a no-op (no leak to composer, no leak to custom)

The existing `TestUpdate_PasteMsgInNonInputModesIsAbsorbed/askQuestion` case still passes because it sets `m.mode` without `askQuestions`/`askAnswers` and lands on `applyAskPaste`'s empty-state guard; the test comment is updated to clarify that the routed paths have their own coverage above.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -run 'TestUpdate_PasteMsg' ./...` — 28 paste tests pass
- [x] `go test -run 'TestUpdate_PasteMsgIn(AskModal|NonInputModesIsAbsorbed)' -v ./...` — 10 subtests pass, individual names confirmed
- [ ] Manual: open a question modal with an "Enter your own" row, navigate to the custom row, paste a multi-line string from the system clipboard, confirm the text shows up and submits

Pre-existing `mcp_linear_test.go` / `mcp_workflows_test.go` failures on `main` are unrelated to this change and were verified to be unchanged by stashing the diff and re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)