### PR TITLE
feat: macOS image paste via osascript pasteboard coercion

### DIFF
--- a/clipboard.go
+++ b/clipboard.go
@@ -117,12 +117,12 @@ func clipboardEmitOSC52(s string) error {
 }
 
 type imagePastedMsg struct {
-	data       []byte
-	mime       string
+	data        []byte
+	mime        string
 	pngForKitty []byte
-	width      int
-	height     int
-	err        error
+	width       int
+	height      int
+	err         error
 }
 
 var acceptedImageMimes = map[string]bool{
@@ -263,7 +263,10 @@ func pasteImageDarwin() ([]byte, string, error) {
 		return nil, "", err
 	}
 	tmpPath := tmp.Name()
-	tmp.Close()
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return nil, "", err
+	}
 	defer os.Remove(tmpPath)
 	if err := darwinClipboardExtractFn(className, tmpPath); err != nil {
 		return nil, "", fmt.Errorf("osascript extract: %w", err)

--- a/clipboard.go
+++ b/clipboard.go
@@ -132,29 +132,55 @@ var acceptedImageMimes = map[string]bool{
 	"image/webp": true,
 }
 
+// Image-paste subprocess seams — tests stub these instead of forking
+// wl-paste / osascript. The Linux pair maps to wl-paste's two-step
+// type listing + typed read; the Darwin pair maps to osascript reading
+// `clipboard info` and coercing the clipboard to a four-char-code class
+// that writes the raw bytes to a temp file.
+var (
+	wlPasteListTypesFn = func() ([]byte, error) {
+		return exec.Command("wl-paste", "--list-types").Output()
+	}
+	wlPasteReadFn = func(mime string) ([]byte, error) {
+		return exec.Command("wl-paste", "--type", mime, "--no-newline").Output()
+	}
+	darwinClipboardInfoFn = func() ([]byte, error) {
+		return exec.Command("osascript", "-e", "clipboard info").Output()
+	}
+	darwinClipboardExtractFn = func(className, dstPath string) error {
+		script := fmt.Sprintf(
+			"set img to (the clipboard as %s)\n"+
+				"set fd to open for access POSIX file %q with write permission\n"+
+				"set eof of fd to 0\n"+
+				"write img to fd\n"+
+				"close access fd",
+			className, dstPath)
+		return exec.Command("osascript", "-e", script).Run()
+	}
+)
+
+// darwinImageClasses lists the MIME types we accept from the macOS
+// pasteboard, paired with the AppleScript four-char-code coercion
+// target and the marker substrings `clipboard info` uses to advertise
+// the type. Order is preference order: PNG first because macOS
+// auto-converts screenshots to PNG and Claude renders it without a
+// re-encode. JPEG / GIF appear under either the «class XXXX» literal
+// or the human alias ("JPEG picture", "GIF picture") — we accept both.
+var darwinImageClasses = []struct {
+	className string
+	mime      string
+	infoTags  []string
+}{
+	{"«class PNGf»", "image/png", []string{"«class PNGf»"}},
+	{"«class JPEG»", "image/jpeg", []string{"«class JPEG»", "JPEG picture"}},
+	{"«class GIFf»", "image/gif", []string{"«class GIFf»", "GIF picture"}},
+}
+
 func pasteImageCmd() tea.Cmd {
 	return func() tea.Msg {
-		listOut, err := exec.Command("wl-paste", "--list-types").Output()
-		if err != nil {
-			return imagePastedMsg{err: errors.New("wl-paste failed (clipboard empty or wl-paste missing)")}
-		}
-		var mime string
-		for _, t := range strings.Split(string(listOut), "\n") {
-			t = strings.TrimSpace(t)
-			if acceptedImageMimes[t] {
-				mime = t
-				break
-			}
-		}
-		if mime == "" {
-			return imagePastedMsg{err: errors.New("no image in clipboard")}
-		}
-		data, err := exec.Command("wl-paste", "--type", mime, "--no-newline").Output()
+		data, mime, err := pasteImageFromClipboard()
 		if err != nil {
 			return imagePastedMsg{err: err}
-		}
-		if len(data) == 0 {
-			return imagePastedMsg{err: errors.New("clipboard image was empty")}
 		}
 		msg := imagePastedMsg{data: data, mime: mime}
 		if png, w, h, derr := encodeToPNG(data); derr == nil {
@@ -164,4 +190,90 @@ func pasteImageCmd() tea.Cmd {
 		}
 		return msg
 	}
+}
+
+// pasteImageFromClipboard dispatches by clipboardGOOS to the per-platform
+// reader. Linux uses wl-paste (no X11 fallback — see CLAUDE.md); macOS
+// uses osascript to coerce the system pasteboard to a known image class.
+func pasteImageFromClipboard() ([]byte, string, error) {
+	switch clipboardGOOS {
+	case "linux":
+		return pasteImageWayland()
+	case "darwin":
+		return pasteImageDarwin()
+	default:
+		return nil, "", fmt.Errorf("image paste not supported on %s", clipboardGOOS)
+	}
+}
+
+func pasteImageWayland() ([]byte, string, error) {
+	listOut, err := wlPasteListTypesFn()
+	if err != nil {
+		return nil, "", errors.New("wl-paste failed (clipboard empty or wl-paste missing)")
+	}
+	var mime string
+	for _, t := range strings.Split(string(listOut), "\n") {
+		t = strings.TrimSpace(t)
+		if acceptedImageMimes[t] {
+			mime = t
+			break
+		}
+	}
+	if mime == "" {
+		return nil, "", errors.New("no image in clipboard")
+	}
+	data, err := wlPasteReadFn(mime)
+	if err != nil {
+		return nil, "", err
+	}
+	if len(data) == 0 {
+		return nil, "", errors.New("clipboard image was empty")
+	}
+	return data, mime, nil
+}
+
+// pasteImageDarwin coerces the macOS pasteboard to a known image class
+// via osascript. `the clipboard as «class XXXX»` returns the raw bytes
+// for that representation; AppleScript writes them to a temp file and
+// we read them back. Verified against a /System PNG: output is
+// byte-identical to the source (no AppleScript wrapper header).
+func pasteImageDarwin() ([]byte, string, error) {
+	info, err := darwinClipboardInfoFn()
+	if err != nil {
+		return nil, "", fmt.Errorf("osascript failed: %w", err)
+	}
+	infoStr := string(info)
+	var className, mime string
+	for _, c := range darwinImageClasses {
+		for _, tag := range c.infoTags {
+			if strings.Contains(infoStr, tag) {
+				className, mime = c.className, c.mime
+				break
+			}
+		}
+		if className != "" {
+			break
+		}
+	}
+	if className == "" {
+		return nil, "", errors.New("no image in clipboard")
+	}
+	tmp, err := os.CreateTemp("", "askclip-*.bin")
+	if err != nil {
+		return nil, "", err
+	}
+	tmpPath := tmp.Name()
+	tmp.Close()
+	defer os.Remove(tmpPath)
+	if err := darwinClipboardExtractFn(className, tmpPath); err != nil {
+		return nil, "", fmt.Errorf("osascript extract: %w", err)
+	}
+	data, err := os.ReadFile(tmpPath)
+	if err != nil {
+		return nil, "", err
+	}
+	if len(data) == 0 {
+		return nil, "", errors.New("clipboard image was empty")
+	}
+	return data, mime, nil
 }

--- a/clipboard_test.go
+++ b/clipboard_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"encoding/base64"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 )
@@ -233,5 +235,254 @@ func TestClipboardCopyText_OSC52FiresEvenWhenBinaryMissing(t *testing.T) {
 	}
 	if !emitted {
 		t.Errorf("OSC 52 must fire before the binary lookup loop, regardless of binary availability")
+	}
+}
+
+// withPasteImageStubs pins clipboardGOOS and saves/restores every
+// per-platform paste seam (wl-paste pair + osascript pair) at test
+// cleanup. Callers then override only the seams the case exercises;
+// the un-overridden ones still point at the saved defaults but won't
+// fire because clipboardGOOS gates the switch.
+func withPasteImageStubs(t *testing.T, goos string) {
+	t.Helper()
+	prevGOOS := clipboardGOOS
+	prevWlList, prevWlRead := wlPasteListTypesFn, wlPasteReadFn
+	prevInfo, prevExtract := darwinClipboardInfoFn, darwinClipboardExtractFn
+	t.Cleanup(func() {
+		clipboardGOOS = prevGOOS
+		wlPasteListTypesFn, wlPasteReadFn = prevWlList, prevWlRead
+		darwinClipboardInfoFn, darwinClipboardExtractFn = prevInfo, prevExtract
+	})
+	clipboardGOOS = goos
+}
+
+func TestPasteImageFromClipboard_UnsupportedGOOS(t *testing.T) {
+	withPasteImageStubs(t, "plan9")
+	_, _, err := pasteImageFromClipboard()
+	if err == nil || !strings.Contains(err.Error(), "plan9") {
+		t.Fatalf("expected unsupported-OS error mentioning plan9, got %v", err)
+	}
+}
+
+func TestPasteImageWayland_PrefersFirstAcceptedMime(t *testing.T) {
+	withPasteImageStubs(t, "linux")
+	var askedMime string
+	payload := []byte("\x89PNG\r\n\x1a\nFAKE")
+	wlPasteListTypesFn = func() ([]byte, error) {
+		return []byte("text/plain\nimage/png\nimage/jpeg\n"), nil
+	}
+	wlPasteReadFn = func(mime string) ([]byte, error) {
+		askedMime = mime
+		return payload, nil
+	}
+	data, mime, err := pasteImageFromClipboard()
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if mime != "image/png" {
+		t.Errorf("mime=%q, want image/png (first accepted in list)", mime)
+	}
+	if askedMime != "image/png" {
+		t.Errorf("wlPasteReadFn called with %q, want image/png", askedMime)
+	}
+	if !bytes.Equal(data, payload) {
+		t.Errorf("data mismatch")
+	}
+}
+
+func TestPasteImageWayland_ListFailurePreservesLegacyErrorString(t *testing.T) {
+	withPasteImageStubs(t, "linux")
+	wlPasteListTypesFn = func() ([]byte, error) {
+		return nil, errors.New("exec: wl-paste not found")
+	}
+	_, _, err := pasteImageFromClipboard()
+	if err == nil {
+		t.Fatal("expected error from wl-paste --list-types failure")
+	}
+	// Users have been seeing this exact phrasing forever — keep it
+	// stable so grep / docs / muscle memory still find it.
+	want := "wl-paste failed (clipboard empty or wl-paste missing)"
+	if err.Error() != want {
+		t.Errorf("err=%q, want %q", err.Error(), want)
+	}
+}
+
+func TestPasteImageWayland_NoImageInClipboard(t *testing.T) {
+	withPasteImageStubs(t, "linux")
+	wlPasteListTypesFn = func() ([]byte, error) {
+		return []byte("text/plain\ntext/html\n"), nil
+	}
+	wlPasteReadFn = func(mime string) ([]byte, error) {
+		t.Fatalf("read should not fire when no accepted mime in list")
+		return nil, nil
+	}
+	_, _, err := pasteImageFromClipboard()
+	if err == nil || !strings.Contains(err.Error(), "no image in clipboard") {
+		t.Fatalf("expected no-image error, got %v", err)
+	}
+}
+
+func TestPasteImageWayland_EmptyData(t *testing.T) {
+	withPasteImageStubs(t, "linux")
+	wlPasteListTypesFn = func() ([]byte, error) {
+		return []byte("image/png\n"), nil
+	}
+	wlPasteReadFn = func(mime string) ([]byte, error) {
+		return []byte{}, nil
+	}
+	_, _, err := pasteImageFromClipboard()
+	if err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("expected empty-image error, got %v", err)
+	}
+}
+
+func TestPasteImageDarwin_DetectsPNGFirst(t *testing.T) {
+	withPasteImageStubs(t, "darwin")
+	// Real `clipboard info` output advertises many classes for the
+	// same image — we want PNG to win regardless of where it lands.
+	darwinClipboardInfoFn = func() ([]byte, error) {
+		return []byte("«class PNGf», 22272, «class AVIF», 4977, JPEG picture, 4630, TIFF picture, 58646"), nil
+	}
+	payload := []byte("\x89PNG\r\n\x1a\nfake-bytes")
+	var extractedClass, gotDst string
+	darwinClipboardExtractFn = func(className, dstPath string) error {
+		extractedClass, gotDst = className, dstPath
+		return os.WriteFile(dstPath, payload, 0o644)
+	}
+	data, mime, err := pasteImageFromClipboard()
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if mime != "image/png" {
+		t.Errorf("mime=%q, want image/png", mime)
+	}
+	if extractedClass != "«class PNGf»" {
+		t.Errorf("extract class=%q, want «class PNGf»", extractedClass)
+	}
+	if gotDst == "" {
+		t.Errorf("extract called with empty dstPath")
+	}
+	if !bytes.Equal(data, payload) {
+		t.Errorf("data mismatch: got %x want %x", data, payload)
+	}
+	// Temp file must be cleaned up.
+	if _, err := os.Stat(gotDst); !os.IsNotExist(err) {
+		t.Errorf("temp file %q still exists after paste; expected cleanup", gotDst)
+	}
+}
+
+func TestPasteImageDarwin_AcceptsJPEGPictureAlias(t *testing.T) {
+	// macOS often advertises JPEG under the human alias rather than
+	// «class JPEG». Both must trigger detection; the coercion target
+	// is always the four-char-code form.
+	withPasteImageStubs(t, "darwin")
+	darwinClipboardInfoFn = func() ([]byte, error) {
+		return []byte("JPEG picture, 12345, TIFF picture, 8888"), nil
+	}
+	var extractedClass string
+	darwinClipboardExtractFn = func(className, dstPath string) error {
+		extractedClass = className
+		return os.WriteFile(dstPath, []byte("\xff\xd8\xff\xe0jpeg"), 0o644)
+	}
+	_, mime, err := pasteImageFromClipboard()
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if mime != "image/jpeg" {
+		t.Errorf("mime=%q, want image/jpeg via JPEG-picture alias", mime)
+	}
+	if extractedClass != "«class JPEG»" {
+		t.Errorf("extract class=%q, want «class JPEG»", extractedClass)
+	}
+}
+
+func TestPasteImageDarwin_AcceptsGIFPictureAlias(t *testing.T) {
+	withPasteImageStubs(t, "darwin")
+	darwinClipboardInfoFn = func() ([]byte, error) {
+		return []byte("GIF picture, 4027"), nil
+	}
+	var extractedClass string
+	darwinClipboardExtractFn = func(className, dstPath string) error {
+		extractedClass = className
+		return os.WriteFile(dstPath, []byte("GIF89a..."), 0o644)
+	}
+	_, mime, err := pasteImageFromClipboard()
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if mime != "image/gif" {
+		t.Errorf("mime=%q, want image/gif via GIF-picture alias", mime)
+	}
+	if extractedClass != "«class GIFf»" {
+		t.Errorf("extract class=%q, want «class GIFf»", extractedClass)
+	}
+}
+
+func TestPasteImageDarwin_NoImageClass(t *testing.T) {
+	withPasteImageStubs(t, "darwin")
+	darwinClipboardInfoFn = func() ([]byte, error) {
+		return []byte("«class utf8», 60, string, 60"), nil
+	}
+	darwinClipboardExtractFn = func(className, dstPath string) error {
+		t.Fatalf("extract should not be called when no image class detected")
+		return nil
+	}
+	_, _, err := pasteImageFromClipboard()
+	if err == nil || !strings.Contains(err.Error(), "no image in clipboard") {
+		t.Fatalf("expected no-image error, got %v", err)
+	}
+}
+
+func TestPasteImageDarwin_InfoSubprocessFailure(t *testing.T) {
+	withPasteImageStubs(t, "darwin")
+	darwinClipboardInfoFn = func() ([]byte, error) {
+		return nil, errors.New("exec: osascript not found")
+	}
+	darwinClipboardExtractFn = func(className, dstPath string) error {
+		t.Fatalf("extract should not be called when info call failed")
+		return nil
+	}
+	_, _, err := pasteImageFromClipboard()
+	if err == nil || !strings.Contains(err.Error(), "osascript") {
+		t.Fatalf("expected osascript error, got %v", err)
+	}
+}
+
+func TestPasteImageDarwin_ExtractFailureCleansTemp(t *testing.T) {
+	withPasteImageStubs(t, "darwin")
+	darwinClipboardInfoFn = func() ([]byte, error) {
+		return []byte("«class PNGf», 100"), nil
+	}
+	var seenDst string
+	darwinClipboardExtractFn = func(className, dstPath string) error {
+		seenDst = dstPath
+		// The extract command failed — temp file may exist as a
+		// zero-byte placeholder (CreateTemp made it), but defer
+		// os.Remove must still wipe it.
+		return errors.New("applescript: write failed")
+	}
+	_, _, err := pasteImageFromClipboard()
+	if err == nil || !strings.Contains(err.Error(), "osascript extract") {
+		t.Fatalf("expected extract error, got %v", err)
+	}
+	if seenDst == "" {
+		t.Fatal("extract was never called")
+	}
+	if _, statErr := os.Stat(seenDst); !os.IsNotExist(statErr) {
+		t.Errorf("temp file %q still exists after extract failure; expected cleanup", seenDst)
+	}
+}
+
+func TestPasteImageDarwin_EmptyData(t *testing.T) {
+	withPasteImageStubs(t, "darwin")
+	darwinClipboardInfoFn = func() ([]byte, error) {
+		return []byte("«class PNGf», 100"), nil
+	}
+	darwinClipboardExtractFn = func(className, dstPath string) error {
+		return os.WriteFile(dstPath, []byte{}, 0o644)
+	}
+	_, _, err := pasteImageFromClipboard()
+	if err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("expected empty-image error, got %v", err)
 	}
 }

