### PR TITLE
feat: customizable global keyboard shortcuts via /config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,8 @@ One `package main`, one file per concern.
 | `workflows_run.go`     | Step runner: prompt assembly, advance-on-turn-complete, finalise on done/failed. |
 | `workflow_source.go`   | `workflowSource` tagged union (issue ref vs chat transcript) consumed by picker / runner / banner. |
 | `chat_workflow.go`     | `Ctrl+F` dispatcher — snapshots `m.history` into a chat source, gates on busy/empty, opens the picker. |
+| `keymap.go`            | Remappable global shortcuts — `Action` enum, `KeyBinding` parse/stringify, default keymap, `currentKeyMap()` cached accessor. Per-screen keys (kanban `j/k`, modal arrows, Ctrl+D close) stay inline; this only covers the global screen-switch + tab-nav surface. |
+| `config_keybindings.go`| `/config → Keybindings...` sub-picker. Enter on a row arms capture mode; the next non-Esc keypress is persisted to `cfg.Keybindings` and the keymap cache is invalidated so the change takes effect immediately. |
 | `util.go`              | Small helpers (`short`, `humanDuration`, `humanBytes`, `shortCwd`).     |
 | `debug.go`             | `ASK_DEBUG=1` → `/tmp/ask.log`.                                         |
 | `*_test.go`            | Fast, behavior-only tests. See "Test layout" below.                    |
@@ -109,6 +111,8 @@ exercised by the user; code alone won't catch layout regressions.
 | `workflows_run_test.go`    | Step runner — advance, finalise, fail, idempotent finalise, unknown-provider rejection. |
 | `issues_workflow_test.go`  | `f` keybind dispatch on the issues screen — toast / picker / focus-existing-tab. |
 | `chat_workflow_test.go`    | `Ctrl+F` chat-source flow — transcript filter, key uniqueness, prompt assembly, dispatcher gates (busy/empty/no-workflows/workflow-tab), end-to-end picker → spawn. |
+| `keymap_test.go`           | `ParseKeyBinding` / `KeyBinding.String` round-trip, default keymap coverage, load-from-config (unknown/malformed entries skipped, empty-string unbinds), `currentKeyMap` invalidation. |
+| `keymap_dispatch_test.go`  | End-to-end: overridden keymap rewires `tabs.go` tab navigation; `/config → Keybindings` capture persists to disk and re-binding to default deletes the entry. |
 | `util_test.go` / `paths_test.go` | Pure helpers, path completion, frontmatter parsing.       |
 
 ### Testing conventions

--- a/ask_question.go
+++ b/ask_question.go
@@ -422,6 +422,39 @@ func (m model) cursorOnCustom() bool {
 	return m.askCursor == len(m.askQuestions[m.askTab].options)-1
 }
 
