### PR TITLE
feat: surface y/n shortcuts in cancel-confirm popup help

### DIFF
--- a/ask_question.go
+++ b/ask_question.go
@@ -568,7 +568,7 @@ func renderCancelConfirmBox(title, sub string, choice int) string {
 		yes = askConfirmBtnActiveStyle.Render("Yes")
 	}
 	buttons := lipgloss.JoinHorizontal(lipgloss.Top, no, "   ", yes)
-	help := askHelpStyle.Render("←→ switch · enter confirm · esc back")
+	help := askHelpStyle.Render("y yes · n/esc no · ←→ switch · enter confirm")
 	body := strings.Join([]string{
 		askPromptStyle.Render(title),
 		dimStyle.Render(sub),


### PR DESCRIPTION
## Summary

- The cancel-turn, close-tab, merge-PR, and ask-cancel-dialog confirm modals (all rendered through `renderCancelConfirmBox`) already accepted `y` to confirm and `n` (or `Esc`) to dismiss — see `update.go:1589`, `update.go:1638`, `update.go:1670`, `ask_question.go:506`. But the help line only advertised `←→ switch · enter confirm · esc back`, so the shortcut was undiscoverable and users were sidestepping four overlapping yes/no popups with arrow keys.
- Pulling `y` and `n/esc` to the front of the help line matches the approval modal's existing style (`approval.go:112`) and lets users skip the arrow-key navigation entirely.
- No behavior change — the underlying handlers were untouched. This is a one-line help-text update in `renderCancelConfirmBox`.

## Test plan

- [x] `go build ./...`, `go vet ./...` — clean
- [x] Existing confirm-modal absorption tests still pass: `TestUpdate_PasteMsgDuringCancelTurnConfirmIsAbsorbed`, `TestUpdate_PasteMsgDuringCloseTabConfirmIsAbsorbed`, `TestUpdate_PasteMsgInNonInputModesIsAbsorbed`
- [ ] Reviewer: trigger any of the four popups (e.g. `Ctrl+C` mid-turn, `Ctrl+D` on a busy tab) and confirm the help line now reads `y yes · n/esc no · ←→ switch · enter confirm` and that `y`/`n` actually shortcut the choice

🤖 Generated with [Claude Code](https://claude.com/claude-code)