--- a/clipboard_test.go
+++ b/clipboard_test.go
@@ -4,7 +4,11 @@ import (
 	"bytes"
 	"encoding/base64"
 	"errors"
+	"image"
+	"image/color"
+	"image/png"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -336,6 +340,53 @@ func TestPasteImageWayland_EmptyData(t *testing.T) {
 	}
 }
 
+func TestPasteImageWayland_ReadFailurePropagates(t *testing.T) {
+	withPasteImageStubs(t, "linux")
+	wlPasteListTypesFn = func() ([]byte, error) {
+		return []byte("image/png\n"), nil
+	}
+	wlPasteReadFn = func(mime string) ([]byte, error) {
+		return nil, errors.New("read failed")
+	}
+	_, _, err := pasteImageFromClipboard()
+	if err == nil || !strings.Contains(err.Error(), "read failed") {
+		t.Fatalf("expected read failure to propagate, got %v", err)
+	}
+}
+
+func TestPasteImageCmd_EmitsImagePastedMsgShape(t *testing.T) {
+	withPasteImageStubs(t, "linux")
+	var payloadBuf bytes.Buffer
+	img := image.NewNRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.NRGBA{A: 255})
+	if err := png.Encode(&payloadBuf, img); err != nil {
+		t.Fatalf("encode png fixture: %v", err)
+	}
+	payload := payloadBuf.Bytes()
+	wlPasteListTypesFn = func() ([]byte, error) {
+		return []byte("image/png\n"), nil
+	}
+	wlPasteReadFn = func(mime string) ([]byte, error) {
+		return payload, nil
+	}
+	got, ok := pasteImageCmd()().(imagePastedMsg)
+	if !ok {
+		t.Fatalf("cmd returned %T, want imagePastedMsg", got)
+	}
+	if got.err != nil {
+		t.Fatalf("unexpected err: %v", got.err)
+	}
+	if got.mime != "image/png" {
+		t.Errorf("mime=%q, want image/png", got.mime)
+	}
+	if !bytes.Equal(got.data, payload) {
+		t.Errorf("data mismatch")
+	}
+	if len(got.pngForKitty) == 0 || got.width != 1 || got.height != 1 {
+		t.Errorf("kitty preview shape = bytes:%d %dx%d, want nonempty 1x1", len(got.pngForKitty), got.width, got.height)
+	}
+}
+
 func TestPasteImageDarwin_DetectsPNGFirst(t *testing.T) {
 	withPasteImageStubs(t, "darwin")
 	// Real `clipboard info` output advertises many classes for the
@@ -448,6 +499,25 @@ func TestPasteImageDarwin_InfoSubprocessFailure(t *testing.T) {
 	}
 }
 
