### PR TITLE
fix: wire /config top-level filter to its handler

### DIFF
--- a/config_memory.go
+++ b/config_memory.go
@@ -249,7 +249,7 @@ func (m model) updateConfigMemoryFieldInput(msg tea.KeyPressMsg) (tea.Model, tea
 		}
 		return m, nil
 	}
-	if msg.Text != "" && msg.Mod&^tea.ModShift == 0 {
+	if configTextInputKey(msg) {
 		m.configMemoryFieldDraft += msg.Text
 		return m, nil
 	}

--- a/config_modal.go
+++ b/config_modal.go
@@ -159,7 +159,7 @@ func (m model) updateConfigModal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if msg.Mod == tea.ModCtrl && msg.Code == 'c' {
 		return m.clearConfigModal(), nil
 	}
-	items := m.configItemsAll()
+	items := m.filteredConfigItems()
 	switch msg.Code {
 	case tea.KeyEsc:
 		return m.clearConfigModal(), nil
@@ -186,6 +186,18 @@ func (m model) updateConfigModal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		return m.clearConfigModal(), nil
+	case tea.KeyBackspace:
+		if m.configFilter != "" {
+			r := []rune(m.configFilter)
+			m.configFilter = string(r[:len(r)-1])
+			m.configCursor = 0
+		}
+		return m, nil
+	}
+	if msg.Text != "" && msg.Mod&^tea.ModShift == 0 {
+		m.configFilter += msg.Text
+		m.configCursor = 0
+		return m, nil
 	}
 	return m, nil
 }
@@ -195,11 +207,11 @@ func (m model) updateConfigModal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 // layering. Cursor + filter reset on entry so the user lands on
 // the first row.
 //
-// NOTE: configFilter is currently a single field shared with the
-// (now empty) top-level filter. It's reset on open and on close
-// here so the layers don't see each other's strings, but the next
-// submenu that wants its own filter should split this into
-// per-picker fields rather than reusing the shared slot.
+// NOTE: configFilter is a single field shared with the top-level
+// "Global / Project" filter. It's reset on open and on close here so
+// the layers don't see each other's strings; the next submenu that
+// wants its own filter should split this into per-picker fields
+// rather than reusing the shared slot.
 func (m model) openConfigGlobalPicker() model {
 	m.configGlobalPickerActive = true
 	m.configGlobalCursor = 0

--- a/config_modal.go
+++ b/config_modal.go
@@ -194,12 +194,16 @@ func (m model) updateConfigModal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	}
-	if msg.Text != "" && msg.Mod&^tea.ModShift == 0 {
+	if configTextInputKey(msg) {
 		m.configFilter += msg.Text
 		m.configCursor = 0
 		return m, nil
 	}
 	return m, nil
+}
+
+func configTextInputKey(msg tea.KeyPressMsg) bool {
+	return msg.Text != "" && stripKeyLockModifiers(msg.Mod)&^tea.ModShift == 0
 }
 
 // openConfigGlobalPicker opens the Global Options submenu — the
@@ -264,7 +268,7 @@ func (m model) updateConfigGlobalPicker(msg tea.KeyPressMsg) (tea.Model, tea.Cmd
 		}
 		return m, nil
 	}
