### PR TITLE
fix: skip failed trailing turns on provider switch

### DIFF
--- a/virtual_session.go
+++ b/virtual_session.go
@@ -384,10 +384,13 @@ type NeutralTurn struct {
 }
 
 // neutralTurnsFromHistory flattens a UI history slice to the
-// provider-neutral turn list. histPrerendered entries (tool blocks,
-// diff blocks) are deliberately skipped — they're noise when
-// seeding the target provider with conversational context and the
-// tools aren't portable across provider schemas anyway.
+// provider-neutral completed-turn list. histPrerendered entries (tool
+// blocks, diff blocks, errors) are deliberately skipped — they're noise
+// when seeding the target provider with conversational context and the
+// tools aren't portable across provider schemas anyway. A trailing user
+// turn without an assistant response is also skipped: it represents an
+// in-flight or failed provider turn, not stable history a target provider
+// can safely resume from.
 func neutralTurnsFromHistory(history []historyEntry) []NeutralTurn {
 	out := make([]NeutralTurn, 0, len(history))
 	for _, e := range history {
@@ -397,6 +400,9 @@ func neutralTurnsFromHistory(history []historyEntry) []NeutralTurn {
 		case histResponse:
 			out = append(out, NeutralTurn{Role: "assistant", Text: e.text})
 		}
+	}
+	for len(out) > 0 && out[len(out)-1].Role == "user" {
+		out = out[:len(out)-1]
 	}
 	return out
 }

--- a/virtual_session_test.go
+++ b/virtual_session_test.go
@@ -1113,18 +1113,86 @@ func TestNeutralTurnsFromHistory_MapsKindsAndSkipsTools(t *testing.T) {
 		{kind: histUser, text: "more"},
 	}
 	got := neutralTurnsFromHistory(history)
-	if len(got) != 3 {
-		t.Fatalf("want 3 turns, got %d: %+v", len(got), got)
+	if len(got) != 2 {
+		t.Fatalf("want 2 turns, got %d: %+v", len(got), got)
 	}
 	want := []NeutralTurn{
 		{Role: "user", Text: "hi"},
 		{Role: "assistant", Text: "hello"},
-		{Role: "user", Text: "more"},
 	}
 	for i, w := range want {
 		if got[i] != w {
 			t.Errorf("turn[%d] = %+v, want %+v", i, got[i], w)
 		}
+	}
+}
+
+func TestApplyProviderSwitch_SkipsErroredTrailingUserTurn(t *testing.T) {
+	isolateHome(t)
+	pA := newFakeProvider()
+	pA.id = "claude"
+	pA.displayName = "Claude"
+	pB := newFakeProvider()
+	pB.id = "codex"
+	pB.displayName = "Codex"
+	materializeCalls := 0
+	pB.materializeFn = func(string, []NeutralTurn) (string, string, error) {
+		materializeCalls++
+		return "should-not-be-used", "", nil
+	}
+	withRegisteredProviders(t, pA, pB)
+
+	store := &virtualSessionStore{Version: 1}
+	vsID := upsertVirtualSession(store, "", "/ws", "claude", "claude-session", "/ws", "failed prompt", time.Now().UTC())
+	if err := saveVirtualSessions(store); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	m := newTestModel(t, pA)
+	m.cwd = "/ws"
+	m.virtualSessionID = vsID
+	m.sessionID = "claude-session"
+	m.history = []historyEntry{
+		{kind: histUser, text: "failed prompt"},
+		{kind: histPrerendered, text: "error: usage limit reached"},
+	}
+	m.providerSwitchProvIdx = 1
+
+	newM, cmd := m.applyProviderSwitch("")
+	mm := newM.(model)
+	if cmd != nil {
+		t.Fatal("switch after an unanswered error turn should not dispatch session translation")
+	}
+	if materializeCalls != 0 {
+		t.Fatalf("target Materialize called %d times; failed trailing user turn must not become a resume session", materializeCalls)
+	}
+	if mm.busy {
+		t.Error("switch with no completed turns should leave the tab idle")
+	}
+	if mm.sessionID != "" {
+		t.Errorf("sessionID=%q; next codex send should start a fresh thread", mm.sessionID)
+	}
+	if mm.virtualSessionID != vsID {
+		t.Errorf("virtualSessionID=%q want %q", mm.virtualSessionID, vsID)
+	}
+
+	sentM, sendCmd := mm.sendToProvider("try codex")
+	if sendCmd == nil {
+		t.Fatal("fresh codex send should start provider")
+	}
+	done := runProviderStartCmd(t, sendCmd)
+	sent := sentM.(model)
+	if !sent.procStarting {
+		t.Fatal("send should be waiting for codex startup")
+	}
+	if len(pB.startArgs) != 1 {
+		t.Fatalf("StartSession called %d times, want 1", len(pB.startArgs))
+	}
+	if pB.startArgs[0].SessionID != "" {
+		t.Errorf("StartSession SessionID=%q; want fresh thread after failed source turn", pB.startArgs[0].SessionID)
+	}
+	if done.err != nil {
+		t.Fatalf("start cmd returned error: %v", done.err)
 	}
 }
 