+func TestPasteImageDarwin_CreateTempFailure(t *testing.T) {
+	withPasteImageStubs(t, "darwin")
+	darwinClipboardInfoFn = func() ([]byte, error) {
+		return []byte("«class PNGf», 100"), nil
+	}
+	darwinClipboardExtractFn = func(className, dstPath string) error {
+		t.Fatalf("extract should not be called when temp creation failed")
+		return nil
+	}
+	missingTempDir := filepath.Join(t.TempDir(), "missing")
+	t.Setenv("TMPDIR", missingTempDir)
+	t.Setenv("TMP", missingTempDir)
+	t.Setenv("TEMP", missingTempDir)
+	_, _, err := pasteImageFromClipboard()
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected temp creation failure, got %v", err)
+	}
+}
+
 func TestPasteImageDarwin_ExtractFailureCleansTemp(t *testing.T) {
 	withPasteImageStubs(t, "darwin")
 	darwinClipboardInfoFn = func() ([]byte, error) {
@@ -470,6 +540,28 @@ func TestPasteImageDarwin_ExtractFailureCleansTemp(t *testing.T) {
 	}
 	if _, statErr := os.Stat(seenDst); !os.IsNotExist(statErr) {
 		t.Errorf("temp file %q still exists after extract failure; expected cleanup", seenDst)
+	}
+}
+
+func TestPasteImageDarwin_ReadFileFailureCleansTemp(t *testing.T) {
+	withPasteImageStubs(t, "darwin")
+	darwinClipboardInfoFn = func() ([]byte, error) {
+		return []byte("«class PNGf», 100"), nil
+	}
+	var seenDst string
+	darwinClipboardExtractFn = func(className, dstPath string) error {
+		seenDst = dstPath
+		return os.Remove(dstPath)
+	}
+	_, _, err := pasteImageFromClipboard()
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected read-file failure, got %v", err)
+	}
+	if seenDst == "" {
+		t.Fatal("extract was never called")
+	}
+	if _, statErr := os.Stat(seenDst); !os.IsNotExist(statErr) {
+		t.Errorf("temp file %q still exists after read failure; expected cleanup", seenDst)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `Ctrl+V` on macOS used to surface `paste: wl-paste failed (clipboard empty or wl-paste missing)` because `pasteImageCmd` unconditionally forked `wl-paste`. This PR adds a Darwin reader so image paste actually works on macOS, mirroring the GOOS dispatch that `clipboardCopyText` already does for text.
- The Darwin path scans `osascript -e 'clipboard info'` for `«class PNGf»` / `«class JPEG»` / `«class GIFf»` (plus the human aliases `JPEG picture` / `GIF picture`), then coerces the pasteboard with `the clipboard as «class XXXX»` and writes the raw bytes to a temp file via AppleScript `open for access … with write permission`. Verified against a `/System` PNG: temp-file output is byte-identical to the source — no AppleScript wrapper header.
- PNG is preferred over JPEG/GIF because macOS auto-converts screenshots and Claude renders PNG without a re-encode. WebP is intentionally skipped on Darwin (the pasteboard doesn't expose a stable WebP class).
- Subprocess seams (`wlPasteListTypesFn` / `wlPasteReadFn` / `darwinClipboardInfoFn` / `darwinClipboardExtractFn`) match the existing `clipboardLookPath` / `clipboardRun` pattern so tests fake both platforms without forking. Linux path keeps the legacy error string for log/grep stability.

## Test plan

- [x] `go build ./...`, `go vet ./...` — clean
- [x] 12 new behavioral tests pass; full clipboard suite (`-run Clipboard|PasteImage|Osc52`) = 27/27 green
  - GOOS dispatch (`UnsupportedGOOS`)
  - Wayland: prefers first accepted mime, list-failure error string preserved, no-image, empty-data
  - Darwin: PNG-first preference (even when many classes advertised), JPEG-picture alias, GIF-picture alias, no-image class, info-call subprocess failure, extract failure with temp-file cleanup assertion, empty-data
- [x] **Live integration verified on macOS**: put a known 22272-byte PNG on the clipboard, called `pasteImageDarwin()` against the real `osascript`, output was byte-identical to the source (size + magic bytes)
- [ ] Reviewer: confirm `Ctrl+V` with an image on the clipboard now produces an `imagePastedMsg` whose `data` reaches the attachments queue (rather than the legacy `paste: wl-paste failed …` error toast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)