-	if msg.Text != "" && msg.Mod&^tea.ModShift == 0 {
+	if configTextInputKey(msg) {
 		m.configFilter += msg.Text
 		m.configGlobalCursor = 0
 		return m, nil

--- a/config_project.go
+++ b/config_project.go
@@ -240,7 +240,7 @@ func (m model) updateConfigProjectPicker(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 		}
 		return m, nil
 	}
-	if msg.Text != "" && msg.Mod&^tea.ModShift == 0 {
+	if configTextInputKey(msg) {
 		m.configFilter += msg.Text
 		m.configProjectCursor = 0
 		return m, nil
@@ -346,7 +346,7 @@ func (m model) updateConfigProjectFieldInput(msg tea.KeyPressMsg) (tea.Model, te
 		}
 		return m, nil
 	}
-	if msg.Text != "" && msg.Mod&^tea.ModShift == 0 {
+	if configTextInputKey(msg) {
 		m.configProjectFieldDraft += msg.Text
 		return m, nil
 	}

--- a/config_project_test.go
+++ b/config_project_test.go
@@ -64,6 +64,60 @@ func TestEnterTopLevel_ProjectRow_OpensSubmenu(t *testing.T) {
 	}
 }
 
+// TestConfigTopLevel_FilterAndBackspace covers the regression where
+// typing at the top-level /config menu did nothing — the renderer
+// already drew the "Type to filter" placeholder via filteredConfigItems,
+// but the handler was reading the unfiltered list and never captured
+// text into m.configFilter. Typing should narrow the rows and
+// Backspace should restore the full list.
+func TestConfigTopLevel_FilterAndBackspace(t *testing.T) {
+	isolateHome(t)
+	m := newTestModel(t, newFakeProvider())
+	m = m.startConfigModal()
+
+	// Type "pro" character by character to narrow to Project Options.
+	// Single 'p' isn't enough — "options" contains 'p' so both rows
+	// still match; "pro" is the smallest prefix that disambiguates.
+	for _, r := range "pro" {
+		mi, _ := m.updateConfigModal(tea.KeyPressMsg{Text: string(r)})
+		m = mi.(model)
+	}
+	if m.configFilter != "pro" {
+		t.Fatalf("typing 'pro' should populate configFilter; got %q", m.configFilter)
+	}
+	items := m.filteredConfigItems()
+	if len(items) != 1 || items[0].id != "project" {
+		t.Fatalf("filter 'pro' should narrow to project row; got %+v", items)
+	}
+	// Cursor should snap to 0 so the (single remaining) row is selected.
+	if m.configCursor != 0 {
+		t.Errorf("filter should reset configCursor to 0; got %d", m.configCursor)
+	}
+	// Enter on the filtered single result must open Project Options.
+	mi, _ := m.updateConfigModal(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = mi.(model)
+	if !m.configProjectPickerActive {
+		t.Errorf("Enter on the filtered Project row should open Project submenu")
+	}
+
+	// Reset, type something that matches nothing.
+	m = newTestModel(t, newFakeProvider()).startConfigModal()
+	mi, _ = m.updateConfigModal(tea.KeyPressMsg{Text: "x"})
+	m = mi.(model)
+	if len(m.filteredConfigItems()) != 0 {
+		t.Errorf("filter 'x' should produce empty list; got %d rows", len(m.filteredConfigItems()))
+	}
+	// Backspace clears the filter character; full list restored.
+	mi, _ = m.updateConfigModal(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	m = mi.(model)
+	if m.configFilter != "" {
+		t.Fatalf("Backspace should clear single-char filter; got %q", m.configFilter)
+	}
+	if got := len(m.filteredConfigItems()); got != 2 {
+		t.Errorf("after Backspace the full list should restore; got %d rows", got)
+	}
+}
+
 func TestProjectPicker_DefaultsToNoneProvider(t *testing.T) {
 	isolateHome(t)
 	m := newTestModel(t, newFakeProvider())

--- a/config_project_test.go
+++ b/config_project_test.go
@@ -118,6 +118,126 @@ func TestConfigTopLevel_FilterAndBackspace(t *testing.T) {
 	}
 }
 
+func TestConfigTopLevel_FilterBackspaceRemovesOneRune(t *testing.T) {
+	isolateHome(t)
+	m := newTestModel(t, newFakeProvider()).startConfigModal()
+	for _, s := range []string{"å", "p"} {
+		mi, _ := m.updateConfigModal(tea.KeyPressMsg{Text: s})
+		m = mi.(model)
+	}
+	if m.configFilter != "åp" {
+		t.Fatalf("filter=%q want åp", m.configFilter)
+	}
+	mi, _ := m.updateConfigModal(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	m = mi.(model)
+	if m.configFilter != "å" {
+		t.Fatalf("after first Backspace filter=%q want å", m.configFilter)
+	}
+	mi, _ = m.updateConfigModal(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	m = mi.(model)
+	if m.configFilter != "" {
+		t.Fatalf("after second Backspace filter=%q want empty", m.configFilter)
+	}
+}
+
+func TestConfigTopLevel_FilterModifierGate(t *testing.T) {
+	isolateHome(t)
+	cases := []struct {
+		name string
+		msg  tea.KeyPressMsg
+		want string
+	}{
+		{"plain", tea.KeyPressMsg{Text: "p", Code: 'p'}, "p"},
+		{"shift", tea.KeyPressMsg{Text: "P", Code: 'p', Mod: tea.ModShift}, "P"},
+		{"caps lock", tea.KeyPressMsg{Text: "P", Code: 'p', Mod: tea.ModCapsLock}, "P"},
+		{"num lock", tea.KeyPressMsg{Text: "1", Code: '1', Mod: tea.ModNumLock}, "1"},
+		{"ctrl", tea.KeyPressMsg{Text: "p", Code: 'p', Mod: tea.ModCtrl}, ""},
+		{"alt", tea.KeyPressMsg{Text: "p", Code: 'p', Mod: tea.ModAlt}, ""},
+		{"ctrl shift", tea.KeyPressMsg{Text: "P", Code: 'p', Mod: tea.ModCtrl | tea.ModShift}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestModel(t, newFakeProvider()).startConfigModal()
+			mi, _ := m.updateConfigModal(tc.msg)
+			m = mi.(model)
+			if m.configFilter != tc.want {
+				t.Fatalf("filter=%q want %q", m.configFilter, tc.want)
+			}
+		})
+	}
+}
+
+func TestConfigTopLevel_EnterWithStaleCursorClearsSafely(t *testing.T) {
+	isolateHome(t)
+	m := newTestModel(t, newFakeProvider()).startConfigModal()
+	m.configFilter = "pro"
+	m.configCursor = 99
+	mi, _ := m.updateConfigModal(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = mi.(model)
+	if m.mode != modeInput {
+		t.Fatalf("stale cursor Enter should close config; mode=%v", m.mode)
+	}
+	if m.configFilter != "" || m.configCursor != 0 {
+		t.Fatalf("clearConfigModal should reset filter/cursor; filter=%q cursor=%d", m.configFilter, m.configCursor)
+	}
+}
+
+func TestConfigTopLevel_FilterDoesNotLeakAcrossSubmenus(t *testing.T) {
+	isolateHome(t)
+	pressText := func(m model, s string) model {
+		for _, r := range s {
+			mi, _ := m.updateConfigModal(tea.KeyPressMsg{Text: string(r), Code: r})
+			m = mi.(model)
+		}
+		return m
+	}
+
+	m := newTestModel(t, newFakeProvider()).startConfigModal()
+	m = pressText(m, "pro")
+	mi, _ := m.updateConfigModal(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = mi.(model)
+	if !m.configProjectPickerActive {
+		t.Fatalf("filtered Project row should open Project submenu")
+	}
+	if m.configFilter != "" {
+		t.Fatalf("top-level filter leaked into Project submenu: %q", m.configFilter)
+	}
+	m = pressText(m, "git")
+	if m.configFilter != "git" {
+		t.Fatalf("project filter=%q want git", m.configFilter)
+	}
+	mi, _ = m.updateConfigModal(tea.KeyPressMsg{Code: tea.KeyEsc})
+	m = mi.(model)
+	if m.configProjectPickerActive {
+		t.Fatalf("Esc should close Project submenu")
+	}
+	if m.configFilter != "" {
+		t.Fatalf("Project filter leaked back to top level: %q", m.configFilter)
+	}
+
+	m = pressText(m, "glo")
+	mi, _ = m.updateConfigModal(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = mi.(model)
+	if !m.configGlobalPickerActive {
+		t.Fatalf("filtered Global row should open Global submenu")
+	}
+	if m.configFilter != "" {
+		t.Fatalf("top-level filter leaked into Global submenu: %q", m.configFilter)
+	}
+	m = pressText(m, "theme")
+	if m.configFilter != "theme" {
+		t.Fatalf("global filter=%q want theme", m.configFilter)
+	}
+	mi, _ = m.updateConfigModal(tea.KeyPressMsg{Code: tea.KeyEsc})
+	m = mi.(model)
+	if m.configGlobalPickerActive {
+		t.Fatalf("Esc should close Global submenu")
+	}
+	if m.configFilter != "" {
+		t.Fatalf("Global filter leaked back to top level: %q", m.configFilter)
+	}
+}
+
 func TestProjectPicker_DefaultsToNoneProvider(t *testing.T) {
 	isolateHome(t)
 	m := newTestModel(t, newFakeProvider())


### PR DESCRIPTION
## Summary
The /config top-level picker (Global Options / Project Options) draws a \"Type to filter\" placeholder at the top of the box and renders rows through \`filteredConfigItems()\`, but \`updateConfigModal\` was reading the unfiltered \`configItemsAll()\` and had no \`msg.Text\` capture or Backspace branch. Symptom: typing on the top-level picker did nothing, while every submenu (Global Options, Project Options, …) filtered correctly. Noticed during local testing today.

Switch the handler to read \`filteredConfigItems()\` for cursor bounds, add the same Backspace pop + \`msg.Text\`-append pair the submenus already use, and reset the cursor to 0 on every filter mutation so the highlight follows the now-narrowed list. \`configFilter\` remains the shared slot across layers — \`openConfigGlobalPicker\` / \`closeConfigGlobalPicker\` (and their project peer) still clear it on entry / exit, so a string typed at the top level can't bleed into a submenu and vice versa. Also refreshed the NOTE comment that called the top-level filter \"(now empty)\".

## Verification
- \`go build ./...\` — clean
- \`go vet ./...\` — clean
- \`go test ./... -count=1 -run 'TestConfigTopLevel_FilterAndBackspace|TestEnterTopLevel|TestConfigItemsAll'\` — passes
- Full \`go test ./...\` passes excluding the same upstream pre-existing failures noted in #36's body (TestLinear* / TestWorkflow*MCP / TestApp_CtrlZSuspends* / TestFetchUsageMjs_HasNo).

## Test plan
- [ ] \`/config\` to open the top-level menu.
- [ ] Type \`pro\` — list narrows to \"Project Options\".
- [ ] Backspace — list restores.
- [ ] Type \`x\` — list is empty (no match), no crash.
- [ ] Backspace — full list back.
- [ ] Type \`pro\` then Enter — opens Project Options submenu (filter is auto-cleared on entry).
- [ ] Esc back to top-level — filter remains empty (cleared on submenu close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)