@@ -1783,7 +1851,10 @@ func TestResumeVirtualSession_TranslateRecoversWorktreeFromSourceRef(t *testing.
 	pA.id = "fakeA"
 	pA.displayName = "Fake A"
 	pA.loadHistoryFn = func(_ string, _ HistoryOpts) ([]historyEntry, error) {
-		return []historyEntry{{kind: histUser, text: "u"}}, nil
+		return []historyEntry{
+			{kind: histUser, text: "u"},
+			{kind: histResponse, text: "a"},
+		}, nil
 	}
 	pB := newFakeProvider()
 	pB.id = "fakeB"
@@ -1836,7 +1907,10 @@ func TestResumeVirtualSession_TranslateKeepsProjectRootWhenSourceRefIsProjectRoo
 	pA.id = "fakeA"
 	pA.displayName = "Fake A"
 	pA.loadHistoryFn = func(_ string, _ HistoryOpts) ([]historyEntry, error) {
-		return []historyEntry{{kind: histUser, text: "u"}}, nil
+		return []historyEntry{
+			{kind: histUser, text: "u"},
+			{kind: histResponse, text: "a"},
+		}, nil
 	}
 	pB := newFakeProvider()
 	pB.id = "fakeB"


### PR DESCRIPTION
## Summary
- `neutralTurnsFromHistory` (used by `Ctrl+B` cross-provider switch) now drops any trailing user turn that has no paired assistant response. Such a turn represents an in-flight or errored provider turn (e.g. Claude usage limit), not stable history a target provider can resume from.
- Without this, switching providers after a failed turn would feed the failed prompt to the target provider as if resuming a real conversation — minting a `Materialize`'d session ID and either making the new provider "answer" the failed prompt or carry an inherited session that never properly existed.

## Fix
One-liner in `virtual_session.go` after the existing kind-mapping loop:

```go
for len(out) > 0 && out[len(out)-1].Role == "user" {
    out = out[:len(out)-1]
}
```

`histPrerendered` error blocks were already filtered; this sweep removes the user message that *triggered* the error.

## Test coverage
- `TestNeutralTurnsFromHistory_MapsKindsAndSkipsTools` updated to assert the trailing user turn is dropped (3 → 2 turns).
- New `TestApplyProviderSwitch_SkipsErroredTrailingUserTurn` walks the full reproducer: Claude errors out → switch to Codex → assert no `Materialize` call, sessionID cleared, next send starts a fresh thread.
- Two unrelated `TestResumeVirtualSession_Translate*` tests adjusted to give their fake provider a paired assistant turn so they exercise resume on real history, not on what the new filter would discard.

## Verification
- `go build ./...` ✓
- `go vet ./...` ✓
- Targeted tests pass: `TestNeutralTurnsFromHistory_MapsKindsAndSkipsTools`, `TestApplyProviderSwitch_SkipsErroredTrailingUserTurn`, `Test.*VirtualSession`, `Test.*ProviderSwitch`, `TestSendToProvider`, codex/claude stream tests.
- `go test ./...` shows 31 pre-existing Linear/workflow MCP failures (inactive provider / missing workflows) that reproduce on plain `origin/main` — unrelated to this change.

## Notes
This is a reopening of #36, which I closed myself by mistake. The commit is unchanged (`5515791`); rebased mentally against today's `origin/main` — `virtual_session.go` hasn't been touched on main since the fix was authored, so there are no conflicts.