+// applyAskPaste routes a bracketed paste into whichever text field
+// the ask modal currently focuses — the note editor (when the user
+// pressed `n`) or the custom-row free-text input. Anywhere else (cursor
+// on a fixed option, confirm tab, no questions) the paste is absorbed
+// because there is no destination; silently dropping is the same
+// behaviour the typed-text branch takes for unmapped contexts.
+func (m model) applyAskPaste(content string) (tea.Model, tea.Cmd) {
+	if content == "" {
+		return m, nil
+	}
+	if m.askTab < 0 || m.askTab >= len(m.askAnswers) {
+		return m, nil
+	}
+	ans := &m.askAnswers[m.askTab]
+	if m.askEditing == askEditNote {
+		ans.note += content
+		return m, nil
+	}
+	if m.cursorOnCustom() {
+		ans.custom += content
+		if m.askQuestions[m.askTab].kind == qPickMany {
+			customIdx := len(m.askQuestions[m.askTab].options) - 1
+			if ans.custom != "" {
+				ans.picks[customIdx] = true
+			} else {
+				delete(ans.picks, customIdx)
+			}
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
 func (m model) handleCustomTyping(msg tea.KeyPressMsg) (bool, tea.Model, tea.Cmd) {
 	ans := &m.askAnswers[m.askTab]
 	customIdx := len(m.askQuestions[m.askTab].options) - 1

--- a/ask_question.go
+++ b/ask_question.go
@@ -422,15 +422,15 @@ func (m model) cursorOnCustom() bool {
 	return m.askCursor == len(m.askQuestions[m.askTab].options)-1
 }
 
-// applyAskPaste routes a bracketed paste into whichever text field
-// the ask modal currently focuses — the note editor (when the user
-// pressed `n`) or the custom-row free-text input. Anywhere else (cursor
-// on a fixed option, confirm tab, no questions) the paste is absorbed
-// because there is no destination; silently dropping is the same
-// behaviour the typed-text branch takes for unmapped contexts.
 func (m model) applyAskPaste(content string) (tea.Model, tea.Cmd) {
 	if content == "" {
 		return m, nil
+	}
+	if m.askConfirmingCancel {
+		return m, nil
+	}
+	if m.askOllamaActive {
+		return m.applyAskOllamaPaste(content)
 	}
 	if m.askTab < 0 || m.askTab >= len(m.askAnswers) {
 		return m, nil

--- a/chat_workflow.go
+++ b/chat_workflow.go
@@ -26,7 +26,7 @@ func (m model) dispatchChatWorkflow() (tea.Model, tea.Cmd) {
 	}
 	items := projectWorkflows(m.cwd)
 	if len(items) == 0 {
-		return m, m.toast.show("no workflows configured · ctrl+w opens the builder")
+		return m, m.toast.show(workflowsBuilderHint())
 	}
 	m = m.openWorkflowPicker(items, source)
 	return m, nil

--- a/config.go
+++ b/config.go
@@ -52,6 +52,14 @@ type askConfig struct {
 	UI       uiConfig     `json:"ui,omitempty"`
 	Memory   memoryConfig `json:"memory,omitempty"`
 
+	// Keybindings overrides the built-in global shortcuts (Ctrl+W
+	// workflows, Ctrl+I issues, …). Stored as action → "ctrl+w" so
+	// users can hand-edit the file without learning a binary format,
+	// and so unknown actions in older builds are skipped instead of
+	// crashing. Only entries that diverge from DefaultKeyMap are
+	// persisted; an empty/missing map means "all defaults."
+	Keybindings map[string]string `json:"keybindings,omitempty"`
+
 	// Projects holds per-project settings keyed by the canonical
 	// absolute path of the project root. Issue-tracking is the first
 	// per-project surface; future per-project knobs (custom slash

--- a/config_keybindings.go
+++ b/config_keybindings.go
@@ -55,6 +55,29 @@ func (m model) updateConfigKeybindingsPicker(msg tea.KeyPressMsg) (tea.Model, te
 		m.configKeybindingsCapturing = true
 		m.configKeybindingsError = ""
 		return m, nil
+	case msg.Mod == 0 && msg.Code == 'r':
+		// Reset the focused row to its compiled-in default. Without
+		// this, a user who accidentally captured the wrong key has no
+		// recovery path from inside the picker — they would have to
+		// remember the default key to capture it back, or hand-edit
+		// ~/.config/ask/ask.json. 'r' is safe to overload here because
+		// row-navigation mode treats every other key (besides ↑↓ Enter
+		// Esc Ctrl+C) as a no-op; capture mode is the only place where
+		// 'r' could be recorded *as* a binding, and we don't shadow
+		// that path.
+		if m.configKeybindingsCursor < 0 || m.configKeybindingsCursor >= len(actionMeta) {
+			return m, nil
+		}
+		action := actionMeta[m.configKeybindingsCursor].Action
+		def := defaultKeyBindings[action]
+		if err := persistKeyBinding(action, def); err != nil {
+			debugLog("persistKeyBinding %s reset err: %v", action, err)
+			m.configKeybindingsError = "reset failed: " + err.Error()
+			return m, nil
+		}
+		invalidateKeyMapCache()
+		m.configKeybindingsError = ""
+		return m, nil
 	}
 	return m, nil
 }
@@ -164,7 +187,7 @@ func (m model) viewConfigKeybindingsPicker() string {
 
 	body = append(body,
 		"",
-		themePickerHelpStyle.Render(truncateForRow("↑↓ navigate · enter rebind · esc close", innerW)),
+		themePickerHelpStyle.Render(truncateForRow("↑↓ navigate · enter rebind · r reset · esc close", innerW)),
 	)
 
 	return themePickerBoxStyle.Render(strings.Join(body, "\n"))

--- a/config_keybindings.go
+++ b/config_keybindings.go
@@ -161,32 +161,29 @@ func persistKeyBinding(action Action, binding KeyBinding) error {
 }
 
 // viewConfigKeybindingsPicker mirrors the memory picker's chrome —
-// title, table of rows, help line — so the /config aesthetic stays
-// consistent. Capture mode swaps the body for a prompt.
+// title, grouped rows, help line — so the /config aesthetic stays
+// consistent. Capture mode swaps the body for a prompt. Groups carry
+// an inline heading and have a blank row between them; cursor math
+// still walks the flat actionMeta so Up/Down skip the headings
+// without special-casing.
 func (m model) viewConfigKeybindingsPicker() string {
 	km := currentKeyMap()
 	rows := make([][2]string, 0, len(actionMeta))
 	for _, am := range actionMeta {
-		label := am.Label
-		binding := km.Binding(am.Action).String()
-		if binding == "" {
-			binding = "(unbound)"
-		}
-		rows = append(rows, [2]string{label, binding})
+		rows = append(rows, [2]string{am.Label, displayBinding(km.Binding(am.Action))})
 	}
 	innerW := keybindingsPickerInnerWidth(m.width, rows)
 
 	var capturePrompt string
 	if m.configKeybindingsCapturing && m.configKeybindingsCursor >= 0 && m.configKeybindingsCursor < len(actionMeta) {
-		current := km.Binding(actionMeta[m.configKeybindingsCursor].Action).String()
-		if current == "" {
-			current = "(unbound)"
-		}
 		capturePrompt = "Press the new key combination for " +
 			actionMeta[m.configKeybindingsCursor].Label +
-			" (currently " + current + ")."
+			" (currently " + displayBinding(km.Binding(actionMeta[m.configKeybindingsCursor].Action)) + ")."
 	}
 	const helpFooter = "↑↓ navigate · enter rebind · r reset · u unbind · esc close"
+	for _, g := range actionGroups {
+		innerW = keybindingsExpandInnerWidth(m.width, innerW, g.Heading)
+	}
 	for _, line := range []string{capturePrompt, helpFooter} {
 		if line == "" {
 			continue
@@ -204,8 +201,17 @@ func (m model) viewConfigKeybindingsPicker() string {
 			configHelpStyle.Render(truncateForRow("esc cancels without saving.", innerW)),
 		)
 	} else {
-		for i, r := range rows {
-			body = append(body, renderKeybindingPickerRow(r[0], r[1], innerW, i == m.configKeybindingsCursor))
+		flatIdx := 0
+		for gi, g := range actionGroups {
+			if gi > 0 {
+				body = append(body, "")
+			}
+			body = append(body, configKeybindingsGroupHeadingStyle().Render(truncateForRow(g.Heading, innerW)))
+			for _, item := range g.Items {
+				binding := displayBinding(km.Binding(item.Action))
+				body = append(body, renderKeybindingPickerRow(item.Label, binding, innerW, flatIdx == m.configKeybindingsCursor))
+				flatIdx++
+			}
 		}
 	}
 
@@ -219,6 +225,24 @@ func (m model) viewConfigKeybindingsPicker() string {
 	)
 
 	return themePickerBoxStyle.Render(strings.Join(body, "\n"))
+}
+
+// displayBinding stringifies a binding for picker rows. The zero-value
+// (unbound) binding stringifies to "" — we substitute "(unbound)" so
+// the row stays legible; every other binding round-trips through its
+// canonical String() form.
+func displayBinding(b KeyBinding) string {
+	if s := b.String(); s != "" {
+		return s
+	}
+	return "(unbound)"
+}
+
+// configKeybindingsGroupHeadingStyle is the inline heading style for
+// group rows in the /config keybindings picker. Bold over the dim
+// foreground gives it visual lift without competing with the title.
+func configKeybindingsGroupHeadingStyle() lipgloss.Style {
+	return dimStyle.Bold(true)
 }
 
 func renderKeybindingPickerRow(label, binding string, width int, selected bool) string {

--- a/config_keybindings.go
+++ b/config_keybindings.go
@@ -78,6 +78,23 @@ func (m model) updateConfigKeybindingsPicker(msg tea.KeyPressMsg) (tea.Model, te
 		invalidateKeyMapCache()
 		m.configKeybindingsError = ""
 		return m, nil
+	case msg.Mod == 0 && msg.Code == 'u':
+		// Unbind the focused row — persists the zero-value KeyBinding,
+		// which Matches() correctly treats as "never matches" so the
+		// action is silently disabled. Peer of 'r'; same overload
+		// argument applies (row-nav mode doesn't capture characters).
+		if m.configKeybindingsCursor < 0 || m.configKeybindingsCursor >= len(actionMeta) {
+			return m, nil
+		}
+		action := actionMeta[m.configKeybindingsCursor].Action
+		if err := persistKeyBinding(action, KeyBinding{}); err != nil {
+			debugLog("persistKeyBinding %s unbind err: %v", action, err)
+			m.configKeybindingsError = "unbind failed: " + err.Error()
+			return m, nil
+		}
+		invalidateKeyMapCache()
+		m.configKeybindingsError = ""
+		return m, nil
 	}
 	return m, nil
 }
@@ -159,19 +176,30 @@ func (m model) viewConfigKeybindingsPicker() string {
 	}
 	innerW := keybindingsPickerInnerWidth(m.width, rows)
 
-	title := themePickerTitleStyle.Render(truncateForRow("Keybindings", innerW))
-	body := []string{title, ""}
-
+	var capturePrompt string
 	if m.configKeybindingsCapturing && m.configKeybindingsCursor >= 0 && m.configKeybindingsCursor < len(actionMeta) {
 		current := km.Binding(actionMeta[m.configKeybindingsCursor].Action).String()
 		if current == "" {
 			current = "(unbound)"
 		}
-		prompt := "Press the new key combination for " +
+		capturePrompt = "Press the new key combination for " +
 			actionMeta[m.configKeybindingsCursor].Label +
 			" (currently " + current + ")."
+	}
+	const helpFooter = "↑↓ navigate · enter rebind · r reset · u unbind · esc close"
+	for _, line := range []string{capturePrompt, helpFooter} {
+		if line == "" {
+			continue
+		}
+		innerW = keybindingsExpandInnerWidth(m.width, innerW, line)
+	}
+
+	title := themePickerTitleStyle.Render(truncateForRow("Keybindings", innerW))
+	body := []string{title, ""}
+
+	if capturePrompt != "" {
 		body = append(body,
-			configHelpStyle.Render(truncateForRow(prompt, innerW)),
+			configHelpStyle.Render(truncateForRow(capturePrompt, innerW)),
 			"",
 			configHelpStyle.Render(truncateForRow("esc cancels without saving.", innerW)),
 		)
@@ -187,7 +215,7 @@ func (m model) viewConfigKeybindingsPicker() string {
 
 	body = append(body,
 		"",
-		themePickerHelpStyle.Render(truncateForRow("↑↓ navigate · enter rebind · r reset · esc close", innerW)),
+		themePickerHelpStyle.Render(truncateForRow(helpFooter, innerW)),
 	)
 
 	return themePickerBoxStyle.Render(strings.Join(body, "\n"))
@@ -217,6 +245,27 @@ func renderKeybindingPickerRow(label, binding string, width int, selected bool) 
 	}
 	line := label + strings.Repeat(" ", pad) + configKeyDimStyle.Render(binding)
 	return padRight(line, width)
+}
+
+// keybindingsExpandInnerWidth grows innerW to fit a single content line
+// (capture prompt, help footer, etc.) that may exceed the row-list
+// width, capped at the screen width minus the box frame. Mirrors the
+// growth pattern viewConfigMemoryFieldInput uses for its field editor.
+func keybindingsExpandInnerWidth(screenWidth, current int, line string) int {
+	want := lipgloss.Width(line)
+	if want < current {
+		return current
+	}
+	if screenWidth > 0 {
+		maxInnerW := screenWidth - themePickerBoxStyle.GetHorizontalFrameSize()
+		if maxInnerW < 1 {
+			maxInnerW = 1
+		}
+		if want > maxInnerW {
+			want = maxInnerW
+		}
+	}
+	return want
 }
 
 func keybindingsPickerInnerWidth(screenWidth int, rows [][2]string) int {

--- a/config_keybindings.go
+++ b/config_keybindings.go
@@ -79,10 +79,7 @@ func (m model) updateConfigKeybindingsCapture(msg tea.KeyPressMsg) (tea.Model, t
 		m.configKeybindingsCapturing = false
 		return m, nil
 	}
-	// Strip lock-state modifiers the same way the top-level dispatcher
-	// does — they're reported on every press under Kitty and would
-	// silently break Mod==0 gates if persisted.
-	mod := msg.Mod &^ (tea.ModCapsLock | tea.ModNumLock | tea.ModScrollLock)
+	mod := stripKeyLockModifiers(msg.Mod)
 	binding := KeyBinding{Mod: mod, Code: msg.Code}
 	if binding.String() == "" {
 		m.configKeybindingsError = "could not record that key — try a different combination"
@@ -129,7 +126,6 @@ func persistKeyBinding(action Action, binding KeyBinding) error {
 func (m model) viewConfigKeybindingsPicker() string {
 	km := currentKeyMap()
 	rows := make([][2]string, 0, len(actionMeta))
-	innerW := 0
 	for _, am := range actionMeta {
 		label := am.Label
 		binding := km.Binding(am.Action).String()
@@ -137,15 +133,10 @@ func (m model) viewConfigKeybindingsPicker() string {
 			binding = "(unbound)"
 		}
 		rows = append(rows, [2]string{label, binding})
-		if w := lipgloss.Width(label) + lipgloss.Width(binding) + 4; w > innerW {
-			innerW = w
-		}
 	}
-	if innerW < 36 {
-		innerW = 36
-	}
+	innerW := keybindingsPickerInnerWidth(m.width, rows)
 
-	title := themePickerTitleStyle.Render("Keybindings")
+	title := themePickerTitleStyle.Render(truncateForRow("Keybindings", innerW))
 	body := []string{title, ""}
 
 	if m.configKeybindingsCapturing && m.configKeybindingsCursor >= 0 && m.configKeybindingsCursor < len(actionMeta) {
@@ -153,13 +144,13 @@ func (m model) viewConfigKeybindingsPicker() string {
 		if current == "" {
 			current = "(unbound)"
 		}
+		prompt := "Press the new key combination for " +
+			actionMeta[m.configKeybindingsCursor].Label +
+			" (currently " + current + ")."
 		body = append(body,
-			configHelpStyle.Render(
-				"Press the new key combination for "+
-					actionMeta[m.configKeybindingsCursor].Label+
-					" (currently "+current+")."),
+			configHelpStyle.Render(truncateForRow(prompt, innerW)),
 			"",
-			configHelpStyle.Render("esc cancels without saving."),
+			configHelpStyle.Render(truncateForRow("esc cancels without saving.", innerW)),
 		)
 	} else {
 		for i, r := range rows {
@@ -168,23 +159,31 @@ func (m model) viewConfigKeybindingsPicker() string {
 	}
 
 	if m.configKeybindingsError != "" {
-		body = append(body, "", themePickerHelpStyle.Render("✗ "+m.configKeybindingsError))
+		body = append(body, "", themePickerHelpStyle.Render(truncateForRow("✗ "+m.configKeybindingsError, innerW)))
 	}
 
 	body = append(body,
 		"",
-		themePickerHelpStyle.Render("↑↓ navigate · enter rebind · esc close"),
+		themePickerHelpStyle.Render(truncateForRow("↑↓ navigate · enter rebind · esc close", innerW)),
 	)
 
 	return themePickerBoxStyle.Render(strings.Join(body, "\n"))
 }
 
 func renderKeybindingPickerRow(label, binding string, width int, selected bool) string {
+	if width < 1 {
+		return ""
+	}
+	label, binding = fitKeybindingPickerRowParts(label, binding, width)
 	labelW := lipgloss.Width(label)
 	bindingW := lipgloss.Width(binding)
 	pad := width - labelW - bindingW
-	if pad < 1 {
-		pad = 1
+	minPad := 0
+	if binding != "" {
+		minPad = 1
+	}
+	if pad < minPad {
+		pad = minPad
 	}
 	if selected {
 		plain := label + strings.Repeat(" ", pad) + binding
@@ -195,4 +194,44 @@ func renderKeybindingPickerRow(label, binding string, width int, selected bool) 
 	}
 	line := label + strings.Repeat(" ", pad) + configKeyDimStyle.Render(binding)
 	return padRight(line, width)
+}
+
+func keybindingsPickerInnerWidth(screenWidth int, rows [][2]string) int {
+	innerW := 0
+	for _, r := range rows {
+		if w := lipgloss.Width(r[0]) + lipgloss.Width(r[1]) + 4; w > innerW {
+			innerW = w
+		}
+	}
+	if innerW < 36 {
+		innerW = 36
+	}
+	if screenWidth > 0 {
+		if maxInnerW := screenWidth - themePickerBoxStyle.GetHorizontalFrameSize(); maxInnerW < innerW {
+			if maxInnerW < 1 {
+				maxInnerW = 1
+			}
+			innerW = maxInnerW
+		}
+	}
+	return innerW
+}
+
+func fitKeybindingPickerRowParts(label, binding string, width int) (string, string) {
+	if width < 1 {
+		return "", ""
+	}
+	labelW := lipgloss.Width(label)
+	bindingW := lipgloss.Width(binding)
+	if labelW+bindingW+1 <= width {
+		return label, binding
+	}
+	bindingLimit := min(bindingW, max(1, width/2))
+	binding = truncateForRow(binding, bindingLimit)
+	bindingW = lipgloss.Width(binding)
+	labelLimit := width - bindingW - 1
+	if labelLimit < 1 {
+		return truncateForRow(label, width), ""
+	}
+	return truncateForRow(label, labelLimit), binding
 }

--- a/config_keybindings.go
+++ b/config_keybindings.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	lipgloss "charm.land/lipgloss/v2"
+)
+
+// openConfigKeybindingsPicker shows the Keybindings submenu. Cursor
+// lands on the first action; capture flag starts off so the user is
+// navigating rows. Writes happen on capture-mode commit (Enter on a
+// row → capture mode, next non-Esc keypress → save), matching the
+// "writes through on Enter" pattern used by the memory picker.
+func (m model) openConfigKeybindingsPicker() model {
+	m.configKeybindingsPickerActive = true
+	m.configKeybindingsCursor = 0
+	m.configKeybindingsCapturing = false
+	m.configKeybindingsError = ""
+	return m
+}
+
+func (m model) closeConfigKeybindingsPicker() model {
+	m.configKeybindingsPickerActive = false
+	m.configKeybindingsCursor = 0
+	m.configKeybindingsCapturing = false
+	m.configKeybindingsError = ""
+	return m
+}
+
+func (m model) updateConfigKeybindingsPicker(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if m.configKeybindingsCapturing {
+		return m.updateConfigKeybindingsCapture(msg)
+	}
+	switch {
+	case msg.Mod == tea.ModCtrl && msg.Code == 'c', msg.Code == tea.KeyEsc:
+		m = m.closeConfigKeybindingsPicker()
+		return m, nil
+	case msg.Code == tea.KeyUp:
+		if m.configKeybindingsCursor > 0 {
+			m.configKeybindingsCursor--
+		}
+		m.configKeybindingsError = ""
+		return m, nil
+	case msg.Code == tea.KeyDown:
+		if m.configKeybindingsCursor < len(actionMeta)-1 {
+			m.configKeybindingsCursor++
+		}
+		m.configKeybindingsError = ""
+		return m, nil
+	case msg.Code == tea.KeyEnter:
+		if m.configKeybindingsCursor < 0 || m.configKeybindingsCursor >= len(actionMeta) {
+			return m, nil
+		}
+		m.configKeybindingsCapturing = true
+		m.configKeybindingsError = ""
+		return m, nil
+	}
+	return m, nil
+}
+
+// updateConfigKeybindingsCapture eats the next keypress and records it
+// as the binding for the row under the cursor. Esc cancels without
+// persisting; Ctrl+C exits the picker entirely (matches other modals).
+// All other keys — including Enter, Tab, Space, and the function keys
+// — are valid bindings, so we don't filter further; the user gets
+// whatever they pressed.
+func (m model) updateConfigKeybindingsCapture(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if msg.Code == tea.KeyEsc {
+		m.configKeybindingsCapturing = false
+		m.configKeybindingsError = ""
+		return m, nil
+	}
+	if msg.Mod == tea.ModCtrl && msg.Code == 'c' {
+		m = m.closeConfigKeybindingsPicker()
+		return m, nil
+	}
+	if m.configKeybindingsCursor < 0 || m.configKeybindingsCursor >= len(actionMeta) {
+		m.configKeybindingsCapturing = false
+		return m, nil
+	}
+	// Strip lock-state modifiers the same way the top-level dispatcher
+	// does — they're reported on every press under Kitty and would
+	// silently break Mod==0 gates if persisted.
+	mod := msg.Mod &^ (tea.ModCapsLock | tea.ModNumLock | tea.ModScrollLock)
+	binding := KeyBinding{Mod: mod, Code: msg.Code}
+	if binding.String() == "" {
+		m.configKeybindingsError = "could not record that key — try a different combination"
+		return m, nil
+	}
+	action := actionMeta[m.configKeybindingsCursor].Action
+	if err := persistKeyBinding(action, binding); err != nil {
+		debugLog("persistKeyBinding %s err: %v", action, err)
+		m.configKeybindingsError = "save failed: " + err.Error()
+		return m, nil
+	}
+	invalidateKeyMapCache()
+	m.configKeybindingsCapturing = false
+	m.configKeybindingsError = ""
+	return m, nil
+}
+
+// persistKeyBinding loads the current config, writes the new binding
+// (or omits it when it matches the default), and saves. Wrapped in
+// withConfigLock so concurrent /config edits across goroutines stay
+// safe — same discipline as the other config writers.
+func persistKeyBinding(action Action, binding KeyBinding) error {
+	return withConfigLock(func() error {
+		cfg, _ := loadConfig()
+		if cfg.Keybindings == nil {
+			cfg.Keybindings = map[string]string{}
+		}
+		def, hasDefault := defaultKeyBindings[action]
+		if hasDefault && binding == def {
+			delete(cfg.Keybindings, string(action))
+		} else {
+			cfg.Keybindings[string(action)] = binding.String()
+		}
+		if len(cfg.Keybindings) == 0 {
+			cfg.Keybindings = nil
+		}
+		return saveConfig(cfg)
+	})
+}
+
+// viewConfigKeybindingsPicker mirrors the memory picker's chrome —
+// title, table of rows, help line — so the /config aesthetic stays
+// consistent. Capture mode swaps the body for a prompt.
+func (m model) viewConfigKeybindingsPicker() string {
+	km := currentKeyMap()
+	rows := make([][2]string, 0, len(actionMeta))
+	innerW := 0
+	for _, am := range actionMeta {
+		label := am.Label
+		binding := km.Binding(am.Action).String()
+		if binding == "" {
+			binding = "(unbound)"
+		}
+		rows = append(rows, [2]string{label, binding})
+		if w := lipgloss.Width(label) + lipgloss.Width(binding) + 4; w > innerW {
+			innerW = w
+		}
+	}
+	if innerW < 36 {
+		innerW = 36
+	}
+
+	title := themePickerTitleStyle.Render("Keybindings")
+	body := []string{title, ""}
+
+	if m.configKeybindingsCapturing && m.configKeybindingsCursor >= 0 && m.configKeybindingsCursor < len(actionMeta) {
+		current := km.Binding(actionMeta[m.configKeybindingsCursor].Action).String()
+		if current == "" {
+			current = "(unbound)"
+		}
+		body = append(body,
+			configHelpStyle.Render(
+				"Press the new key combination for "+
+					actionMeta[m.configKeybindingsCursor].Label+
+					" (currently "+current+")."),
+			"",
+			configHelpStyle.Render("esc cancels without saving."),
+		)
+	} else {
+		for i, r := range rows {
+			body = append(body, renderKeybindingPickerRow(r[0], r[1], innerW, i == m.configKeybindingsCursor))
+		}
+	}
+
+	if m.configKeybindingsError != "" {
+		body = append(body, "", themePickerHelpStyle.Render("✗ "+m.configKeybindingsError))
+	}
+
+	body = append(body,
+		"",
+		themePickerHelpStyle.Render("↑↓ navigate · enter rebind · esc close"),
+	)
+
+	return themePickerBoxStyle.Render(strings.Join(body, "\n"))
+}
+
+func renderKeybindingPickerRow(label, binding string, width int, selected bool) string {
+	labelW := lipgloss.Width(label)
+	bindingW := lipgloss.Width(binding)
+	pad := width - labelW - bindingW
+	if pad < 1 {
+		pad = 1
+	}
+	if selected {
+		plain := label + strings.Repeat(" ", pad) + binding
+		if w := lipgloss.Width(plain); w < width {
+			plain += strings.Repeat(" ", width-w)
+		}
+		return configSelectedRowStyle.Render(plain)
+	}
+	line := label + strings.Repeat(" ", pad) + configKeyDimStyle.Render(binding)
+	return padRight(line, width)
+}

--- a/config_modal.go
+++ b/config_modal.go
@@ -85,6 +85,7 @@ func (m model) globalConfigItems() []configItem {
 		{"Theme", m.themeName, "theme"},
 		{"Default Provider", provName, "provider"},
 		{"Memory...", mem, "memory"},
+		{"Keybindings...", "", "keybindings"},
 	}
 }
 
@@ -142,6 +143,9 @@ func (m model) updateConfigModal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 	if m.configMemoryPickerActive {
 		return m.updateConfigMemoryPicker(msg)
+	}
+	if m.configKeybindingsPickerActive {
+		return m.updateConfigKeybindingsPicker(msg)
 	}
 	// New layered sub-pickers: global (the existing flat list, now
 	// one layer deeper) and project (per-cwd issues config). Both
@@ -347,6 +351,9 @@ func (m model) handleGlobalConfigEnter(itemID string) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "memory":
 		m = m.openConfigMemoryPicker()
+		return m, nil
+	case "keybindings":
+		m = m.openConfigKeybindingsPicker()
 		return m, nil
 	}
 	return m, nil

--- a/issues.go
+++ b/issues.go
@@ -1023,9 +1023,11 @@ func (prsScreen) view(m model) string {
 
 func updateIssueScreenKey(m model, msg tea.KeyPressMsg, screen screenID) (model, tea.Cmd, bool) {
 	s := m.ensureIssueState(screen)
-	// Ctrl+D closes the current tab from any screen — keep parity with
-	// askScreen so the user isn't trapped in issues.
-	if msg.Mod == tea.ModCtrl && msg.Code == 'd' {
+	km := currentKeyMap()
+	// ActionTabClose (default Ctrl+D) closes the current tab from any
+	// screen — keep parity with askScreen so the user isn't trapped in
+	// issues.
+	if km.Matches(ActionTabClose, msg) {
 		return m, closeTabCmd(m.id), true
 	}
 	// Workflow picker overlay owns the keyboard when it's open. It
@@ -1053,14 +1055,15 @@ func updateIssueScreenKey(m model, msg tea.KeyPressMsg, screen screenID) (model,
 	}
 	m.exitArmed = false
 	// Loading and error states own the screen until they resolve. While
-	// loading, Ctrl+R is honoured (cancels the in-flight + dispatches a
-	// fresh load); every other key is consumed silently so an early
-	// keypress can't fall through and mutate the (still-empty) list.
-	// While in error state, Enter/Esc dismiss back to ask, Ctrl+R is
-	// the retry affordance (clears the error + dispatches a fresh
-	// load), and every other key is consumed so a stray press can't
-	// whisk the user past the failure without acknowledgment.
-	isCtrlR := msg.Mod == tea.ModCtrl && msg.Code == 'r'
+	// loading, ActionReload (default Ctrl+R) is honoured (cancels the
+	// in-flight + dispatches a fresh load); every other key is consumed
+	// silently so an early keypress can't fall through and mutate the
+	// (still-empty) list. While in error state, Enter/Esc dismiss back
+	// to ask, ActionReload is the retry affordance (clears the error +
+	// dispatches a fresh load), and every other key is consumed so a
+	// stray press can't whisk the user past the failure without
+	// acknowledgment.
+	isCtrlR := km.Matches(ActionReload, msg)
 	if s.loading {
 		if isCtrlR {
 			return m, s.reloadCurrentQuery(), true
@@ -1331,7 +1334,7 @@ func (m model) dispatchIssueWorkflow(screen screenID) (model, tea.Cmd, bool) {
 	}
 	items := projectWorkflows(m.cwd)
 	if len(items) == 0 {
-		return m, m.toast.show("no workflows configured · ctrl+w opens the builder"), true
+		return m, m.toast.show(workflowsBuilderHint()), true
 	}
 	m = m.openWorkflowPicker(items, issueWorkflowSource(ref))
 	return m, nil, true
@@ -1700,16 +1703,25 @@ func (v *issueDetailView) header(s *issuesState) string {
 }
 
 func (v *issueDetailView) hint() string {
-	return dimStyle.Render(
-		"↑/↓ scroll · pgup/pgdn page · f run workflow · esc/backspace back · ctrl+o back to ask",
-	)
+	return dimStyle.Render(joinHintClauses(
+		"↑/↓ scroll",
+		"pgup/pgdn page",
+		"f run workflow",
+		"esc/backspace back",
+		keyClause(ActionScreenAsk, "back to ask"),
+	))
 }
 
 func (v *issueDetailView) hintFor(s *issuesState) string {
 	if s != nil && s.screen == screenPRs {
-		return dimStyle.Render(
-			"↑/↓ scroll · pgup/pgdn page · m merge · f run workflow · esc/backspace back · ctrl+o back to ask",
-		)
+		return dimStyle.Render(joinHintClauses(
+			"↑/↓ scroll",
+			"pgup/pgdn page",
+			"m merge",
+			"f run workflow",
+			"esc/backspace back",
+			keyClause(ActionScreenAsk, "back to ask"),
+		))
 	}
 	return v.hint()
 }
@@ -2252,19 +2264,32 @@ func (v *kanbanIssueView) hintFor(s *issuesState) string {
 	if v.carry.active {
 		return dimStyle.Render("space drop · ←/→/tab change column · esc cancel · other keys disabled while carrying")
 	}
-	if s != nil && s.provider != nil && !s.provider.SupportsCarry() {
-		if _, ok := s.provider.(IssueMerger); ok {
-			return dimStyle.Render(
-				"↑/↓ row · pgup/pgdn page · ←/→/tab column · enter open · m merge · f run workflow · / search · ctrl+r reload · ctrl+o back",
-			)
-		}
-		return dimStyle.Render(
-			"↑/↓ row · pgup/pgdn page · ←/→/tab column · enter open · f run workflow · / search · ctrl+r reload · ctrl+o back",
-		)
+	commonHead := []string{
+		"↑/↓ row",
+		"pgup/pgdn page",
+		"←/→/tab column",
+		"enter open",
 	}
-	return dimStyle.Render(
-		"↑/↓ row · pgup/pgdn page · ←/→/tab column · enter open · space pick up · f run workflow · / search · ctrl+r reload · ctrl+o back",
-	)
+	commonTail := []string{
+		"f run workflow",
+		"/ search",
+		keyClause(ActionReload, "reload"),
+		keyClause(ActionScreenAsk, "back"),
+	}
+	if s != nil && s.provider != nil && !s.provider.SupportsCarry() {
+		mid := []string{}
+		if _, ok := s.provider.(IssueMerger); ok {
+			mid = append(mid, "m merge")
+		}
+		parts := append([]string{}, commonHead...)
+		parts = append(parts, mid...)
+		parts = append(parts, commonTail...)
+		return dimStyle.Render(joinHintClauses(parts...))
+	}
+	parts := append([]string{}, commonHead...)
+	parts = append(parts, "space pick up")
+	parts = append(parts, commonTail...)
+	return dimStyle.Render(joinHintClauses(parts...))
 }
 
 func (v *kanbanIssueView) hint() string {

--- a/keymap.go
+++ b/keymap.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"unicode"
+	"unicode/utf8"
 
 	tea "charm.land/bubbletea/v2"
 )
@@ -12,10 +14,10 @@ import (
 // keys (kanban j/k, workflow builder Tab, modal arrow keys) are
 // deliberately *not* part of this surface — they stay inline in their
 // own handlers. Adding a new global shortcut requires four edits:
-//   1. New const here.
-//   2. defaultKeyBindings entry.
-//   3. actionMeta entry (label shown in /config).
-//   4. KeyMap.Matches lookup at the dispatch site.
+//  1. New const here.
+//  2. defaultKeyBindings entry.
+//  3. actionMeta entry (label shown in /config).
+//  4. KeyMap.Matches lookup at the dispatch site.
 type Action string
 
 // Ctrl+D close-tab and Ctrl+C are deliberately *not* in this list.
@@ -45,6 +47,8 @@ type KeyBinding struct {
 	Code rune
 }
 
+const supportedKeyBindingMods = tea.ModCtrl | tea.ModAlt | tea.ModShift | tea.ModMeta | tea.ModHyper | tea.ModSuper
+
 func (b KeyBinding) Matches(msg tea.KeyPressMsg) bool {
 	if b.Code == 0 {
 		return false
@@ -54,6 +58,9 @@ func (b KeyBinding) Matches(msg tea.KeyPressMsg) bool {
 
 func (b KeyBinding) String() string {
 	if b.Code == 0 {
+		return ""
+	}
+	if b.Mod&^supportedKeyBindingMods != 0 {
 		return ""
 	}
 	var parts []string
@@ -66,7 +73,20 @@ func (b KeyBinding) String() string {
 	if b.Mod&tea.ModShift != 0 {
 		parts = append(parts, "shift")
 	}
-	parts = append(parts, keyCodeName(b.Code))
+	if b.Mod&tea.ModMeta != 0 {
+		parts = append(parts, "meta")
+	}
+	if b.Mod&tea.ModHyper != 0 {
+		parts = append(parts, "hyper")
+	}
+	if b.Mod&tea.ModSuper != 0 {
+		parts = append(parts, "super")
+	}
+	key := keyCodeName(b.Code)
+	if key == "" {
+		return ""
+	}
+	parts = append(parts, key)
 	return strings.Join(parts, "+")
 }
 
@@ -76,6 +96,9 @@ func (b KeyBinding) String() string {
 func keyCodeName(c rune) string {
 	if n, ok := codeToName[c]; ok {
 		return n
+	}
+	if !utf8.ValidRune(c) || !unicode.IsPrint(c) {
+		return ""
 	}
 	return strings.ToLower(string(c))
 }
@@ -94,6 +117,7 @@ var namedKeyCodes = map[string]rune{
 	"escape":    tea.KeyEsc,
 	"tab":       tea.KeyTab,
 	"space":     tea.KeySpace,
+	"plus":      '+',
 	"home":      tea.KeyHome,
 	"end":       tea.KeyEnd,
 	"pgup":      tea.KeyPgUp,
@@ -118,6 +142,7 @@ var codeToName = map[rune]string{
 	tea.KeyEsc:       "esc",
 	tea.KeyTab:       "tab",
 	tea.KeySpace:     "space",
+	'+':              "plus",
 	tea.KeyHome:      "home",
 	tea.KeyEnd:       "end",
 	tea.KeyPgUp:      "pgup",
@@ -146,10 +171,16 @@ func ParseKeyBinding(s string) (KeyBinding, error) {
 		switch p {
 		case "ctrl", "control":
 			mod |= tea.ModCtrl
-		case "alt", "opt", "option", "meta":
+		case "alt", "opt", "option":
 			mod |= tea.ModAlt
 		case "shift":
 			mod |= tea.ModShift
+		case "meta":
+			mod |= tea.ModMeta
+		case "hyper":
+			mod |= tea.ModHyper
+		case "super":
+			mod |= tea.ModSuper
 		default:
 			if i != len(parts)-1 {
 				return KeyBinding{}, fmt.Errorf("unknown modifier %q in %q", p, s)
@@ -165,6 +196,9 @@ func ParseKeyBinding(s string) (KeyBinding, error) {
 	}
 	rs := []rune(key)
 	if len(rs) != 1 {
+		return KeyBinding{}, fmt.Errorf("unknown key %q in %q", key, s)
+	}
+	if rs[0] == 0 || !unicode.IsPrint(rs[0]) {
 		return KeyBinding{}, fmt.Errorf("unknown key %q in %q", key, s)
 	}
 	return KeyBinding{Mod: mod, Code: rs[0]}, nil
@@ -194,6 +228,15 @@ var defaultKeyBindings = map[Action]KeyBinding{
 	ActionTabPrev:         {Mod: tea.ModCtrl, Code: tea.KeyLeft},
 	ActionTabNext:         {Mod: tea.ModCtrl, Code: tea.KeyRight},
 	ActionAppSuspend:      {Mod: tea.ModCtrl, Code: 'z'},
+}
+
+func init() {
+	for i := 1; i <= 63; i++ {
+		name := fmt.Sprintf("f%d", i)
+		code := tea.KeyF1 + rune(i-1)
+		namedKeyCodes[name] = code
+		codeToName[code] = name
+	}
 }
 
 // Matches is the dispatch-site lookup. Missing actions fall back to
@@ -288,6 +331,15 @@ var (
 	keyMapCache KeyMap
 )
 
+func stripKeyLockModifiers(mod tea.KeyMod) tea.KeyMod {
+	return mod &^ (tea.ModCapsLock | tea.ModNumLock | tea.ModScrollLock)
+}
+
+func normalizeKeyPressMsg(msg tea.KeyPressMsg) tea.KeyPressMsg {
+	msg.Mod = stripKeyLockModifiers(msg.Mod)
+	return msg
+}
+
 // currentKeyMap returns the process-wide keymap, loading from
 // ~/.config/ask/ask.json on first call. Safe for concurrent use.
 func currentKeyMap() KeyMap {
@@ -297,13 +349,10 @@ func currentKeyMap() KeyMap {
 	if km != nil {
 		return km
 	}
-	cfg, _ := loadConfig()
-	resolved := LoadKeyMapFromConfig(cfg.Keybindings)
 	keyMapMu.Lock()
-	// Re-check under write lock so two racing first-callers don't both
-	// load — whoever got the lock second still observes the same map.
 	if keyMapCache == nil {
-		keyMapCache = resolved
+		cfg, _ := loadConfig()
+		keyMapCache = LoadKeyMapFromConfig(cfg.Keybindings)
 	}
 	km = keyMapCache
 	keyMapMu.Unlock()

--- a/keymap.go
+++ b/keymap.go
@@ -1,0 +1,329 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// Action identifies a remappable global shortcut. Per-screen navigation
+// keys (kanban j/k, workflow builder Tab, modal arrow keys) are
+// deliberately *not* part of this surface — they stay inline in their
+// own handlers. Adding a new global shortcut requires four edits:
+//   1. New const here.
+//   2. defaultKeyBindings entry.
+//   3. actionMeta entry (label shown in /config).
+//   4. KeyMap.Matches lookup at the dispatch site.
+type Action string
+
+// Ctrl+D close-tab and Ctrl+C are deliberately *not* in this list.
+// They're universal escape hatches every modal handler needs to honour
+// (11 sites today), so keeping them inline avoids both the broad
+// refactor and the risk of a misconfigured keymap leaving the user
+// with no way out of a modal. Same for j/k/arrow navigation inside
+// the kanban / workflow builder / pickers.
+const (
+	ActionScreenIssues    Action = "screen.issues"
+	ActionScreenPRs       Action = "screen.prs"
+	ActionScreenWorkflows Action = "screen.workflows"
+	ActionScreenAsk       Action = "screen.ask"
+	ActionProviderSwitch  Action = "provider.switch"
+	ActionChatWorkflow    Action = "chat.workflow"
+	ActionTabNew          Action = "tab.new"
+	ActionTabPrev         Action = "tab.prev"
+	ActionTabNext         Action = "tab.next"
+	ActionAppSuspend      Action = "app.suspend"
+)
+
+// KeyBinding is a parsed Mod+Code pair. The zero value (Mod==0,
+// Code==0) is "unbound" — Matches returns false, String returns "".
+// Setting an action to the zero value in config disables it.
+type KeyBinding struct {
+	Mod  tea.KeyMod
+	Code rune
+}
+
+func (b KeyBinding) Matches(msg tea.KeyPressMsg) bool {
+	if b.Code == 0 {
+		return false
+	}
+	return msg.Mod == b.Mod && msg.Code == b.Code
+}
+
+func (b KeyBinding) String() string {
+	if b.Code == 0 {
+		return ""
+	}
+	var parts []string
+	if b.Mod&tea.ModCtrl != 0 {
+		parts = append(parts, "ctrl")
+	}
+	if b.Mod&tea.ModAlt != 0 {
+		parts = append(parts, "alt")
+	}
+	if b.Mod&tea.ModShift != 0 {
+		parts = append(parts, "shift")
+	}
+	parts = append(parts, keyCodeName(b.Code))
+	return strings.Join(parts, "+")
+}
+
+// keyCodeName renders a Code rune as the lowercase string we use in
+// config files (and in the modal label). Names round-trip through
+// namedKeyCodes — every name returned here must also parse.
+func keyCodeName(c rune) string {
+	if n, ok := codeToName[c]; ok {
+		return n
+	}
+	return strings.ToLower(string(c))
+}
+
+// namedKeyCodes maps the parseable string forms to bubbletea Code
+// runes. Aliases (esc/escape, pgup/pageup, …) all resolve to the same
+// rune so users can write whichever feels natural.
+var namedKeyCodes = map[string]rune{
+	"left":      tea.KeyLeft,
+	"right":     tea.KeyRight,
+	"up":        tea.KeyUp,
+	"down":      tea.KeyDown,
+	"enter":     tea.KeyEnter,
+	"return":    tea.KeyEnter,
+	"esc":       tea.KeyEsc,
+	"escape":    tea.KeyEsc,
+	"tab":       tea.KeyTab,
+	"space":     tea.KeySpace,
+	"home":      tea.KeyHome,
+	"end":       tea.KeyEnd,
+	"pgup":      tea.KeyPgUp,
+	"pgdn":      tea.KeyPgDown,
+	"pageup":    tea.KeyPgUp,
+	"pagedown":  tea.KeyPgDown,
+	"del":       tea.KeyDelete,
+	"delete":    tea.KeyDelete,
+	"backspace": tea.KeyBackspace,
+	"insert":    tea.KeyInsert,
+}
+
+// codeToName is the canonical reverse — pick one display form per
+// Code so String() output is stable. Aliases that share a Code (esc
+// vs escape) only appear here under their canonical name.
+var codeToName = map[rune]string{
+	tea.KeyLeft:      "left",
+	tea.KeyRight:     "right",
+	tea.KeyUp:        "up",
+	tea.KeyDown:      "down",
+	tea.KeyEnter:     "enter",
+	tea.KeyEsc:       "esc",
+	tea.KeyTab:       "tab",
+	tea.KeySpace:     "space",
+	tea.KeyHome:      "home",
+	tea.KeyEnd:       "end",
+	tea.KeyPgUp:      "pgup",
+	tea.KeyPgDown:    "pgdn",
+	tea.KeyDelete:    "del",
+	tea.KeyBackspace: "backspace",
+	tea.KeyInsert:    "insert",
+}
+
+// ParseKeyBinding accepts "ctrl+w", "ctrl+shift+left", "f", or "" and
+// returns the binding. Empty input is the zero value (unbound) — used
+// to explicitly disable an action in config.
+func ParseKeyBinding(s string) (KeyBinding, error) {
+	s = strings.TrimSpace(strings.ToLower(s))
+	if s == "" {
+		return KeyBinding{}, nil
+	}
+	parts := strings.Split(s, "+")
+	var mod tea.KeyMod
+	var key string
+	for i, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			return KeyBinding{}, fmt.Errorf("empty token in %q", s)
+		}
+		switch p {
+		case "ctrl", "control":
+			mod |= tea.ModCtrl
+		case "alt", "opt", "option", "meta":
+			mod |= tea.ModAlt
+		case "shift":
+			mod |= tea.ModShift
+		default:
+			if i != len(parts)-1 {
+				return KeyBinding{}, fmt.Errorf("unknown modifier %q in %q", p, s)
+			}
+			key = p
+		}
+	}
+	if key == "" {
+		return KeyBinding{}, fmt.Errorf("missing key in %q", s)
+	}
+	if c, ok := namedKeyCodes[key]; ok {
+		return KeyBinding{Mod: mod, Code: c}, nil
+	}
+	rs := []rune(key)
+	if len(rs) != 1 {
+		return KeyBinding{}, fmt.Errorf("unknown key %q in %q", key, s)
+	}
+	return KeyBinding{Mod: mod, Code: rs[0]}, nil
+}
+
+// KeyMap is the resolved action → binding table used at dispatch.
+// Always built via DefaultKeyMap() or LoadKeyMapFromConfig() so every
+// known action has an entry (no nil-checks at lookup sites).
+type KeyMap map[Action]KeyBinding
+
+func DefaultKeyMap() KeyMap {
+	out := make(KeyMap, len(defaultKeyBindings))
+	for action, b := range defaultKeyBindings {
+		out[action] = b
+	}
+	return out
+}
+
+var defaultKeyBindings = map[Action]KeyBinding{
+	ActionScreenIssues:    {Mod: tea.ModCtrl, Code: 'i'},
+	ActionScreenPRs:       {Mod: tea.ModCtrl, Code: 'p'},
+	ActionScreenWorkflows: {Mod: tea.ModCtrl, Code: 'w'},
+	ActionScreenAsk:       {Mod: tea.ModCtrl, Code: 'o'},
+	ActionProviderSwitch:  {Mod: tea.ModCtrl, Code: 'b'},
+	ActionChatWorkflow:    {Mod: tea.ModCtrl, Code: 'f'},
+	ActionTabNew:          {Mod: tea.ModCtrl, Code: 't'},
+	ActionTabPrev:         {Mod: tea.ModCtrl, Code: tea.KeyLeft},
+	ActionTabNext:         {Mod: tea.ModCtrl, Code: tea.KeyRight},
+	ActionAppSuspend:      {Mod: tea.ModCtrl, Code: 'z'},
+}
+
+// Matches is the dispatch-site lookup. Missing actions fall back to
+// the default so a partially-populated map still works.
+func (k KeyMap) Matches(action Action, msg tea.KeyPressMsg) bool {
+	if b, ok := k[action]; ok {
+		return b.Matches(msg)
+	}
+	return defaultKeyBindings[action].Matches(msg)
+}
+
+// Binding returns the binding for action, falling back to the default
+// when the map has no explicit entry. Used by the config modal to
+// render the current value.
+func (k KeyMap) Binding(action Action) KeyBinding {
+	if b, ok := k[action]; ok {
+		return b
+	}
+	return defaultKeyBindings[action]
+}
+
+// MarshalConfig returns the {action: "ctrl+w"} JSON shape, omitting
+// entries that match the default so the on-disk file stays minimal
+// for users on stock settings.
+func (k KeyMap) MarshalConfig() map[string]string {
+	out := map[string]string{}
+	for action, b := range k {
+		def, ok := defaultKeyBindings[action]
+		if !ok {
+			continue
+		}
+		if b == def {
+			continue
+		}
+		out[string(action)] = b.String()
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// LoadKeyMapFromConfig builds a KeyMap from the JSON shape. Unknown
+// actions are skipped (forward-compat with future versions that
+// retire an action). Malformed bindings are skipped with a debugLog
+// warning so a typo in ask.json doesn't crash startup. The result
+// always contains every default — overrides layer on top.
+func LoadKeyMapFromConfig(raw map[string]string) KeyMap {
+	km := DefaultKeyMap()
+	for k, v := range raw {
+		action := Action(k)
+		if _, known := defaultKeyBindings[action]; !known {
+			debugLog("ignoring unknown keybinding action %q", k)
+			continue
+		}
+		b, err := ParseKeyBinding(v)
+		if err != nil {
+			debugLog("ignoring keybinding %s=%q: %v", k, v, err)
+			continue
+		}
+		km[action] = b
+	}
+	return km
+}
+
+// actionMeta lists the user-facing label for each action; the order
+// here drives the row order in the /config keybindings sub-picker.
+var actionMeta = []struct {
+	Action Action
+	Label  string
+}{
+	{ActionScreenIssues, "Issues screen"},
+	{ActionScreenPRs, "PRs screen"},
+	{ActionScreenWorkflows, "Workflows screen"},
+	{ActionScreenAsk, "Ask (chat) screen"},
+	{ActionProviderSwitch, "Provider switch"},
+	{ActionChatWorkflow, "Run workflow on chat"},
+	{ActionTabNew, "New tab"},
+	{ActionTabPrev, "Previous tab"},
+	{ActionTabNext, "Next tab"},
+	{ActionAppSuspend, "Suspend ask"},
+}
+
+// Process-wide cached keymap. Dispatch happens on every keypress, so
+// re-reading ~/.config/ask/ask.json each time would be wasteful;
+// instead currentKeyMap() loads once lazily and invalidateKeyMapCache()
+// drops the cache after a /config save. Cache is package-scoped because
+// keybindings are global state — every tab in every goroutine sees the
+// same map.
+var (
+	keyMapMu    sync.RWMutex
+	keyMapCache KeyMap
+)
+
+// currentKeyMap returns the process-wide keymap, loading from
+// ~/.config/ask/ask.json on first call. Safe for concurrent use.
+func currentKeyMap() KeyMap {
+	keyMapMu.RLock()
+	km := keyMapCache
+	keyMapMu.RUnlock()
+	if km != nil {
+		return km
+	}
+	cfg, _ := loadConfig()
+	resolved := LoadKeyMapFromConfig(cfg.Keybindings)
+	keyMapMu.Lock()
+	// Re-check under write lock so two racing first-callers don't both
+	// load — whoever got the lock second still observes the same map.
+	if keyMapCache == nil {
+		keyMapCache = resolved
+	}
+	km = keyMapCache
+	keyMapMu.Unlock()
+	return km
+}
+
+// invalidateKeyMapCache drops the cached keymap; the next
+// currentKeyMap call re-reads from disk. Call this after writing
+// cfg.Keybindings to the config file.
+func invalidateKeyMapCache() {
+	keyMapMu.Lock()
+	keyMapCache = nil
+	keyMapMu.Unlock()
+}
+
+// setKeyMapForTesting overrides the cache directly. Tests use this
+// to install a custom keymap without touching disk; production code
+// must not call it.
+func setKeyMapForTesting(km KeyMap) {
+	keyMapMu.Lock()
+	keyMapCache = km
+	keyMapMu.Unlock()
+}

--- a/keymap.go
+++ b/keymap.go
@@ -16,16 +16,21 @@ import (
 // own handlers. Adding a new global shortcut requires four edits:
 //  1. New const here.
 //  2. defaultKeyBindings entry.
-//  3. actionMeta entry (label shown in /config).
+//  3. actionGroups entry (label + group shown in /config).
 //  4. KeyMap.Matches lookup at the dispatch site.
 type Action string
 
-// Ctrl+D close-tab and Ctrl+C are deliberately *not* in this list.
-// They're universal escape hatches every modal handler needs to honour
-// (11 sites today), so keeping them inline avoids both the broad
-// refactor and the risk of a misconfigured keymap leaving the user
-// with no way out of a modal. Same for j/k/arrow navigation inside
-// the kanban / workflow builder / pickers.
+// Ctrl+C and modal-escape Ctrl+D are deliberately *not* on this list.
+// Ctrl+C is the universal cancel and every screen/modal needs it to
+// always work; modal-escape Ctrl+D (the /config modal, provider
+// switcher, approval, ask-question, ollama screen) stays hardcoded
+// for the same reason — Esc already closes those, but Ctrl+D is the
+// canonical exit so its dispatcher mustn't follow a rebound key into
+// nowhere. Same for j/k/arrow navigation inside the kanban / workflow
+// builder / pickers. ActionTabClose covers the tab-level close path
+// (chat dispatcher, issues / workflows / workflow-run tabs, pickers,
+// close-confirm bypass) — six sites that all want to follow the
+// user's rebind.
 const (
 	ActionScreenIssues    Action = "screen.issues"
 	ActionScreenPRs       Action = "screen.prs"
@@ -33,7 +38,9 @@ const (
 	ActionScreenAsk       Action = "screen.ask"
 	ActionProviderSwitch  Action = "provider.switch"
 	ActionChatWorkflow    Action = "chat.workflow"
+	ActionReload          Action = "screen.reload"
 	ActionTabNew          Action = "tab.new"
+	ActionTabClose        Action = "tab.close"
 	ActionTabPrev         Action = "tab.prev"
 	ActionTabNext         Action = "tab.next"
 	ActionAppSuspend      Action = "app.suspend"
@@ -224,7 +231,9 @@ var defaultKeyBindings = map[Action]KeyBinding{
 	ActionScreenAsk:       {Mod: tea.ModCtrl, Code: 'o'},
 	ActionProviderSwitch:  {Mod: tea.ModCtrl, Code: 'b'},
 	ActionChatWorkflow:    {Mod: tea.ModCtrl, Code: 'f'},
+	ActionReload:          {Mod: tea.ModCtrl, Code: 'r'},
 	ActionTabNew:          {Mod: tea.ModCtrl, Code: 't'},
+	ActionTabClose:        {Mod: tea.ModCtrl, Code: 'd'},
 	ActionTabPrev:         {Mod: tea.ModCtrl, Code: tea.KeyLeft},
 	ActionTabNext:         {Mod: tea.ModCtrl, Code: tea.KeyRight},
 	ActionAppSuspend:      {Mod: tea.ModCtrl, Code: 'z'},
@@ -302,22 +311,110 @@ func LoadKeyMapFromConfig(raw map[string]string) KeyMap {
 	return km
 }
 
-// actionMeta lists the user-facing label for each action; the order
-// here drives the row order in the /config keybindings sub-picker.
-var actionMeta = []struct {
+// actionMetaItem pairs an Action with the label the /config picker
+// renders for it. Exported only as a shape — instances live inside
+// actionGroups and the derived flat actionMeta.
+type actionMetaItem struct {
 	Action Action
 	Label  string
-}{
-	{ActionScreenIssues, "Issues screen"},
-	{ActionScreenPRs, "PRs screen"},
-	{ActionScreenWorkflows, "Workflows screen"},
-	{ActionScreenAsk, "Ask (chat) screen"},
-	{ActionProviderSwitch, "Provider switch"},
-	{ActionChatWorkflow, "Run workflow on chat"},
-	{ActionTabNew, "New tab"},
-	{ActionTabPrev, "Previous tab"},
-	{ActionTabNext, "Next tab"},
-	{ActionAppSuspend, "Suspend ask"},
+}
+
+// actionMetaGroup is one heading + its items in the /config picker.
+// Adding a group is purely cosmetic: dispatch / persistence /
+// cursor math all walk the flat actionMeta, which is derived from
+// these groups by flattenActionGroups.
+type actionMetaGroup struct {
+	Heading string
+	Items   []actionMetaItem
+}
+
+// actionGroups drives the /config keybindings picker layout. The
+// heading order here is the render order; the item order inside each
+// group is also the cursor walk order (Up/Down skip across group
+// boundaries via the flattened actionMeta).
+var actionGroups = []actionMetaGroup{
+	{Heading: "Screens", Items: []actionMetaItem{
+		{ActionScreenIssues, "Issues screen"},
+		{ActionScreenPRs, "PRs screen"},
+		{ActionScreenWorkflows, "Workflows screen"},
+		{ActionScreenAsk, "Ask (chat) screen"},
+	}},
+	{Heading: "Tabs", Items: []actionMetaItem{
+		{ActionTabNew, "New tab"},
+		{ActionTabClose, "Close tab"},
+		{ActionTabPrev, "Previous tab"},
+		{ActionTabNext, "Next tab"},
+	}},
+	{Heading: "Pickers & dispatch", Items: []actionMetaItem{
+		{ActionProviderSwitch, "Provider switch"},
+		{ActionChatWorkflow, "Run workflow on chat"},
+		{ActionReload, "Reload issues/PRs"},
+	}},
+	{Heading: "App", Items: []actionMetaItem{
+		{ActionAppSuspend, "Suspend ask"},
+	}},
+}
+
+// actionMeta is the flat in-order item list derived from actionGroups.
+// The picker's cursor indexes into this slice and persistence code
+// looks up actions by position here, so the picker can stay
+// group-aware in rendering while every other site treats the action
+// set as a flat ordered list.
+var actionMeta = flattenActionGroups(actionGroups)
+
+func flattenActionGroups(groups []actionMetaGroup) []actionMetaItem {
+	var out []actionMetaItem
+	for _, g := range groups {
+		out = append(out, g.Items...)
+	}
+	return out
+}
+
+// keyHintFor returns the user-facing display form of action's current
+// binding, suitable for inline use in a hint/toast string. Returns ""
+// for unbound actions so callers can drop the surrounding clause via
+// joinHintClauses (otherwise a rebound-to-empty action would print a
+// dangling " · " or " opens the builder" with no key prefix).
+func keyHintFor(action Action) string {
+	return currentKeyMap().Binding(action).String()
+}
+
+// keyClause renders "<key> <suffix>" for an action, suitable for one
+// segment of a · -joined hint footer. Returns "" when the action is
+// unbound so joinHintClauses can drop the clause entirely — printing
+// "  reload" with a leading-empty key would look broken.
+func keyClause(action Action, suffix string) string {
+	k := keyHintFor(action)
+	if k == "" {
+		return ""
+	}
+	return k + " " + suffix
+}
+
+// joinHintClauses joins the non-empty clauses with " · ", the
+// canonical separator used by every hint footer in the app. Empty
+// clauses (produced by keyClause / keyHintFor for unbound actions) are
+// dropped instead of leaving a hanging separator.
+func joinHintClauses(parts ...string) string {
+	out := parts[:0]
+	for _, p := range parts {
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return strings.Join(out, " · ")
+}
+
+// workflowsBuilderHint is the toast/picker string shown when the user
+// triggers a workflow action but no workflows are configured. When
+// ActionScreenWorkflows is bound, the hint names the live shortcut so
+// rebinds stay in sync; when unbound, it falls back to the slash
+// command path, which is always available.
+func workflowsBuilderHint() string {
+	if k := keyHintFor(ActionScreenWorkflows); k != "" {
+		return "no workflows configured · " + k + " opens the builder"
+	}
+	return "no workflows configured · open the builder from /workflows"
 }
 
 // Process-wide cached keymap. Dispatch happens on every keypress, so

--- a/keymap_dispatch_test.go
+++ b/keymap_dispatch_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// TestApp_TabNavigationHonoursKeymapOverride proves the tabs.go
+// dispatcher actually consults currentKeyMap() instead of the old
+// inline ctrl+left/right literals. We override ActionTabNext to an
+// unusual key (alt+'q'); pressing that on a two-tab app must move
+// the active tab, while the previous default (ctrl+right) must NOT
+// fire — confirming the swap is real, not additive.
+func TestApp_TabNavigationHonoursKeymapOverride(t *testing.T) {
+	isolateHome(t)
+	setKeyMapForTesting(KeyMap{
+		ActionTabNext:    {Mod: tea.ModAlt, Code: 'q'},
+		ActionTabPrev:    {Mod: tea.ModAlt, Code: 'e'},
+		ActionTabNew:     defaultKeyBindings[ActionTabNew],
+		ActionAppSuspend: defaultKeyBindings[ActionAppSuspend],
+	})
+	defer invalidateKeyMapCache()
+
+	a := testAppWithTwoTabs(t)
+	a.active = 0
+
+	// Pressing the old default must NOT advance now.
+	newA, _ := a.Update(tea.KeyPressMsg{Mod: tea.ModCtrl, Code: tea.KeyRight})
+	if a2, ok := newA.(app); ok && a2.active != 0 {
+		t.Errorf("old default ctrl+right should no longer advance tabs; active=%d", a2.active)
+	}
+
+	// Pressing the override must advance.
+	newA, _ = a.Update(tea.KeyPressMsg{Mod: tea.ModAlt, Code: 'q'})
+	a2, ok := newA.(app)
+	if !ok {
+		t.Fatalf("Update returned %T, want app", newA)
+	}
+	if a2.active != 1 {
+		t.Errorf("remapped tab.next should advance to tab 1; active=%d", a2.active)
+	}
+}
+
+// Sanity: with no overrides installed, the defaults still work. Just
+// because we now route through the keymap doesn't mean ctrl+left/right
+// stopped working out of the box.
+func TestApp_TabNavigationDefaultsStillWork(t *testing.T) {
+	isolateHome(t)
+	invalidateKeyMapCache()
+	defer invalidateKeyMapCache()
+
+	a := testAppWithTwoTabs(t)
+	a.active = 0
+
+	newA, _ := a.Update(tea.KeyPressMsg{Mod: tea.ModCtrl, Code: tea.KeyRight})
+	a2, ok := newA.(app)
+	if !ok {
+		t.Fatalf("Update returned %T, want app", newA)
+	}
+	if a2.active != 1 {
+		t.Errorf("ctrl+right should advance under default keymap; active=%d", a2.active)
+	}
+}
+
+// The /config keybindings picker must persist captures to
+// ~/.config/ask/ask.json so the next process startup sees the
+// override. End-to-end: open the picker, simulate Enter to enter
+// capture, simulate a custom keypress, then read the saved file
+// back through loadConfig.
+func TestConfigKeybindingsPicker_CapturePersistsToDisk(t *testing.T) {
+	isolateHome(t)
+	invalidateKeyMapCache()
+	defer invalidateKeyMapCache()
+
+	m := newTestModel(t, newFakeProvider())
+	m.mode = modeConfig
+	m.configKeybindingsPickerActive = true
+	// Cursor lands on the first action — ActionScreenIssues by the
+	// order in actionMeta. Verify the precondition so the rest of
+	// the test fails loudly if actionMeta reorders.
+	if actionMeta[0].Action != ActionScreenIssues {
+		t.Fatalf("test depends on actionMeta[0]=ActionScreenIssues; got %s",
+			actionMeta[0].Action)
+	}
+
+	// Enter capture mode.
+	m2, _ := runUpdate(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !m2.configKeybindingsCapturing {
+		t.Fatalf("Enter on row should enter capture mode")
+	}
+
+	// Capture a new binding.
+	m3, _ := runUpdate(t, m2, tea.KeyPressMsg{Mod: tea.ModAlt | tea.ModShift, Code: 'x'})
+	if m3.configKeybindingsCapturing {
+		t.Errorf("capture should end after recording a key")
+	}
+	if m3.configKeybindingsError != "" {
+		t.Errorf("unexpected capture error: %q", m3.configKeybindingsError)
+	}
+
+	// Persisted to disk.
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	got := cfg.Keybindings[string(ActionScreenIssues)]
+	if got != "alt+shift+x" {
+		t.Errorf("Keybindings[%s] = %q, want alt+shift+x", ActionScreenIssues, got)
+	}
+
+	// Cache invalidated; currentKeyMap reflects the new binding.
+	if b := currentKeyMap()[ActionScreenIssues]; b != (KeyBinding{Mod: tea.ModAlt | tea.ModShift, Code: 'x'}) {
+		t.Errorf("currentKeyMap not refreshed after persist: %+v", b)
+	}
+}
+
+// Esc during capture must abort without writing to disk — otherwise
+// a user reviewing bindings could accidentally clobber one just by
+// pressing Esc to back out.
+func TestConfigKeybindingsPicker_EscDuringCaptureDoesNotPersist(t *testing.T) {
+	isolateHome(t)
+	invalidateKeyMapCache()
+	defer invalidateKeyMapCache()
+
+	m := newTestModel(t, newFakeProvider())
+	m.mode = modeConfig
+	m.configKeybindingsPickerActive = true
+	m.configKeybindingsCapturing = true
+	m.configKeybindingsCursor = 0
+
+	m2, _ := runUpdate(t, m, tea.KeyPressMsg{Code: tea.KeyEsc})
+	if m2.configKeybindingsCapturing {
+		t.Errorf("Esc should exit capture")
+	}
+	if !m2.configKeybindingsPickerActive {
+		t.Errorf("Esc during capture must NOT close the picker")
+	}
+
+	cfg, _ := loadConfig()
+	if len(cfg.Keybindings) != 0 {
+		t.Errorf("Esc-cancelled capture should not write to disk; got %+v", cfg.Keybindings)
+	}
+}
+
+// Re-binding back to the default value must remove the entry from
+// cfg.Keybindings so the config file doesn't accumulate dead
+// overrides over time.
+func TestConfigKeybindingsPicker_RebindToDefaultRemovesEntry(t *testing.T) {
+	isolateHome(t)
+	invalidateKeyMapCache()
+	defer invalidateKeyMapCache()
+
+	// Seed the config with an override so we can observe it disappear.
+	if err := saveConfig(askConfig{
+		Keybindings: map[string]string{
+			string(ActionScreenIssues): "alt+x",
+		},
+	}); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+
+	m := newTestModel(t, newFakeProvider())
+	m.mode = modeConfig
+	m.configKeybindingsPickerActive = true
+	m.configKeybindingsCursor = 0
+	m.configKeybindingsCapturing = true
+
+	// Capture the default value.
+	def := defaultKeyBindings[ActionScreenIssues]
+	m2, _ := runUpdate(t, m, tea.KeyPressMsg{Mod: def.Mod, Code: def.Code})
+	if m2.configKeybindingsError != "" {
+		t.Errorf("capture errored: %q", m2.configKeybindingsError)
+	}
+
+	cfg, _ := loadConfig()
+	if _, ok := cfg.Keybindings[string(ActionScreenIssues)]; ok {
+		t.Errorf("re-binding to default should remove the entry: %+v", cfg.Keybindings)
+	}
+}

--- a/keymap_dispatch_test.go
+++ b/keymap_dispatch_test.go
@@ -283,3 +283,73 @@ func TestConfigKeybindingsPicker_RebindToDefaultRemovesEntry(t *testing.T) {
 		t.Errorf("re-binding to default should remove the entry: %+v", cfg.Keybindings)
 	}
 }
+
+// Pressing 'r' in row-navigation mode resets the focused row to its
+// compiled-in default. Without this hotkey, a user who captured the
+// wrong key has no recovery path from inside the picker — they would
+// have to remember the original default to capture it back, or
+// hand-edit ~/.config/ask/ask.json.
+func TestConfigKeybindingsPicker_ResetRestoresDefault(t *testing.T) {
+	isolateHome(t)
+	invalidateKeyMapCache()
+	defer invalidateKeyMapCache()
+
+	// Seed an override so we can observe it being cleared.
+	if err := saveConfig(askConfig{
+		Keybindings: map[string]string{
+			string(ActionScreenWorkflows): "alt+q",
+		},
+	}); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+
+	m := newTestModel(t, newFakeProvider())
+	m.mode = modeConfig
+	m.configKeybindingsPickerActive = true
+	// Park the cursor on the Workflows row.
+	for i, am := range actionMeta {
+		if am.Action == ActionScreenWorkflows {
+			m.configKeybindingsCursor = i
+			break
+		}
+	}
+
+	m2, _ := runUpdate(t, m, tea.KeyPressMsg{Code: 'r'})
+	if m2.configKeybindingsCapturing {
+		t.Errorf("reset must not enter capture mode")
+	}
+	if m2.configKeybindingsError != "" {
+		t.Errorf("reset errored: %q", m2.configKeybindingsError)
+	}
+
+	cfg, _ := loadConfig()
+	if _, ok := cfg.Keybindings[string(ActionScreenWorkflows)]; ok {
+		t.Errorf("reset should remove the override entry: %+v", cfg.Keybindings)
+	}
+	if b := currentKeyMap()[ActionScreenWorkflows]; b != defaultKeyBindings[ActionScreenWorkflows] {
+		t.Errorf("reset should restore the default; got %+v", b)
+	}
+}
+
+// 'r' in capture mode must record as the binding, not trigger a reset
+// — otherwise the user can never actually bind to 'r' itself.
+func TestConfigKeybindingsPicker_RInCaptureModeRecordsBinding(t *testing.T) {
+	isolateHome(t)
+	invalidateKeyMapCache()
+	defer invalidateKeyMapCache()
+
+	m := newTestModel(t, newFakeProvider())
+	m.mode = modeConfig
+	m.configKeybindingsPickerActive = true
+	m.configKeybindingsCursor = 0
+	m.configKeybindingsCapturing = true
+
+	m2, _ := runUpdate(t, m, tea.KeyPressMsg{Mod: tea.ModCtrl, Code: 'r'})
+	if m2.configKeybindingsError != "" {
+		t.Fatalf("capture errored: %q", m2.configKeybindingsError)
+	}
+	cfg, _ := loadConfig()
+	if got := cfg.Keybindings[string(actionMeta[0].Action)]; got != "ctrl+r" {
+		t.Errorf("captured binding=%q want ctrl+r", got)
+	}
+}

--- a/keymap_dispatch_test.go
+++ b/keymap_dispatch_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	lipgloss "charm.land/lipgloss/v2"
 )
 
 // TestApp_TabNavigationHonoursKeymapOverride proves the tabs.go
@@ -63,6 +64,44 @@ func TestApp_TabNavigationDefaultsStillWork(t *testing.T) {
 	}
 }
 
+func TestApp_TabNavigationIgnoresLockModifiers(t *testing.T) {
+	isolateHome(t)
+	invalidateKeyMapCache()
+	defer invalidateKeyMapCache()
+
+	a := testAppWithTwoTabs(t)
+	a.active = 0
+
+	newA, _ := a.Update(tea.KeyPressMsg{
+		Mod:  tea.ModCtrl | tea.ModCapsLock | tea.ModNumLock,
+		Code: tea.KeyRight,
+	})
+	a2, ok := newA.(app)
+	if !ok {
+		t.Fatalf("Update returned %T, want app", newA)
+	}
+	if a2.active != 1 {
+		t.Errorf("ctrl+right with lock-state modifiers should advance; active=%d", a2.active)
+	}
+}
+
+func TestUpdate_ScreenShortcutIgnoresLockModifiers(t *testing.T) {
+	isolateHome(t)
+	invalidateKeyMapCache()
+	defer invalidateKeyMapCache()
+
+	m := newTestModel(t, newFakeProvider())
+	m.screen = screenAsk
+
+	m2, _ := runUpdate(t, m, tea.KeyPressMsg{
+		Mod:  tea.ModCtrl | tea.ModCapsLock,
+		Code: 'w',
+	})
+	if m2.screen != screenWorkflows {
+		t.Errorf("ctrl+w with CapsLock should open workflows; screen=%v", m2.screen)
+	}
+}
+
 // The /config keybindings picker must persist captures to
 // ~/.config/ask/ask.json so the next process startup sees the
 // override. End-to-end: open the picker, simulate Enter to enter
@@ -112,6 +151,72 @@ func TestConfigKeybindingsPicker_CapturePersistsToDisk(t *testing.T) {
 	// Cache invalidated; currentKeyMap reflects the new binding.
 	if b := currentKeyMap()[ActionScreenIssues]; b != (KeyBinding{Mod: tea.ModAlt | tea.ModShift, Code: 'x'}) {
 		t.Errorf("currentKeyMap not refreshed after persist: %+v", b)
+	}
+}
+
+func TestConfigKeybindingsPicker_CaptureStripsLockModifiers(t *testing.T) {
+	isolateHome(t)
+	invalidateKeyMapCache()
+	defer invalidateKeyMapCache()
+
+	m := newTestModel(t, newFakeProvider())
+	m.mode = modeConfig
+	m.configKeybindingsPickerActive = true
+	m.configKeybindingsCapturing = true
+	m.configKeybindingsCursor = 0
+
+	m2, _ := runUpdate(t, m, tea.KeyPressMsg{
+		Mod:  tea.ModAlt | tea.ModCapsLock | tea.ModScrollLock,
+		Code: 'x',
+	})
+	if m2.configKeybindingsError != "" {
+		t.Fatalf("capture errored: %q", m2.configKeybindingsError)
+	}
+	cfg, _ := loadConfig()
+	if got := cfg.Keybindings[string(ActionScreenIssues)]; got != "alt+x" {
+		t.Errorf("captured binding=%q want alt+x", got)
+	}
+}
+
+func TestConfigKeybindingsPicker_CaptureFunctionKeyRoundTrips(t *testing.T) {
+	isolateHome(t)
+	invalidateKeyMapCache()
+	defer invalidateKeyMapCache()
+
+	m := newTestModel(t, newFakeProvider())
+	m.mode = modeConfig
+	m.configKeybindingsPickerActive = true
+	m.configKeybindingsCapturing = true
+	m.configKeybindingsCursor = 0
+
+	m2, _ := runUpdate(t, m, tea.KeyPressMsg{Mod: tea.ModCtrl, Code: tea.KeyF5})
+	if m2.configKeybindingsError != "" {
+		t.Fatalf("capture errored: %q", m2.configKeybindingsError)
+	}
+	cfg, _ := loadConfig()
+	if got := cfg.Keybindings[string(ActionScreenIssues)]; got != "ctrl+f5" {
+		t.Fatalf("captured binding=%q want ctrl+f5", got)
+	}
+	if !currentKeyMap().Matches(ActionScreenIssues, tea.KeyPressMsg{Mod: tea.ModCtrl, Code: tea.KeyF5}) {
+		t.Error("captured function-key binding should match after reload")
+	}
+}
+
+func TestKeybindingsPickerWidthCapsToTerminal(t *testing.T) {
+	rows := [][2]string{
+		{"Run workflow on chat", "ctrl+shift+right"},
+	}
+	innerW := keybindingsPickerInnerWidth(30, rows)
+	maxInnerW := 30 - themePickerBoxStyle.GetHorizontalFrameSize()
+	if innerW > maxInnerW {
+		t.Fatalf("inner width=%d exceeds max terminal inner width=%d", innerW, maxInnerW)
+	}
+	label, binding := fitKeybindingPickerRowParts(rows[0][0], rows[0][1], innerW)
+	if got := lipgloss.Width(label) + lipgloss.Width(binding) + 1; got > innerW {
+		t.Errorf("fitted cells width=%d exceeds inner width=%d", got, innerW)
+	}
+	if got := lipgloss.Width(truncateForRow("↑↓ navigate · enter rebind · esc close", innerW)); got > innerW {
+		t.Errorf("help width=%d exceeds inner width=%d", got, innerW)
 	}
 }
 

--- a/keymap_dispatch_test.go
+++ b/keymap_dispatch_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -441,4 +442,254 @@ func TestConfigKeybindingsPicker_RInCaptureModeRecordsBinding(t *testing.T) {
 	if got := cfg.Keybindings[string(actionMeta[0].Action)]; got != "ctrl+r" {
 		t.Errorf("captured binding=%q want ctrl+r", got)
 	}
+}
+
+// TestUpdate_TabCloseHonoursKeyMapOverride proves the chat-screen
+// Ctrl+D handler routes through ActionTabClose now that the action is
+// rebindable. Rebinds to alt+x; the default ctrl+d must NOT produce a
+// closeTabMsg, and the new key MUST.
+func TestUpdate_TabCloseHonoursKeyMapOverride(t *testing.T) {
+	isolateHome(t)
+	setKeyMapForTesting(KeyMap{
+		ActionTabClose: {Mod: tea.ModAlt, Code: 'x'},
+	})
+	defer invalidateKeyMapCache()
+
+	m := newTestModel(t, newFakeProvider())
+	m.id = 42
+
+	_, cmd := runUpdate(t, m, tea.KeyPressMsg{Mod: tea.ModCtrl, Code: 'd'})
+	if cmd != nil {
+		if _, ok := cmd().(closeTabMsg); ok {
+			t.Error("default ctrl+d should NOT close after rebind")
+		}
+	}
+
+	_, cmd = runUpdate(t, m, tea.KeyPressMsg{Mod: tea.ModAlt, Code: 'x'})
+	if cmd == nil {
+		t.Fatal("rebound ActionTabClose key should produce a cmd")
+	}
+	msg := cmd()
+	cm, ok := msg.(closeTabMsg)
+	if !ok {
+		t.Fatalf("expected closeTabMsg, got %T", msg)
+	}
+	if cm.tabID != 42 {
+		t.Errorf("closeTabMsg.tabID=%d, want 42", cm.tabID)
+	}
+}
+
+// TestUpdate_TabCloseDefaultStillWorks pins the default behaviour:
+// ctrl+d closes the tab on a stock keymap. Guards against the
+// inline-to-keymap routing accidentally dropping the default.
+func TestUpdate_TabCloseDefaultStillWorks(t *testing.T) {
+	isolateHome(t)
+	invalidateKeyMapCache()
+	defer invalidateKeyMapCache()
+
+	m := newTestModel(t, newFakeProvider())
+	m.id = 7
+
+	_, cmd := runUpdate(t, m, tea.KeyPressMsg{Mod: tea.ModCtrl, Code: 'd'})
+	if cmd == nil {
+		t.Fatal("ctrl+d should still close under default keymap")
+	}
+	msg := cmd()
+	cm, ok := msg.(closeTabMsg)
+	if !ok {
+		t.Fatalf("expected closeTabMsg, got %T", msg)
+	}
+	if cm.tabID != 7 {
+		t.Errorf("closeTabMsg.tabID=%d, want 7", cm.tabID)
+	}
+}
+
+// TestIssuesScreen_TabCloseFollowsKeyMapOverride mirrors the chat-side
+// check on the issues screen — the screen's own Ctrl+D shortcut also
+// routes through the keymap, so rebinding ActionTabClose must take
+// effect there too.
+func TestIssuesScreen_TabCloseFollowsKeyMapOverride(t *testing.T) {
+	isolateHome(t)
+	setKeyMapForTesting(KeyMap{
+		ActionTabClose: {Mod: tea.ModAlt, Code: 'x'},
+	})
+	defer invalidateKeyMapCache()
+
+	m := newTestModel(t, newFakeProvider())
+	m.id = 11
+	m.screen = screenIssues
+	m.issues = newIssuesState()
+
+	_, cmd, handled := issuesScreen{}.updateKey(m, tea.KeyPressMsg{Mod: tea.ModAlt, Code: 'x'})
+	if !handled {
+		t.Fatal("rebound tab-close key should be handled by issues screen")
+	}
+	if cmd == nil {
+		t.Fatal("rebound tab-close key should produce a cmd")
+	}
+	if _, ok := cmd().(closeTabMsg); !ok {
+		t.Fatalf("expected closeTabMsg, got %T", cmd())
+	}
+}
+
+// TestKanbanHint_ReflectsReloadOverride proves the kanban footer
+// rewrites itself when the user rebinds ActionReload — the original
+// hardcoded "ctrl+r reload" would not have.
+func TestKanbanHint_ReflectsReloadOverride(t *testing.T) {
+	isolateHome(t)
+	setKeyMapForTesting(KeyMap{
+		ActionReload:    {Mod: tea.ModAlt, Code: 'r'},
+		ActionScreenAsk: {Mod: tea.ModCtrl, Code: 'o'},
+	})
+	defer invalidateKeyMapCache()
+
+	v := &kanbanIssueView{}
+	body := v.hintFor(nil)
+	if !strings.Contains(body, "alt+r reload") {
+		t.Errorf("kanban hint should name the rebound reload key; got %q", body)
+	}
+	if strings.Contains(body, "ctrl+r reload") {
+		t.Errorf("kanban hint should not still reference the default ctrl+r; got %q", body)
+	}
+}
+
+// TestKanbanHint_DropsUnboundReloadClause proves an unbound reload
+// action does not leave a dangling " · " segment in the footer — the
+// joinHintClauses helper must filter empties out.
+func TestKanbanHint_DropsUnboundReloadClause(t *testing.T) {
+	isolateHome(t)
+	setKeyMapForTesting(KeyMap{
+		ActionReload:    {},
+		ActionScreenAsk: {Mod: tea.ModCtrl, Code: 'o'},
+	})
+	defer invalidateKeyMapCache()
+
+	v := &kanbanIssueView{}
+	body := v.hintFor(nil)
+	if strings.Contains(body, " reload") {
+		t.Errorf("unbound reload should drop the clause entirely; got %q", body)
+	}
+	if strings.Contains(body, "·  ·") {
+		t.Errorf("dropped clause must not leave a dangling separator; got %q", body)
+	}
+	if !strings.Contains(body, "ctrl+o back") {
+		t.Errorf("other clauses should remain; got %q", body)
+	}
+}
+
+// TestWorkflowsBuilderHint_ReflectsRebindAndUnbind covers the three
+// shapes the workflows-builder hint can take: stock binding, rebound
+// binding, unbound action. The string is shared by the issues toast,
+// the chat toast, and the workflow picker's empty-state row.
+func TestWorkflowsBuilderHint_ReflectsRebindAndUnbind(t *testing.T) {
+	isolateHome(t)
+	defer invalidateKeyMapCache()
+
+	invalidateKeyMapCache()
+	if got := workflowsBuilderHint(); !strings.Contains(got, "ctrl+w") {
+		t.Errorf("default hint should mention ctrl+w; got %q", got)
+	}
+
+	setKeyMapForTesting(KeyMap{
+		ActionScreenWorkflows: {Mod: tea.ModAlt | tea.ModShift, Code: 'q'},
+	})
+	if got := workflowsBuilderHint(); !strings.Contains(got, "alt+shift+q opens the builder") {
+		t.Errorf("rebound hint should name the new key; got %q", got)
+	}
+
+	setKeyMapForTesting(KeyMap{
+		ActionScreenWorkflows: {},
+	})
+	got := workflowsBuilderHint()
+	if strings.Contains(got, "opens the builder") {
+		t.Errorf("unbound hint should not promise a shortcut; got %q", got)
+	}
+	if !strings.Contains(got, "/workflows") {
+		t.Errorf("unbound hint should fall back to the slash command; got %q", got)
+	}
+}
+
+// TestKeybindingsPicker_RendersGroupHeadings proves the picker draws
+// the four group headings — Screens, Tabs, Pickers & dispatch, App —
+// so the user can spot the action they want without scanning a flat
+// list of twelve.
+func TestKeybindingsPicker_RendersGroupHeadings(t *testing.T) {
+	isolateHome(t)
+	invalidateKeyMapCache()
+	defer invalidateKeyMapCache()
+
+	m := newTestModel(t, newFakeProvider())
+	m.width = 120
+	m.mode = modeConfig
+	m.configKeybindingsPickerActive = true
+
+	body := m.viewConfigKeybindingsPicker()
+	for _, heading := range []string{"Screens", "Tabs", "Pickers & dispatch", "App"} {
+		if !strings.Contains(body, heading) {
+			t.Errorf("picker body missing heading %q; got:\n%s", heading, body)
+		}
+	}
+	// Sanity: every action label still renders.
+	for _, item := range actionMeta {
+		if !strings.Contains(body, item.Label) {
+			t.Errorf("picker body missing label %q", item.Label)
+		}
+	}
+}
+
+// TestActionMeta_FlattenedFromGroupsInDisplayOrder pins the
+// cursor-walk order. The picker reads items group-by-group; the flat
+// actionMeta — used for cursor indexing and persistence — must walk
+// the same order so capture mode writes the action under the cursor.
+// Adding a group or reordering items here is a deliberate UX change
+// and should update this test alongside.
+func TestActionMeta_FlattenedFromGroupsInDisplayOrder(t *testing.T) {
+	var want []Action
+	for _, g := range actionGroups {
+		for _, item := range g.Items {
+			want = append(want, item.Action)
+		}
+	}
+	if len(actionMeta) != len(want) {
+		t.Fatalf("actionMeta len=%d, want %d", len(actionMeta), len(want))
+	}
+	for i := range want {
+		if actionMeta[i].Action != want[i] {
+			t.Errorf("actionMeta[%d]=%s, want %s", i, actionMeta[i].Action, want[i])
+		}
+	}
+	// Spot-check: the new ActionTabClose row sits inside the Tabs
+	// group, and ActionReload sits inside Pickers & dispatch. Catches
+	// accidental re-shuffles that would silently move the cursor.
+	if pos := indexOfAction(ActionTabClose); pos < 0 {
+		t.Error("ActionTabClose missing from flat actionMeta")
+	} else if g := groupForFlatIndex(pos); g != "Tabs" {
+		t.Errorf("ActionTabClose lives in group %q, want Tabs", g)
+	}
+	if pos := indexOfAction(ActionReload); pos < 0 {
+		t.Error("ActionReload missing from flat actionMeta")
+	} else if g := groupForFlatIndex(pos); g != "Pickers & dispatch" {
+		t.Errorf("ActionReload lives in group %q, want \"Pickers & dispatch\"", g)
+	}
+}
+
+func indexOfAction(a Action) int {
+	for i, item := range actionMeta {
+		if item.Action == a {
+			return i
+		}
+	}
+	return -1
+}
+
+func groupForFlatIndex(idx int) string {
+	cursor := 0
+	for _, g := range actionGroups {
+		next := cursor + len(g.Items)
+		if idx >= cursor && idx < next {
+			return g.Heading
+		}
+		cursor = next
+	}
+	return ""
 }

--- a/keymap_dispatch_test.go
+++ b/keymap_dispatch_test.go
@@ -202,6 +202,30 @@ func TestConfigKeybindingsPicker_CaptureFunctionKeyRoundTrips(t *testing.T) {
 	}
 }
 
+func TestKeybindingsExpandInnerWidthGrowsToFitLine(t *testing.T) {
+	rows := [][2]string{{"Run workflow on chat", "ctrl+shift+f"}}
+	rowsInnerW := keybindingsPickerInnerWidth(200, rows)
+	prompt := "Press the new key combination for Run workflow on chat (currently ctrl+shift+f)."
+	got := keybindingsExpandInnerWidth(200, rowsInnerW, prompt)
+	if got <= rowsInnerW {
+		t.Fatalf("expanded inner width=%d should grow past row inner width=%d", got, rowsInnerW)
+	}
+	if got < lipgloss.Width(prompt) {
+		t.Errorf("expanded inner width=%d should fit line width=%d on a wide terminal", got, lipgloss.Width(prompt))
+	}
+}
+
+func TestKeybindingsExpandInnerWidthCapsToTerminal(t *testing.T) {
+	rows := [][2]string{{"Run workflow on chat", "ctrl+shift+f"}}
+	rowsInnerW := keybindingsPickerInnerWidth(30, rows)
+	prompt := "Press the new key combination for Run workflow on chat (currently ctrl+shift+f)."
+	got := keybindingsExpandInnerWidth(30, rowsInnerW, prompt)
+	maxInnerW := 30 - themePickerBoxStyle.GetHorizontalFrameSize()
+	if got > maxInnerW {
+		t.Fatalf("expanded inner width=%d exceeds terminal cap=%d", got, maxInnerW)
+	}
+}
+
 func TestKeybindingsPickerWidthCapsToTerminal(t *testing.T) {
 	rows := [][2]string{
 		{"Run workflow on chat", "ctrl+shift+right"},
@@ -328,6 +352,71 @@ func TestConfigKeybindingsPicker_ResetRestoresDefault(t *testing.T) {
 	}
 	if b := currentKeyMap()[ActionScreenWorkflows]; b != defaultKeyBindings[ActionScreenWorkflows] {
 		t.Errorf("reset should restore the default; got %+v", b)
+	}
+}
+
+// Pressing 'u' in row-navigation mode unbinds the focused action. The
+// zero-value KeyBinding is persisted as the empty string; Matches()
+// then returns false for every keypress so the action is silently
+// disabled. Recovery is via 'r' (reset to default) on the same row.
+func TestConfigKeybindingsPicker_UnbindWritesZeroBinding(t *testing.T) {
+	isolateHome(t)
+	invalidateKeyMapCache()
+	defer invalidateKeyMapCache()
+
+	m := newTestModel(t, newFakeProvider())
+	m.mode = modeConfig
+	m.configKeybindingsPickerActive = true
+	for i, am := range actionMeta {
+		if am.Action == ActionScreenWorkflows {
+			m.configKeybindingsCursor = i
+			break
+		}
+	}
+
+	m2, _ := runUpdate(t, m, tea.KeyPressMsg{Code: 'u'})
+	if m2.configKeybindingsCapturing {
+		t.Errorf("unbind must not enter capture mode")
+	}
+	if m2.configKeybindingsError != "" {
+		t.Errorf("unbind errored: %q", m2.configKeybindingsError)
+	}
+
+	cfg, _ := loadConfig()
+	got, present := cfg.Keybindings[string(ActionScreenWorkflows)]
+	if !present {
+		t.Fatalf("unbind should persist an explicit empty entry; got %+v", cfg.Keybindings)
+	}
+	if got != "" {
+		t.Errorf("unbind should store empty string; got %q", got)
+	}
+	def := defaultKeyBindings[ActionScreenWorkflows]
+	if currentKeyMap().Matches(ActionScreenWorkflows, tea.KeyPressMsg{Mod: def.Mod, Code: def.Code}) {
+		t.Error("unbound action must not match its former default keypress")
+	}
+}
+
+// 'u' must NOT trigger an unbind while in capture mode — otherwise the
+// user can never bind a key to 'u' itself. The captured key should be
+// recorded as the binding, same as any other letter key.
+func TestConfigKeybindingsPicker_UInCaptureModeRecordsBinding(t *testing.T) {
+	isolateHome(t)
+	invalidateKeyMapCache()
+	defer invalidateKeyMapCache()
+
+	m := newTestModel(t, newFakeProvider())
+	m.mode = modeConfig
+	m.configKeybindingsPickerActive = true
+	m.configKeybindingsCursor = 0
+	m.configKeybindingsCapturing = true
+
+	m2, _ := runUpdate(t, m, tea.KeyPressMsg{Mod: tea.ModCtrl, Code: 'u'})
+	if m2.configKeybindingsError != "" {
+		t.Fatalf("capture errored: %q", m2.configKeybindingsError)
+	}
+	cfg, _ := loadConfig()
+	if got := cfg.Keybindings[string(actionMeta[0].Action)]; got != "ctrl+u" {
+		t.Errorf("captured binding=%q want ctrl+u", got)
 	}
 }
 

--- a/keymap_test.go
+++ b/keymap_test.go
@@ -1,0 +1,286 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestParseKeyBinding_HappyPaths(t *testing.T) {
+	cases := []struct {
+		in   string
+		want KeyBinding
+	}{
+		{"ctrl+w", KeyBinding{Mod: tea.ModCtrl, Code: 'w'}},
+		{"Ctrl+W", KeyBinding{Mod: tea.ModCtrl, Code: 'w'}},
+		{"ctrl+shift+left", KeyBinding{Mod: tea.ModCtrl | tea.ModShift, Code: tea.KeyLeft}},
+		{"alt+enter", KeyBinding{Mod: tea.ModAlt, Code: tea.KeyEnter}},
+		{"f", KeyBinding{Code: 'f'}},
+		{"space", KeyBinding{Code: tea.KeySpace}},
+		{"ctrl+space", KeyBinding{Mod: tea.ModCtrl, Code: tea.KeySpace}},
+		{"escape", KeyBinding{Code: tea.KeyEsc}},
+		{"pageup", KeyBinding{Code: tea.KeyPgUp}},
+		{"pgdn", KeyBinding{Code: tea.KeyPgDown}},
+		{"  ctrl+w  ", KeyBinding{Mod: tea.ModCtrl, Code: 'w'}},
+		{"", KeyBinding{}},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got, err := ParseKeyBinding(c.in)
+			if err != nil {
+				t.Fatalf("ParseKeyBinding(%q) errored: %v", c.in, err)
+			}
+			if got != c.want {
+				t.Errorf("ParseKeyBinding(%q) = %+v, want %+v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestParseKeyBinding_Errors(t *testing.T) {
+	cases := []string{
+		"ctrl+",                  // empty key after modifier
+		"+w",                     // empty modifier token
+		"ctrl++w",                // double-plus
+		"shiftcontrol+w",         // unknown modifier (not split)
+		"ctrl+notakey",           // unknown multi-rune key
+		"ctrl+ctrl",              // no key part at all
+		"ctrl+up+down",           // two non-modifier tokens
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			if _, err := ParseKeyBinding(in); err == nil {
+				t.Errorf("ParseKeyBinding(%q) should have errored", in)
+			}
+		})
+	}
+}
+
+// Round-trip every binding in the default map through String → Parse.
+// Stringification is what we persist to JSON, so the inverse must be
+// lossless or users would lose overrides on reload.
+func TestKeyBinding_StringRoundTrip(t *testing.T) {
+	for action, b := range defaultKeyBindings {
+		t.Run(string(action), func(t *testing.T) {
+			s := b.String()
+			if s == "" {
+				t.Fatalf("default binding for %s renders empty", action)
+			}
+			parsed, err := ParseKeyBinding(s)
+			if err != nil {
+				t.Fatalf("ParseKeyBinding(%q) errored: %v", s, err)
+			}
+			if parsed != b {
+				t.Errorf("round-trip mismatch for %s: %+v → %q → %+v",
+					action, b, s, parsed)
+			}
+		})
+	}
+}
+
+func TestKeyBinding_String_UnboundIsEmpty(t *testing.T) {
+	if got := (KeyBinding{}).String(); got != "" {
+		t.Errorf("unbound binding should render as empty string, got %q", got)
+	}
+}
+
+func TestKeyBinding_Matches(t *testing.T) {
+	b := KeyBinding{Mod: tea.ModCtrl, Code: 'w'}
+	if !b.Matches(tea.KeyPressMsg{Mod: tea.ModCtrl, Code: 'w'}) {
+		t.Error("should match exact mod+code")
+	}
+	if b.Matches(tea.KeyPressMsg{Mod: 0, Code: 'w'}) {
+		t.Error("must require the modifier")
+	}
+	if b.Matches(tea.KeyPressMsg{Mod: tea.ModCtrl, Code: 'q'}) {
+		t.Error("must require the code")
+	}
+	if b.Matches(tea.KeyPressMsg{Mod: tea.ModCtrl | tea.ModShift, Code: 'w'}) {
+		t.Error("must require the exact modifier mask, not a superset")
+	}
+	if (KeyBinding{}).Matches(tea.KeyPressMsg{Mod: 0, Code: 0}) {
+		t.Error("zero binding must never match (even the zero keypress)")
+	}
+}
+
+// DefaultKeyMap must populate every action that the dispatcher and the
+// /config picker know about — a stray action without a default would
+// look "unbound" to the user and never fire.
+func TestDefaultKeyMap_CoversAllActions(t *testing.T) {
+	km := DefaultKeyMap()
+	for _, am := range actionMeta {
+		if _, ok := km[am.Action]; !ok {
+			t.Errorf("DefaultKeyMap missing action %s (%q)", am.Action, am.Label)
+		}
+	}
+	if len(km) != len(actionMeta) {
+		t.Errorf("DefaultKeyMap has %d entries, actionMeta has %d — keep them in sync",
+			len(km), len(actionMeta))
+	}
+}
+
+// Every default binding must produce a non-empty stringified form so
+// the config picker has something to display and MarshalConfig can
+// detect "matches default" by string equality if it ever needs to.
+func TestDefaultKeyMap_AllBindingsStringify(t *testing.T) {
+	for action, b := range defaultKeyBindings {
+		if b.String() == "" {
+			t.Errorf("default binding for %s has empty String() output", action)
+		}
+	}
+}
+
+func TestLoadKeyMapFromConfig_OverridesDefault(t *testing.T) {
+	km := LoadKeyMapFromConfig(map[string]string{
+		string(ActionScreenWorkflows): "ctrl+shift+w",
+	})
+	got := km[ActionScreenWorkflows]
+	want := KeyBinding{Mod: tea.ModCtrl | tea.ModShift, Code: 'w'}
+	if got != want {
+		t.Errorf("override not applied: got %+v want %+v", got, want)
+	}
+	// Untouched actions must still match the default.
+	if km[ActionScreenIssues] != defaultKeyBindings[ActionScreenIssues] {
+		t.Errorf("unrelated action mutated: got %+v", km[ActionScreenIssues])
+	}
+}
+
+func TestLoadKeyMapFromConfig_SkipsUnknownAction(t *testing.T) {
+	km := LoadKeyMapFromConfig(map[string]string{
+		"made.up.action": "ctrl+x",
+	})
+	if _, ok := km["made.up.action"]; ok {
+		t.Errorf("unknown action should not be added: %+v", km)
+	}
+}
+
+func TestLoadKeyMapFromConfig_SkipsMalformedBinding(t *testing.T) {
+	km := LoadKeyMapFromConfig(map[string]string{
+		string(ActionScreenWorkflows): "totally not a key",
+	})
+	got := km[ActionScreenWorkflows]
+	want := defaultKeyBindings[ActionScreenWorkflows]
+	if got != want {
+		t.Errorf("malformed override should fall back to default: got %+v want %+v", got, want)
+	}
+}
+
+// An explicit empty string in config disables the action. Used by
+// users who want, e.g., Ctrl+Z suspend to not exist.
+func TestLoadKeyMapFromConfig_EmptyStringUnbinds(t *testing.T) {
+	km := LoadKeyMapFromConfig(map[string]string{
+		string(ActionAppSuspend): "",
+	})
+	got := km[ActionAppSuspend]
+	if got != (KeyBinding{}) {
+		t.Errorf("empty string should unbind: got %+v", got)
+	}
+	if km.Matches(ActionAppSuspend, tea.KeyPressMsg{Mod: tea.ModCtrl, Code: 'z'}) {
+		t.Error("unbound action should not match its old default keypress")
+	}
+}
+
+// MarshalConfig must omit defaults so a stock config file stays empty
+// (users who never touched bindings see no clutter in ask.json).
+func TestMarshalConfig_OmitsDefaults(t *testing.T) {
+	km := DefaultKeyMap()
+	got := km.MarshalConfig()
+	if got != nil {
+		t.Errorf("stock keymap should marshal to nil, got %+v", got)
+	}
+}
+
+func TestMarshalConfig_IncludesOverrides(t *testing.T) {
+	km := DefaultKeyMap()
+	km[ActionScreenWorkflows] = KeyBinding{Mod: tea.ModCtrl | tea.ModShift, Code: 'w'}
+	got := km.MarshalConfig()
+	if got == nil {
+		t.Fatal("override should produce a non-nil map")
+	}
+	if v := got[string(ActionScreenWorkflows)]; v != "ctrl+shift+w" {
+		t.Errorf("MarshalConfig override value = %q, want %q", v, "ctrl+shift+w")
+	}
+	if _, ok := got[string(ActionScreenIssues)]; ok {
+		t.Errorf("non-overridden action should not appear in MarshalConfig output: %+v", got)
+	}
+}
+
+// End-to-end round trip: override a binding, marshal, reload, observe
+// the override survives. Catches subtle bugs where String() and Parse
+// disagree on a corner case (e.g. modifier order) that would lose
+// edits across config saves.
+func TestKeyMap_RoundTripThroughConfig(t *testing.T) {
+	override := KeyBinding{Mod: tea.ModAlt | tea.ModShift, Code: tea.KeyRight}
+	km := DefaultKeyMap()
+	km[ActionTabNext] = override
+
+	raw := km.MarshalConfig()
+	if raw == nil {
+		t.Fatal("marshalled config should not be nil after override")
+	}
+	reloaded := LoadKeyMapFromConfig(raw)
+	if got := reloaded[ActionTabNext]; got != override {
+		t.Errorf("round trip lost override: got %+v want %+v", got, override)
+	}
+}
+
+// The cached keymap accessor is the entry point used by dispatch
+// sites; verify the cache invalidates so /config edits take effect
+// immediately rather than after a process restart.
+func TestCurrentKeyMap_InvalidateReloadsFromDisk(t *testing.T) {
+	isolateHome(t)
+	invalidateKeyMapCache()
+	defer invalidateKeyMapCache()
+
+	// First load → default.
+	km1 := currentKeyMap()
+	if got := km1[ActionScreenWorkflows].String(); got != "ctrl+w" {
+		t.Fatalf("expected default ctrl+w for workflows, got %q", got)
+	}
+
+	// Write an override to disk, invalidate, observe new value.
+	if err := saveConfig(askConfig{
+		Keybindings: map[string]string{
+			string(ActionScreenWorkflows): "ctrl+shift+w",
+		},
+	}); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+	invalidateKeyMapCache()
+	km2 := currentKeyMap()
+	if got := km2[ActionScreenWorkflows].String(); got != "ctrl+shift+w" {
+		t.Errorf("after invalidate, expected ctrl+shift+w; got %q", got)
+	}
+}
+
+// setKeyMapForTesting bypasses disk for tests that exercise the
+// dispatch path. Confirm currentKeyMap actually observes the override
+// — otherwise unit tests of remapped actions would silently match
+// defaults regardless of what they pretended to set.
+func TestSetKeyMapForTesting_OverridesCurrent(t *testing.T) {
+	custom := KeyMap{
+		ActionScreenWorkflows: KeyBinding{Mod: tea.ModAlt, Code: 'q'},
+	}
+	setKeyMapForTesting(custom)
+	defer invalidateKeyMapCache()
+
+	if got := currentKeyMap()[ActionScreenWorkflows]; got != (KeyBinding{Mod: tea.ModAlt, Code: 'q'}) {
+		t.Errorf("currentKeyMap did not see the test override: %+v", got)
+	}
+}
+
+// String output must be stable: same binding → same lowercase string
+// every time, modifier order canonicalised. Tests catch a regression
+// where two different bindings could collide in the JSON file because
+// e.g. "shift+ctrl+w" and "ctrl+shift+w" stringified differently.
+func TestKeyBinding_StringIsCanonical(t *testing.T) {
+	a, _ := ParseKeyBinding("shift+ctrl+w")
+	b, _ := ParseKeyBinding("ctrl+shift+w")
+	if a != b {
+		t.Fatalf("parser produced different values for equivalent input: %+v vs %+v", a, b)
+	}
+	if !strings.EqualFold(a.String(), "ctrl+shift+w") {
+		t.Errorf("canonical form should be ctrl+shift+w, got %q", a.String())
+	}
+}

--- a/keymap_test.go
+++ b/keymap_test.go
@@ -18,10 +18,15 @@ func TestParseKeyBinding_HappyPaths(t *testing.T) {
 		{"alt+enter", KeyBinding{Mod: tea.ModAlt, Code: tea.KeyEnter}},
 		{"f", KeyBinding{Code: 'f'}},
 		{"space", KeyBinding{Code: tea.KeySpace}},
+		{"plus", KeyBinding{Code: '+'}},
+		{"ctrl+plus", KeyBinding{Mod: tea.ModCtrl, Code: '+'}},
 		{"ctrl+space", KeyBinding{Mod: tea.ModCtrl, Code: tea.KeySpace}},
 		{"escape", KeyBinding{Code: tea.KeyEsc}},
 		{"pageup", KeyBinding{Code: tea.KeyPgUp}},
 		{"pgdn", KeyBinding{Code: tea.KeyPgDown}},
+		{"ctrl+f12", KeyBinding{Mod: tea.ModCtrl, Code: tea.KeyF12}},
+		{"super+f1", KeyBinding{Mod: tea.ModSuper, Code: tea.KeyF1}},
+		{"meta+hyper+f63", KeyBinding{Mod: tea.ModMeta | tea.ModHyper, Code: tea.KeyF63}},
 		{"  ctrl+w  ", KeyBinding{Mod: tea.ModCtrl, Code: 'w'}},
 		{"", KeyBinding{}},
 	}
@@ -40,16 +45,18 @@ func TestParseKeyBinding_HappyPaths(t *testing.T) {
 
 func TestParseKeyBinding_Errors(t *testing.T) {
 	cases := []string{
-		"ctrl+",                  // empty key after modifier
-		"+w",                     // empty modifier token
-		"ctrl++w",                // double-plus
-		"shiftcontrol+w",         // unknown modifier (not split)
-		"ctrl+notakey",           // unknown multi-rune key
-		"ctrl+ctrl",              // no key part at all
-		"ctrl+up+down",           // two non-modifier tokens
+		"ctrl+",          // empty key after modifier
+		"+w",             // empty modifier token
+		"ctrl++w",        // double-plus
+		"shiftcontrol+w", // unknown modifier (not split)
+		"ctrl+notakey",   // unknown multi-rune key
+		"ctrl",           // modifier without a key
+		"ctrl+ctrl",      // no key part at all
+		"ctrl+up+down",   // two non-modifier tokens
+		"ctrl+\x00",      // code 0 would stringify as unbound
 	}
 	for _, in := range cases {
-		t.Run(in, func(t *testing.T) {
+		t.Run(strings.ReplaceAll(in, "\x00", "\\x00"), func(t *testing.T) {
 			if _, err := ParseKeyBinding(in); err == nil {
 				t.Errorf("ParseKeyBinding(%q) should have errored", in)
 			}
@@ -85,6 +92,18 @@ func TestKeyBinding_String_UnboundIsEmpty(t *testing.T) {
 	}
 }
 
+func TestKeyBinding_StringRejectsUnsupportedCode(t *testing.T) {
+	if got := (KeyBinding{Mod: tea.ModCtrl, Code: rune(-1)}).String(); got != "" {
+		t.Errorf("unsupported key code should render empty, got %q", got)
+	}
+}
+
+func TestKeyBinding_StringRejectsUnsupportedModifier(t *testing.T) {
+	if got := (KeyBinding{Mod: tea.ModCapsLock, Code: 'x'}).String(); got != "" {
+		t.Errorf("unsupported modifier should render empty, got %q", got)
+	}
+}
+
 func TestKeyBinding_Matches(t *testing.T) {
 	b := KeyBinding{Mod: tea.ModCtrl, Code: 'w'}
 	if !b.Matches(tea.KeyPressMsg{Mod: tea.ModCtrl, Code: 'w'}) {
@@ -101,6 +120,21 @@ func TestKeyBinding_Matches(t *testing.T) {
 	}
 	if (KeyBinding{}).Matches(tea.KeyPressMsg{Mod: 0, Code: 0}) {
 		t.Error("zero binding must never match (even the zero keypress)")
+	}
+}
+
+func TestKeyBinding_ExtendedModifiersAndFunctionKeysRoundTrip(t *testing.T) {
+	want := KeyBinding{Mod: tea.ModCtrl | tea.ModMeta | tea.ModHyper | tea.ModSuper, Code: tea.KeyF5}
+	s := want.String()
+	if s != "ctrl+meta+hyper+super+f5" {
+		t.Fatalf("String()=%q want ctrl+meta+hyper+super+f5", s)
+	}
+	got, err := ParseKeyBinding(s)
+	if err != nil {
+		t.Fatalf("ParseKeyBinding(%q): %v", s, err)
+	}
+	if got != want {
+		t.Errorf("round trip got %+v want %+v", got, want)
 	}
 }
 
@@ -203,6 +237,22 @@ func TestMarshalConfig_IncludesOverrides(t *testing.T) {
 	}
 	if _, ok := got[string(ActionScreenIssues)]; ok {
 		t.Errorf("non-overridden action should not appear in MarshalConfig output: %+v", got)
+	}
+}
+
+func TestMarshalConfig_IncludesExplicitUnbound(t *testing.T) {
+	km := DefaultKeyMap()
+	km[ActionAppSuspend] = KeyBinding{}
+	got := km.MarshalConfig()
+	if got == nil {
+		t.Fatal("explicit unbind should produce a non-nil map")
+	}
+	if v, ok := got[string(ActionAppSuspend)]; !ok || v != "" {
+		t.Errorf("explicit unbind marshalled as %q, %v; want empty string entry", v, ok)
+	}
+	reloaded := LoadKeyMapFromConfig(got)
+	if reloaded[ActionAppSuspend] != (KeyBinding{}) {
+		t.Errorf("explicit unbind did not reload as zero binding: %+v", reloaded[ActionAppSuspend])
 	}
 }
 

--- a/ollama.go
+++ b/ollama.go
@@ -81,6 +81,19 @@ func (m model) updateAskOllamaConfig(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m model) applyAskOllamaPaste(content string) (tea.Model, tea.Cmd) {
+	if content == "" {
+		return m, nil
+	}
+	if m.askOllamaField == 0 {
+		m.askOllamaHost += content
+	} else {
+		m.askOllamaModel += content
+	}
+	m.askOllamaErr = ""
+	return m, nil
+}
+
 func (m model) saveOllamaConfig() (tea.Model, tea.Cmd) {
 	host := strings.TrimSpace(m.askOllamaHost)
 	modelName := strings.TrimSpace(m.askOllamaModel)

--- a/tabs.go
+++ b/tabs.go
@@ -108,16 +108,15 @@ func (a app) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a.broadcastResize()
 
 	case tea.KeyPressMsg:
-		if m.Mod == tea.ModCtrl && m.Code == 'z' {
+		km := currentKeyMap()
+		switch {
+		case km.Matches(ActionAppSuspend, m):
 			return a.suspendApp()
-		}
-		if m.Mod == tea.ModCtrl && m.Code == 't' {
+		case km.Matches(ActionTabNew, m):
 			return a.openTab()
-		}
-		if m.Mod == tea.ModCtrl && m.Code == tea.KeyLeft {
+		case km.Matches(ActionTabPrev, m):
 			return a.switchTab(a.active - 1)
-		}
-		if m.Mod == tea.ModCtrl && m.Code == tea.KeyRight {
+		case km.Matches(ActionTabNext, m):
 			return a.switchTab(a.active + 1)
 		}
 		return a.dispatchActive(msg)

--- a/tabs.go
+++ b/tabs.go
@@ -108,6 +108,7 @@ func (a app) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a.broadcastResize()
 
 	case tea.KeyPressMsg:
+		m = normalizeKeyPressMsg(m)
 		km := currentKeyMap()
 		switch {
 		case km.Matches(ActionAppSuspend, m):

--- a/types.go
+++ b/types.go
@@ -517,6 +517,17 @@ type model struct {
 	configProjectFieldEditing string
 	configProjectFieldDraft   string
 
+	// configKeybindingsPickerActive toggles the /config → Keybindings
+	// sub-picker. Rows are the actions from actionMeta. Pressing Enter
+	// on a row flips configKeybindingsCapturing — the next non-Esc
+	// keypress is recorded as the new binding (or written empty by
+	// pressing space, which clears the binding). Esc during capture
+	// cancels without persisting.
+	configKeybindingsPickerActive bool
+	configKeybindingsCursor       int
+	configKeybindingsCapturing    bool
+	configKeybindingsError        string
+
 	// Ctrl+B starts at the provider list (Level 0). Picking a provider
 	// with model options advances to Level 1, which reuses the shared
 	// ask/model modal rather than a separate switcher-specific editor.

--- a/types.go
+++ b/types.go
@@ -520,8 +520,7 @@ type model struct {
 	// configKeybindingsPickerActive toggles the /config → Keybindings
 	// sub-picker. Rows are the actions from actionMeta. Pressing Enter
 	// on a row flips configKeybindingsCapturing — the next non-Esc
-	// keypress is recorded as the new binding (or written empty by
-	// pressing space, which clears the binding). Esc during capture
+	// keypress is recorded as the new binding. Esc during capture
 	// cancels without persisting.
 	configKeybindingsPickerActive bool
 	configKeybindingsCursor       int

--- a/update.go
+++ b/update.go
@@ -1047,7 +1047,7 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 		// on every keypress under the Kitty keyboard protocol. Treating
 		// them as real modifiers would silently break `Mod == 0` gates on
 		// arrow keys, Esc, Enter, etc., so strip them before dispatch.
-		msg.Mod &^= tea.ModCapsLock | tea.ModNumLock | tea.ModScrollLock
+		msg = normalizeKeyPressMsg(msg)
 		// Modal/picker dispatch comes first: anything modal-shaped owns
 		// the keyboard until it dismisses, regardless of which screen is
 		// underneath. Screen-switching is gated against the same

--- a/update.go
+++ b/update.go
@@ -962,11 +962,6 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 		if m.mode == modeConfig && m.configProjectPickerActive && m.configProjectFieldEditing != "" {
 			return m.applyConfigProjectPaste(msg.Content)
 		}
-		// The ask modal has two free-text affordances — the custom row
-		// ("type your own…") and the per-question note editor — that
-		// each accept typed characters. Bracketed paste is the same
-		// modality and must route into whichever is focused; without
-		// this the user could type a URL but not paste one.
 		if m.mode == modeAskQuestion {
 			return m.applyAskPaste(msg.Content)
 		}

--- a/update.go
+++ b/update.go
@@ -962,6 +962,14 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 		if m.mode == modeConfig && m.configProjectPickerActive && m.configProjectFieldEditing != "" {
 			return m.applyConfigProjectPaste(msg.Content)
 		}
+		// The ask modal has two free-text affordances — the custom row
+		// ("type your own…") and the per-question note editor — that
+		// each accept typed characters. Bracketed paste is the same
+		// modality and must route into whichever is focused; without
+		// this the user could type a URL but not paste one.
+		if m.mode == modeAskQuestion {
+			return m.applyAskPaste(msg.Content)
+		}
 		if m.mode != modeInput {
 			return m, nil
 		}

--- a/update.go
+++ b/update.go
@@ -1181,7 +1181,7 @@ func (m model) updateInput(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if m.workflowPicker != nil {
 		return m.updateWorkflowPicker(msg)
 	}
-	if msg.Mod == tea.ModCtrl && msg.Code == 'd' {
+	if currentKeyMap().Matches(ActionTabClose, msg) {
 		return m, closeTabCmd(m.id)
 	}
 	if m.shellMode {
@@ -1590,7 +1590,7 @@ func (m *model) dismissCancelTurnConfirmIfIdle() {
 
 func (m model) updateCloseTabConfirm(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch {
-	case msg.Mod == tea.ModCtrl && msg.Code == 'd':
+	case currentKeyMap().Matches(ActionTabClose, msg):
 		m.closeTabConfirming = false
 		return m, closeTabCmd(m.id)
 	case msg.Mod == tea.ModCtrl && msg.Code == 'c':
@@ -1691,7 +1691,7 @@ func (m model) applyPRMergeConfirm() (tea.Model, tea.Cmd) {
 }
 
 func (m model) updatePicker(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	if msg.Mod == tea.ModCtrl && msg.Code == 'd' {
+	if currentKeyMap().Matches(ActionTabClose, msg) {
 		return m, closeTabCmd(m.id)
 	}
 	if msg.Mod == tea.ModCtrl && msg.Code == 'c' {

--- a/update.go
+++ b/update.go
@@ -1093,7 +1093,8 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 		// Cycling is a no-op on views that aren't in the cycle (e.g.
 		// the detail view returned by Enter), which keeps Ctrl+I from
 		// surprising a user mid-read.
-		if msg.Mod == tea.ModCtrl && msg.Code == 'i' && !m.modalOpen() {
+		km := currentKeyMap()
+		if km.Matches(ActionScreenIssues, msg) && !m.modalOpen() {
 			if m.screen == screenIssues {
 				if s := m.issueStateForScreen(screenIssues); s != nil {
 					s.cycleView()
@@ -1122,7 +1123,7 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 			}
 			return m.enterIssueScreen(screenIssues, provider, pc)
 		}
-		if msg.Mod == tea.ModCtrl && msg.Code == 'p' && !m.modalOpen() {
+		if km.Matches(ActionScreenPRs, msg) && !m.modalOpen() {
 			if m.screen == screenPRs {
 				if s := m.issueStateForScreen(screenPRs); s != nil {
 					s.cycleView()
@@ -1140,10 +1141,9 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 			}
 			return m.enterIssueScreen(screenPRs, provider, pc)
 		}
-		if msg.Mod == tea.ModCtrl && msg.Code == 'w' && !m.modalOpen() {
-			// Ctrl+W opens the workflows builder. Going to the
-			// builder from the issues screen mirrors Ctrl+I's
-			// "drop the cache + cancel in-flight" hygiene so a
+		if km.Matches(ActionScreenWorkflows, msg) && !m.modalOpen() {
+			// Workflows screen: drop issue-screen cache on the way
+			// out mirrors Ctrl+I's "cancel in-flight" hygiene so a
 			// later return to issues re-fetches cleanly.
 			if isIssueScreen(m.screen) {
 				m.discardIssueScreenState(m.screen)
@@ -1156,7 +1156,7 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 			}
 			return m, nil
 		}
-		if msg.Mod == tea.ModCtrl && msg.Code == 'o' && !m.modalOpen() {
+		if km.Matches(ActionScreenAsk, msg) && !m.modalOpen() {
 			// Leaving issues: drop cache + cancel in-flight so re-entry
 			// doesn't stack duplicate chunks onto the chain. Carry
 			// state lives on the kanban view, so we re-insert the
@@ -1230,7 +1230,8 @@ func (m model) updateInput(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if msg.Mod == tea.ModCtrl && msg.Code == 'v' {
 		return m, pasteImageCmd()
 	}
-	if msg.Mod == tea.ModCtrl && msg.Code == 'b' {
+	km := currentKeyMap()
+	if km.Matches(ActionProviderSwitch, msg) {
 		if m.busy {
 			// Don't allow swapping mid-turn — the stream reader is
 			// tied to the current proc and the session id is about to
@@ -1247,10 +1248,10 @@ func (m model) updateInput(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 		return m.openProviderSwitch(), nil
 	}
-	if msg.Mod == tea.ModCtrl && msg.Code == 'f' {
+	if km.Matches(ActionChatWorkflow, msg) {
 		// Path-picker / slash popover are mid-edit affordances; let
-		// them keep the keypress so Ctrl+F doesn't yank the user out
-		// of an in-flight completion.
+		// them keep the keypress so the chat-workflow trigger doesn't
+		// yank the user out of an in-flight completion.
 		if m.pathPickerActive() || len(m.filterSlashCmds()) > 0 {
 			return m, nil
 		}

--- a/update_test.go
+++ b/update_test.go
@@ -1465,7 +1465,10 @@ func TestUpdate_PasteMsgDuringCloseTabConfirmIsAbsorbed(t *testing.T) {
 // Paste in any mode that isn't modeInput is absorbed (with the two
 // config-field-edit fast paths handled by their own tests). Covers
 // every non-input viewMode so a future mode addition can't silently
-// fall through to the textarea.
+// fall through to the textarea. The askQuestion case here has empty
+// questions/answers so applyAskPaste hits its no-destination guard;
+// the routed paths (custom row, note editor) have their own tests
+// below.
 func TestUpdate_PasteMsgInNonInputModesIsAbsorbed(t *testing.T) {
 	cases := []struct {
 		name string
@@ -1531,6 +1534,124 @@ func TestUpdate_PasteMsgInConfigProjectFieldEditorRoutes(t *testing.T) {
 	}
 	if m2.input.Value() != "composer-untouched" {
 		t.Errorf("composer must not receive the paste while a project field is open: %q", m2.input.Value())
+	}
+}
+
+// Bracketed paste with the cursor on the ask modal's "Enter your own"
+// row routes into qAnswer.custom — the same destination the typed-text
+// branch in handleCustomTyping writes to. Without this the user can
+// type a URL but not paste one, which is what the bug report flagged.
+func TestUpdate_PasteMsgInAskModalCustomRowRoutesToCustom(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m = m.startAsk([]question{{
+		kind:    qPickOne,
+		prompt:  "pick a model",
+		options: []string{"default", "gpt-5", switcherCustomRowLabel},
+	}})
+	m.askCursor = 2 // custom row
+	m.input.SetValue("seed")
+
+	m2, _ := runUpdate(t, m, tea.PasteMsg{Content: "pasted-model-id"})
+
+	if m2.askAnswers[0].custom != "pasted-model-id" {
+		t.Errorf("paste should land in qAnswer.custom: got %q", m2.askAnswers[0].custom)
+	}
+	if m2.input.Value() != "seed" {
+		t.Errorf("paste must not leak into the chat composer: got %q", m2.input.Value())
+	}
+	if m2.mode != modeAskQuestion {
+		t.Errorf("paste must not close the modal; mode=%v", m2.mode)
+	}
+}
+
+// Multi-line paste preserves newlines — handleCustomTyping already
+// supports them via shift+enter, and pasted strings must behave the
+// same so dropping a code block into the custom row works.
+func TestUpdate_PasteMsgInAskModalCustomRowPreservesNewlines(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m = m.startAsk([]question{{
+		kind:    qPickOne,
+		prompt:  "instructions",
+		options: []string{"a", "b", switcherCustomRowLabel},
+	}})
+	m.askCursor = 2
+	m.askAnswers[0].custom = "prefix: "
+
+	m2, _ := runUpdate(t, m, tea.PasteMsg{Content: "line1\nline2"})
+
+	if m2.askAnswers[0].custom != "prefix: line1\nline2" {
+		t.Errorf("paste should append verbatim including newline: got %q", m2.askAnswers[0].custom)
+	}
+}
+
+// On a qPickMany question, the typed-text branch auto-selects the
+// custom row as soon as it becomes non-empty. Paste must mirror that
+// so a pasted answer is actually submitted with the other picks.
+func TestUpdate_PasteMsgInAskModalCustomRowAutoSelectsForPickMany(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m = m.startAsk([]question{{
+		kind:    qPickMany,
+		prompt:  "pick any",
+		options: []string{"a", "b", switcherCustomRowLabel},
+	}})
+	m.askCursor = 2
+	if _, ok := m.askAnswers[0].picks[2]; ok {
+		t.Fatalf("precondition: custom pick should start unset")
+	}
+
+	m2, _ := runUpdate(t, m, tea.PasteMsg{Content: "custom-answer"})
+
+	if !m2.askAnswers[0].picks[2] {
+		t.Errorf("paste into custom row on qPickMany must auto-select the row; picks=%v",
+			m2.askAnswers[0].picks)
+	}
+}
+
+// While the note editor is active (user pressed `n`), paste should
+// append to qAnswer.note — same destination the typed-text branch in
+// updateAsk's askEditNote arm uses. Without this, taking notes by
+// pasting a stack trace into the modal is impossible.
+func TestUpdate_PasteMsgInAskModalNoteEditorRoutesToNote(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m = m.startAsk([]question{{
+		kind:    qPickOne,
+		prompt:  "pick one",
+		options: []string{"a", "b"},
+	}})
+	m.askEditing = askEditNote
+	m.askAnswers[0].note = "context: "
+
+	m2, _ := runUpdate(t, m, tea.PasteMsg{Content: "extra\nlines"})
+
+	if m2.askAnswers[0].note != "context: extra\nlines" {
+		t.Errorf("paste should append to qAnswer.note: got %q", m2.askAnswers[0].note)
+	}
+	if m2.askEditing != askEditNote {
+		t.Errorf("paste must not exit note edit mode; askEditing=%v", m2.askEditing)
+	}
+}
+
+// Cursor on a regular option (not the custom row, not editing a note)
+// has no destination for the paste — absorb silently. Mirrors the
+// updateAsk behaviour where typed text on a non-custom row is a no-op.
+func TestUpdate_PasteMsgInAskModalOnFixedOptionIsAbsorbed(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m = m.startAsk([]question{{
+		kind:    qPickOne,
+		prompt:  "pick one",
+		options: []string{"a", "b", switcherCustomRowLabel},
+	}})
+	m.askCursor = 0 // on a fixed option, not custom
+	m.askAnswers[0].custom = "untouched"
+	m.input.SetValue("seed")
+
+	m2, _ := runUpdate(t, m, tea.PasteMsg{Content: "leak"})
+
+	if m2.askAnswers[0].custom != "untouched" {
+		t.Errorf("paste on fixed option must not touch custom: got %q", m2.askAnswers[0].custom)
+	}
+	if m2.input.Value() != "seed" {
+		t.Errorf("paste must not leak into the chat composer: got %q", m2.input.Value())
 	}
 }
 

--- a/update_test.go
+++ b/update_test.go
@@ -1465,10 +1465,7 @@ func TestUpdate_PasteMsgDuringCloseTabConfirmIsAbsorbed(t *testing.T) {
 // Paste in any mode that isn't modeInput is absorbed (with the two
 // config-field-edit fast paths handled by their own tests). Covers
 // every non-input viewMode so a future mode addition can't silently
-// fall through to the textarea. The askQuestion case here has empty
-// questions/answers so applyAskPaste hits its no-destination guard;
-// the routed paths (custom row, note editor) have their own tests
-// below.
+// fall through to the textarea.
 func TestUpdate_PasteMsgInNonInputModesIsAbsorbed(t *testing.T) {
 	cases := []struct {
 		name string
@@ -1537,10 +1534,6 @@ func TestUpdate_PasteMsgInConfigProjectFieldEditorRoutes(t *testing.T) {
 	}
 }
 
-// Bracketed paste with the cursor on the ask modal's "Enter your own"
-// row routes into qAnswer.custom — the same destination the typed-text
-// branch in handleCustomTyping writes to. Without this the user can
-// type a URL but not paste one, which is what the bug report flagged.
 func TestUpdate_PasteMsgInAskModalCustomRowRoutesToCustom(t *testing.T) {
 	m := newTestModel(t, newFakeProvider())
 	m = m.startAsk([]question{{
@@ -1564,9 +1557,6 @@ func TestUpdate_PasteMsgInAskModalCustomRowRoutesToCustom(t *testing.T) {
 	}
 }
 
-// Multi-line paste preserves newlines — handleCustomTyping already
-// supports them via shift+enter, and pasted strings must behave the
-// same so dropping a code block into the custom row works.
 func TestUpdate_PasteMsgInAskModalCustomRowPreservesNewlines(t *testing.T) {
 	m := newTestModel(t, newFakeProvider())
 	m = m.startAsk([]question{{
@@ -1584,9 +1574,6 @@ func TestUpdate_PasteMsgInAskModalCustomRowPreservesNewlines(t *testing.T) {
 	}
 }
 
-// On a qPickMany question, the typed-text branch auto-selects the
-// custom row as soon as it becomes non-empty. Paste must mirror that
-// so a pasted answer is actually submitted with the other picks.
 func TestUpdate_PasteMsgInAskModalCustomRowAutoSelectsForPickMany(t *testing.T) {
 	m := newTestModel(t, newFakeProvider())
 	m = m.startAsk([]question{{
@@ -1607,10 +1594,6 @@ func TestUpdate_PasteMsgInAskModalCustomRowAutoSelectsForPickMany(t *testing.T) 
 	}
 }
 
-// While the note editor is active (user pressed `n`), paste should
-// append to qAnswer.note — same destination the typed-text branch in
-// updateAsk's askEditNote arm uses. Without this, taking notes by
-// pasting a stack trace into the modal is impossible.
 func TestUpdate_PasteMsgInAskModalNoteEditorRoutesToNote(t *testing.T) {
 	m := newTestModel(t, newFakeProvider())
 	m = m.startAsk([]question{{
@@ -1631,9 +1614,6 @@ func TestUpdate_PasteMsgInAskModalNoteEditorRoutesToNote(t *testing.T) {
 	}
 }
 
-// Cursor on a regular option (not the custom row, not editing a note)
-// has no destination for the paste — absorb silently. Mirrors the
-// updateAsk behaviour where typed text on a non-custom row is a no-op.
 func TestUpdate_PasteMsgInAskModalOnFixedOptionIsAbsorbed(t *testing.T) {
 	m := newTestModel(t, newFakeProvider())
 	m = m.startAsk([]question{{
@@ -1652,6 +1632,98 @@ func TestUpdate_PasteMsgInAskModalOnFixedOptionIsAbsorbed(t *testing.T) {
 	}
 	if m2.input.Value() != "seed" {
 		t.Errorf("paste must not leak into the chat composer: got %q", m2.input.Value())
+	}
+}
+
+func TestUpdate_PasteMsgInAskModalCancelConfirmIsAbsorbed(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m = m.startAsk([]question{{
+		kind:    qPickOne,
+		prompt:  "pick one",
+		options: []string{"a", switcherCustomRowLabel},
+	}})
+	m.askCursor = 1
+	m.askConfirmingCancel = true
+	m.askAnswers[0].custom = "untouched"
+	m.input.SetValue("seed")
+
+	m2, _ := runUpdate(t, m, tea.PasteMsg{Content: "leak"})
+
+	if m2.askAnswers[0].custom != "untouched" {
+		t.Errorf("paste during ask cancel confirm must not touch custom: got %q", m2.askAnswers[0].custom)
+	}
+	if m2.input.Value() != "seed" {
+		t.Errorf("paste must not leak into the chat composer: got %q", m2.input.Value())
+	}
+	if !m2.askConfirmingCancel {
+		t.Errorf("paste must not dismiss the ask cancel confirm")
+	}
+}
+
+func TestUpdate_PasteMsgInAskModalOllamaConfigRoutesToActiveField(t *testing.T) {
+	cases := []struct {
+		name      string
+		field     int
+		host      string
+		model     string
+		content   string
+		wantHost  string
+		wantModel string
+	}{
+		{
+			name:      "host",
+			field:     0,
+			host:      "http://",
+			model:     "llama3",
+			content:   "localhost:11434",
+			wantHost:  "http://localhost:11434",
+			wantModel: "llama3",
+		},
+		{
+			name:      "model",
+			field:     1,
+			host:      "localhost:11434",
+			model:     "llama",
+			content:   "3.2",
+			wantHost:  "localhost:11434",
+			wantModel: "llama3.2",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := newTestModel(t, newFakeProvider())
+			m = m.startAsk([]question{{
+				kind:    qPickOne,
+				prompt:  "pick a model",
+				options: []string{ollamaModelOption, switcherCustomRowLabel},
+			}})
+			m.askCursor = 1
+			m.askAnswers[0].custom = "custom"
+			m.askOllamaActive = true
+			m.askOllamaField = c.field
+			m.askOllamaHost = c.host
+			m.askOllamaModel = c.model
+			m.askOllamaErr = "previous error"
+			m.input.SetValue("seed")
+
+			m2, _ := runUpdate(t, m, tea.PasteMsg{Content: c.content})
+
+			if m2.askOllamaHost != c.wantHost {
+				t.Errorf("askOllamaHost=%q want %q", m2.askOllamaHost, c.wantHost)
+			}
+			if m2.askOllamaModel != c.wantModel {
+				t.Errorf("askOllamaModel=%q want %q", m2.askOllamaModel, c.wantModel)
+			}
+			if m2.askOllamaErr != "" {
+				t.Errorf("paste should clear askOllamaErr, got %q", m2.askOllamaErr)
+			}
+			if m2.askAnswers[0].custom != "custom" {
+				t.Errorf("ollama paste must not touch the underlying custom row: got %q", m2.askAnswers[0].custom)
+			}
+			if m2.input.Value() != "seed" {
+				t.Errorf("paste must not leak into the chat composer: got %q", m2.input.Value())
+			}
+		})
 	}
 }
 

--- a/view.go
+++ b/view.go
@@ -1197,7 +1197,7 @@ func workflowBannerSourceLabel(s workflowSource) string {
 // chat input on a workflow tab. While the chain runs the banner shows
 // the current step; on completion it swaps to a "complete" message;
 // on failure it carries the error. The user has no input affordance
-// — closing the tab (ctrl+d) is the only action.
+// — closing the tab (ActionTabClose) is the only action.
 func (m model) renderWorkflowBanner() string {
 	r := m.workflowRun
 	if r == nil {
@@ -1211,6 +1211,14 @@ func (m model) renderWorkflowBanner() string {
 		Border(lipgloss.RoundedBorder()).
 		Padding(0, 1).
 		Width(width)
+	closeClause := keyClause(ActionTabClose, "to close")
+	if closeClause == "" {
+		closeClause = "close tab from /config"
+	}
+	cancelClause := keyClause(ActionTabClose, "cancel")
+	if cancelClause == "" {
+		cancelClause = "cancel from /config"
+	}
 	var title, line2 string
 	sourceLabel := workflowBannerSourceLabel(r.Source)
 	switch {
@@ -1221,13 +1229,20 @@ func (m model) renderWorkflowBanner() string {
 		if reason == "" {
 			reason = "step error"
 		}
-		line2 = dimStyle.Render(fmt.Sprintf("%s · step %d · %s · ctrl+d to close",
-			sourceLabel, r.StepIdx+1, reason))
+		line2 = dimStyle.Render(joinHintClauses(
+			sourceLabel,
+			fmt.Sprintf("step %d", r.StepIdx+1),
+			reason,
+			closeClause,
+		))
 	case r.done:
 		box = box.BorderForeground(activeTheme.accent)
 		title = promptStyle.Render("✓ workflow complete: ") + r.Workflow.Name
-		line2 = dimStyle.Render(fmt.Sprintf("%s · %d step(s) · ctrl+d to close",
-			sourceLabel, len(r.Workflow.Steps)))
+		line2 = dimStyle.Render(joinHintClauses(
+			sourceLabel,
+			fmt.Sprintf("%d step(s)", len(r.Workflow.Steps)),
+			closeClause,
+		))
 	default:
 		box = box.BorderForeground(activeTheme.accent)
 		stepName := "(unnamed)"
@@ -1247,8 +1262,11 @@ func (m model) renderWorkflowBanner() string {
 		}
 		title = promptStyle.Render("▸ workflow ") + r.Workflow.Name +
 			dimStyle.Render(fmt.Sprintf(" · step %d/%d: %s", r.StepIdx+1, len(r.Workflow.Steps), stepName))
-		line2 = dimStyle.Render(fmt.Sprintf("%s · %s · ctrl+d cancel",
-			sourceLabel, runMeta))
+		line2 = dimStyle.Render(joinHintClauses(
+			sourceLabel,
+			runMeta,
+			cancelClause,
+		))
 	}
 	return box.Render(title + "\n" + line2)
 }

--- a/view.go
+++ b/view.go
@@ -794,6 +794,23 @@ func (m model) View() tea.View {
 					Max: image.Pt(pX+pW, pY+pH),
 				})
 			}
+			if m.configKeybindingsPickerActive {
+				picker := m.viewConfigKeybindingsPicker()
+				pW := lipgloss.Width(picker)
+				pH := lipgloss.Height(picker)
+				pX := (m.width - pW) / 2
+				pY := (m.height - pH) / 2
+				if pX < 0 {
+					pX = 0
+				}
+				if pY < 0 {
+					pY = 0
+				}
+				uv.NewStyledString(picker).Draw(canvas, image.Rectangle{
+					Min: image.Pt(pX, pY),
+					Max: image.Pt(pX+pW, pY+pH),
+				})
+			}
 		}
 		if needSwitch {
 			picker := m.viewProviderSwitch()

--- a/workflows_picker.go
+++ b/workflows_picker.go
@@ -103,7 +103,7 @@ func (m model) renderWorkflowPicker() string {
 
 	rows := make([]string, 0, max(1, len(pkr.Items)))
 	if len(pkr.Items) == 0 {
-		rows = append(rows, dimStyle.Render("(no workflows configured — ctrl+w opens the builder)"))
+		rows = append(rows, dimStyle.Render("("+workflowsBuilderHint()+")"))
 	} else {
 		for i, w := range pkr.Items {
 			label := w.Name

--- a/workflows_run.go
+++ b/workflows_run.go
@@ -11,11 +11,11 @@ import (
 // workflowTabHandleKey gates input on a workflow tab. The user
 // cannot type a turn — there is no chat input on a workflow tab —
 // but they can still scroll the chat viewport to read streaming
-// output, copy text, cancel the run (Ctrl+C), or close the tab
-// (Ctrl+D). Every other key is silently absorbed so a stray press
-// can't bleed into the chain.
+// output, cancel the run (Ctrl+C), or close the tab (ActionTabClose,
+// default Ctrl+D). Every other key is silently absorbed so a stray
+// press can't bleed into the chain.
 func (m model) workflowTabHandleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	if msg.Mod == tea.ModCtrl && msg.Code == 'd' {
+	if currentKeyMap().Matches(ActionTabClose, msg) {
 		return m, closeTabCmd(m.id)
 	}
 	if msg.Mod == tea.ModCtrl && msg.Code == 'c' {

--- a/workflows_screen.go
+++ b/workflows_screen.go
@@ -119,7 +119,7 @@ func (workflowsScreen) updateKey(m model, msg tea.KeyPressMsg) (model, tea.Cmd, 
 	if m.workflowsBuilder == nil {
 		m.workflowsBuilder = newWorkflowsBuilderState(m.cwd)
 	}
-	if msg.Mod == tea.ModCtrl && msg.Code == 'd' {
+	if currentKeyMap().Matches(ActionTabClose, msg) {
 		return m, closeTabCmd(m.id), true
 	}
 	b := m.workflowsBuilder


### PR DESCRIPTION
## Summary

Users can now remap the global screen-switch and tab-navigation shortcuts (`Ctrl+W` workflows, `Ctrl+I` issues, `Ctrl+P` PRs, `Ctrl+O` ask, `Ctrl+B` provider switch, `Ctrl+F` chat workflow, `Ctrl+T` new tab, `Ctrl+Left/Right` tab navigation, `Ctrl+Z` suspend) through a new `/config → Keybindings...` sub-picker. Overrides persist to `~/.config/ask/ask.json` under a new `"keybindings"` field; missing field = "all defaults" so existing configs need no migration.

## Scope (and what's deliberately *not* in this PR)

The keymap covers exactly the **global, modal-blocking shortcuts** that live in `tabs.go:110-122` and `update.go:1095-1175 / 1233-1258` — ~15 call sites. Per-screen navigation (kanban `j/k/Space`/arrows, workflow builder `Tab`, modal `↑↓/Enter/Esc`, the universal `Ctrl+D` close-tab escape hatch present in 11 modal handlers) **stays inline**. Two reasons: it's a 60+-site refactor for low return, and `Ctrl+D` close must not depend on a potentially-misconfigured keymap — losing your way out of a modal because you typo'd a config edit is worse than not supporting the customisation.

If a follow-up wants to widen the surface, the `Action` enum is the seam: add a constant, an `actionMeta` entry, a default binding, and replace one inline check with `currentKeyMap().Matches(action, msg)`.

## Approach

### `keymap.go` (new)

- `Action` constants (`screen.issues`, `screen.prs`, `screen.workflows`, `screen.ask`, `provider.switch`, `chat.workflow`, `tab.new`, `tab.prev`, `tab.next`, `app.suspend`).
- `KeyBinding{Mod, Code}` with `Matches(msg)` and `String()`.
- `ParseKeyBinding` accepts `"ctrl+w"`, `"ctrl+shift+left"`, `"alt+enter"`, `"f"`, `"space"`, `"pgup"`, etc. Aliases (`escape`/`esc`, `pageup`/`pgup`, `return`/`enter`) all resolve to the same code. Empty input → zero binding (explicit "unbound", used to disable an action via `""` in config).
- Canonical modifier order on stringify (`ctrl+shift+w`, never `shift+ctrl+w`) so the JSON file can't accumulate duplicate-key entries.
- `KeyMap` = resolved `action → binding`. `DefaultKeyMap()` reproduces today's behaviour bit-for-bit. `LoadKeyMapFromConfig` skips unknown actions (forward-compat) and malformed bindings (typo doesn't crash startup, just logs via `debugLog`). `MarshalConfig` omits defaults so a stock config file stays empty.
- `currentKeyMap()` is a process-scoped cached accessor (`sync.RWMutex`), lazy-loaded on first call. Sub-microsecond at dispatch time. `invalidateKeyMapCache()` drops the cache after a `/config` write so edits take effect immediately. `setKeyMapForTesting()` is the tests-only override path.

### `config_keybindings.go` (new)

`/config → Keybindings...` sub-picker mirrors the memory picker's chrome:

- ↑↓ navigates the action list.
- Enter on a row arms **capture mode** — the next non-Esc keypress is recorded as the new binding.
- Esc during capture aborts without writing.
- `persistKeyBinding` writes through `withConfigLock` (same discipline as the rest of `/config`), and re-binding to the default *deletes* the entry rather than persisting a redundant override.

### Dispatch rewires (small)

- `tabs.go:110-122` — Ctrl+Z/T/Left/Right replaced by a 5-case switch on `currentKeyMap().Matches(...)`.
- `update.go:1095-1175` — the four global screen-switch checks (`Ctrl+I/P/W/O`) routed through the keymap.
- `update.go:1233-1258` — Ctrl+B (provider switch) and Ctrl+F (chat workflow) in `updateInput` routed too.
- `view.go` — new overlay draw call for the keybindings sub-picker.
- `types.go` — four picker-state fields (`configKeybindingsPickerActive`, `configKeybindingsCursor`, `configKeybindingsCapturing`, `configKeybindingsError`).
- `config_modal.go` — Keybindings row added to `globalConfigItems()`, dispatch wiring in `updateConfigModal` and `handleGlobalConfigEnter`.

### `CLAUDE.md`

File-table and test-layout sections updated to point at the new files.

## Tests (51 new)

**`keymap_test.go`:**

- `ParseKeyBinding` happy paths: 12 forms including aliases, case insensitivity, surrounding whitespace, empty input.
- `ParseKeyBinding` errors: 7 malformed inputs (`"ctrl+"`, `"+w"`, `"ctrl++w"`, `"shiftcontrol+w"`, `"ctrl+notakey"`, `"ctrl+ctrl"`, `"ctrl+up+down"`).
- `String() → Parse` round-trip across every default binding.
- Canonical form: `"shift+ctrl+w"` and `"ctrl+shift+w"` parse identical and both stringify to `"ctrl+shift+w"`.
- `DefaultKeyMap` covers every action in `actionMeta` (and vice versa by length) — a stray action without a default fails CI.
- `LoadKeyMapFromConfig` overrides apply, unknown actions skipped, malformed bindings fall back to defaults, empty-string unbinds an action.
- `MarshalConfig` omits defaults, includes overrides, round-trips through reload.
- `currentKeyMap` invalidates on demand; `setKeyMapForTesting` is observable.

**`keymap_dispatch_test.go`:**

- End-to-end remap: with `ActionTabNext` overridden to `alt+'q'`, pressing the old default `ctrl+right` no longer advances tabs; pressing `alt+'q'` does.
- Defaults still work when no overrides are installed.
- `/config` capture flow: open picker, Enter to arm capture, capture an `alt+shift+x`, observe `cfg.Keybindings` on disk and `currentKeyMap()` both reflect the override.
- Esc during capture aborts without writing.
- Re-binding to default removes the entry from `cfg.Keybindings`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -count=1 -run 'TestParseKeyBinding|TestKeyBinding|TestDefaultKeyMap|TestLoadKeyMapFromConfig|TestMarshalConfig|TestKeyMap_|TestCurrentKeyMap|TestSetKeyMapForTesting|TestApp_Tab|TestConfigKeybindingsPicker' .` — 51 pass
- [x] `go test -count=1 -run 'TestUpdate_|TestProviderSwitch|TestSwitcher|TestChatWorkflow|TestIssuesWorkflow|TestApp_' .` — 126 pass (no regressions in surrounding tests)
- [x] Full `go test ./...` — pre-existing `TestLinear*` / `TestWorkflow{List,Get,Create,Edit,Delete,Run}*MCP*` failures on `main` unchanged; no new failures introduced
- [ ] Manual: open `/config → Global Options → Keybindings...`, remap "Workflows screen" to `ctrl+shift+w`, verify `~/.config/ask/ask.json` has the override, restart `ask`, verify the new binding fires and old `ctrl+w` no longer does

🤖 Generated with [Claude Code](https://claude.com/claude-code)