### PR TITLE
feat: inline Linear image attachments in MCP tool results

### DIFF
--- a/mcp_linear.go
+++ b/mcp_linear.go
@@ -487,7 +487,8 @@ func (b *mcpBridge) linearGetTool(ctx context.Context, req *mcp.CallToolRequest,
 	teamKey := pc.MCP.Linear.TeamKey
 	out := linearGetOutput{Issue: linearIssueDetailViewOf(it, teamKey)}
 	body, _ := json.Marshal(out)
-	return okResult(string(body)), out, nil
+	res := linearBuildIssueResult(ctx, p, pc.MCP.Linear, string(body), it.description, linearCommentBodies(it.comments))
+	return res, out, nil
 }
 
 func (b *mcpBridge) linearUpdateTool(ctx context.Context, req *mcp.CallToolRequest, in linearUpdateInput) (*mcp.CallToolResult, linearUpdateOutput, error) {
@@ -516,7 +517,8 @@ func (b *mcpBridge) linearUpdateTool(ctx context.Context, req *mcp.CallToolReque
 	}
 	out := linearUpdateOutput{Issue: linearIssueDetailViewOf(it, postTeamKey)}
 	body, _ := json.Marshal(out)
-	return okResult(string(body)), out, nil
+	res := linearBuildIssueResult(ctx, p, pc.MCP.Linear, string(body), it.description, linearCommentBodies(it.comments))
+	return res, out, nil
 }
 
 // linearUpdateInputToOptions translates the wire-shape (JSON-friendly,

--- a/mcp_linear_images.go
+++ b/mcp_linear_images.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// Linear stores screenshots and other inline media on a private
+// uploads.linear.app CDN that requires the same Authorization header
+// the GraphQL API uses. The chat agent therefore can't fetch those
+// URLs on its own — we have to do it server-side and pack the bytes
+// into MCP ImageContent blocks the model can actually read.
+//
+// Caps below keep one issue from blowing the context window. The
+// numbers are conservative; a single descriptive screenshot already
+// dominates a tool result, so 4 / 5 MB is plenty in practice and
+// anything bigger should stay as a URL in the markdown body.
+//
+// Token-bearing fetches are restricted to the `uploads.linear.app`
+// host (see [isLinearImageURL]) so the Linear API key never leaks
+// to third-party CDNs that descriptions might reference.
+
+const (
+	linearImageHost          = "uploads.linear.app"
+	linearImageMaxCount      = 4
+	linearImageMaxBytesEach  = 4 * 1024 * 1024 // 4 MB cap per image
+	linearImageMaxBytesTotal = 8 * 1024 * 1024 // 8 MB cumulative cap
+	linearImageFetchTimeout  = 15 * time.Second
+)
+
+// linearImageMarkdownRe matches markdown image syntax `![alt](url)`.
+// The URL group is bounded by either a closing paren or whitespace so
+// titles like `![](url "caption")` strip cleanly.
+var linearImageMarkdownRe = regexp.MustCompile(`!\[[^\]]*\]\(([^)\s]+)`)
+
+// linearImageRef is one image URL surfaced from markdown plus a tag
+// describing where it came from. The tag isn't currently surfaced to
+// the agent but makes debug logging readable.
+type linearImageRef struct {
+	URL    string
+	Source string
+}
+
+// linearExtractImageURLs walks description + each comment body in
+// order, returning every Linear-hosted image URL exactly once.
+// Non-Linear hosts are dropped silently so we never round-trip a
+// bearer token to an unknown CDN.
+func linearExtractImageURLs(description string, comments []string) []linearImageRef {
+	seen := map[string]bool{}
+	var out []linearImageRef
+	scan := func(body, source string) {
+		for _, m := range linearImageMarkdownRe.FindAllStringSubmatch(body, -1) {
+			raw := strings.TrimSpace(m[1])
+			if !isLinearImageURL(raw) {
+				continue
+			}
+			if seen[raw] {
+				continue
+			}
+			seen[raw] = true
+			out = append(out, linearImageRef{URL: raw, Source: source})
+		}
+	}
+	scan(description, "description")
+	for _, c := range comments {
+		scan(c, "comment")
+	}
+	return out
+}
+
+// isLinearImageURL accepts only https/http URLs whose host matches
+// uploads.linear.app exactly (case-insensitive). External images
+// pasted into a Linear description are deliberately ignored.
+func isLinearImageURL(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return false
+	}
+	return strings.EqualFold(u.Host, linearImageHost)
+}
+
+// linearFetchedImage bundles the bytes + MIME of one inlined image.
+type linearFetchedImage struct {
+	URL      string
+	Data     []byte
+	MIMEType string
+}
+
+// linearImageFetcher is the indirection seam used by handlers and
+// tests. Production wires this to (*linearIssueProvider).fetchImage,
+// reusing the cached http.Client + auth round-tripper so token
+// rotation flows through one place.
+type linearImageFetcher interface {
+	fetchImage(ctx context.Context, cfg linearMCPConfig, rawURL string) (data []byte, mimeType string, err error)
+}
+
+// linearGatherImages walks refs in order, stopping when either the
+// count or cumulative-bytes cap is exhausted. Per-image failures are
+// counted into dropped and otherwise swallowed so a broken CDN entry
+// can't take down the whole tool call.
+func linearGatherImages(ctx context.Context, f linearImageFetcher, cfg linearMCPConfig, refs []linearImageRef) (images []linearFetchedImage, dropped int) {
+	if f == nil || len(refs) == 0 {
+		return nil, 0
+	}
+	total := 0
+	for _, r := range refs {
+		if len(images) >= linearImageMaxCount {
+			dropped++
+			continue
+		}
+		ictx, cancel := context.WithTimeout(ctx, linearImageFetchTimeout)
+		body, mime, err := f.fetchImage(ictx, cfg, r.URL)
+		cancel()
+		if err != nil {
+			dropped++
+			continue
+		}
+		if len(body) == 0 || len(body) > linearImageMaxBytesEach {
+			dropped++
+			continue
+		}
+		if total+len(body) > linearImageMaxBytesTotal {
+			dropped++
+			continue
+		}
+		total += len(body)
+		images = append(images, linearFetchedImage{
+			URL:      r.URL,
+			Data:     body,
+			MIMEType: mime,
+		})
+	}
+	return images, dropped
+}
+
+// linearBuildIssueResult assembles the MCP CallToolResult for any
+// handler that returns a linearIssueDetailView. The text block holds
+// the marshalled JSON payload exactly as before; image blocks are
+// appended for each Linear-hosted image referenced by description or
+// comments. A trailing text note records anything that overflowed
+// the cap so the agent doesn't silently lose images.
+func linearBuildIssueResult(ctx context.Context, f linearImageFetcher, cfg linearMCPConfig, text, description string, comments []string) *mcp.CallToolResult {
+	content := []mcp.Content{&mcp.TextContent{Text: text}}
+	refs := linearExtractImageURLs(description, comments)
+	if len(refs) == 0 {
+		return &mcp.CallToolResult{Content: content}
+	}
+	images, dropped := linearGatherImages(ctx, f, cfg, refs)
+	for _, img := range images {
+		content = append(content, &mcp.ImageContent{
+			Data:     img.Data,
+			MIMEType: img.MIMEType,
+		})
+	}
+	if dropped > 0 {
+		content = append(content, &mcp.TextContent{
+			Text: fmt.Sprintf(
+				"(linear: %d image%s omitted — per-issue cap is %d images / %d MB)",
+				dropped, pluralS(dropped), linearImageMaxCount, linearImageMaxBytesTotal/(1024*1024),
+			),
+		})
+	}
+	return &mcp.CallToolResult{Content: content}
+}
+
+// linearCommentBodies pulls just the body field out of a slice of
+// issue comments. Tiny helper, but keeps the call sites in
+// mcp_linear.go from re-implementing the loop twice.
+func linearCommentBodies(cs []issueComment) []string {
+	if len(cs) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(cs))
+	for _, c := range cs {
+		out = append(out, c.body)
+	}
+	return out
+}
+
+func pluralS(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+// fetchImage implements linearImageFetcher on linearIssueProvider.
+// Reuses the same cached http.Client that callGraphQL primes so the
+// Authorization round-tripper attaches the personal API key without
+// duplicating the cache invalidation logic on token rotation.
+//
+// SECURITY: the host gate runs here before any HTTP call so the API
+// key never round-trips to a non-Linear CDN, even if a malicious
+// description points at one.
+func (p *linearIssueProvider) fetchImage(ctx context.Context, cfg linearMCPConfig, rawURL string) ([]byte, string, error) {
+	if !isLinearImageURL(rawURL) {
+		return nil, "", fmt.Errorf("linear image: refusing to fetch non-linear host %q", rawURL)
+	}
+	endpoint := linearGraphQLEndpointOrDefault(cfg)
+	p.mu.Lock()
+	if p.httpClient == nil || p.cachedEndpoint != endpoint || p.cachedToken != cfg.Token {
+		p.httpClient = &http.Client{
+			Transport: &linearAPIKeyRoundTripper{base: http.DefaultTransport, token: cfg.Token},
+			Timeout:   linearGraphQLCallTimeout,
+		}
+		p.cachedEndpoint = endpoint
+		p.cachedToken = cfg.Token
+		p.statesMu.Lock()
+		p.statesCache = nil
+		p.statesMu.Unlock()
+		p.teamIDMu.Lock()
+		p.teamIDCache = nil
+		p.teamIDMu.Unlock()
+	}
+	cli := p.httpClient
+	p.mu.Unlock()
+
+	return linearFetchImageOverHTTP(ctx, cli, rawURL)
+}
+
+// linearFetchImageOverHTTP is the pure HTTP+parse step behind
+// fetchImage. Pulled out so tests can drive it against an httptest
+// server without going through the host gate — host filtering is the
+// caller's responsibility.
+//
+// Body reads are capped at linearImageMaxBytesEach+1 so an oversized
+// asset surfaces as an explicit cap-exceeded drop in linearGatherImages
+// rather than exhausting memory.
+func linearFetchImageOverHTTP(ctx context.Context, cli *http.Client, rawURL string) ([]byte, string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", rawURL, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	// The shared round-tripper defaults Content-Type to application/json
+	// for unset headers. A GET has no body, so pre-set Accept and a
+	// benign Content-Type rather than letting the JSON default leak in.
+	req.Header.Set("Accept", "image/*")
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	resp, err := cli.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return nil, "", fmt.Errorf("linear image: HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, linearImageMaxBytesEach+1))
+	if err != nil {
+		return nil, "", err
+	}
+	mime := strings.TrimSpace(resp.Header.Get("Content-Type"))
+	if i := strings.IndexByte(mime, ';'); i >= 0 {
+		mime = strings.TrimSpace(mime[:i])
+	}
+	if mime == "" || strings.EqualFold(mime, "application/octet-stream") {
+		mime = http.DetectContentType(body)
+		if i := strings.IndexByte(mime, ';'); i >= 0 {
+			mime = strings.TrimSpace(mime[:i])
+		}
+	}
+	if !strings.HasPrefix(strings.ToLower(mime), "image/") {
+		return nil, "", fmt.Errorf("linear image: non-image content type %q", mime)
+	}
+	return body, mime, nil
+}

--- a/mcp_linear_images.go
+++ b/mcp_linear_images.go
@@ -34,6 +34,15 @@ const (
 	linearImageMaxBytesEach  = 4 * 1024 * 1024 // 4 MB cap per image
 	linearImageMaxBytesTotal = 8 * 1024 * 1024 // 8 MB cumulative cap
 	linearImageFetchTimeout  = 15 * time.Second
+	// linearImageMaxAttempts bounds total fetch attempts so an issue
+	// littered with broken or oversized image links can't drag the
+	// tool call out to minutes. The success cap above only stops once
+	// linearImageMaxCount images have been *kept*; without a separate
+	// attempt cap, dozens of failing refs would each consume up to
+	// linearImageFetchTimeout. Set generously above the success cap
+	// so a few transient failures still let downstream good URLs
+	// through.
+	linearImageMaxAttempts = linearImageMaxCount * 2
 )
 
 // linearImageMarkdownRe matches markdown image syntax `![alt](url)`.
@@ -110,19 +119,29 @@ type linearImageFetcher interface {
 }
 
 // linearGatherImages walks refs in order, stopping when either the
-// count or cumulative-bytes cap is exhausted. Per-image failures are
-// counted into dropped and otherwise swallowed so a broken CDN entry
-// can't take down the whole tool call.
+// success-count cap or the total-attempts cap is exhausted. Per-image
+// failures are counted into dropped and otherwise swallowed so a
+// broken CDN entry can't take down the whole tool call.
+//
+// The attempt cap is what keeps a stale issue with dozens of broken
+// upload links from dragging the tool call into the minutes — without
+// it, len(images) wouldn't advance and the loop would issue one
+// linearImageFetchTimeout-bounded request per ref.
 func linearGatherImages(ctx context.Context, f linearImageFetcher, cfg linearMCPConfig, refs []linearImageRef) (images []linearFetchedImage, dropped int) {
 	if f == nil || len(refs) == 0 {
 		return nil, 0
 	}
 	total := 0
-	for _, r := range refs {
-		if len(images) >= linearImageMaxCount {
-			dropped++
-			continue
+	attempts := 0
+	for i, r := range refs {
+		if len(images) >= linearImageMaxCount || attempts >= linearImageMaxAttempts {
+			// Caps reached. Count every remaining ref as dropped
+			// in one shot and exit, so we don't keep iterating
+			// the list to no effect.
+			dropped += len(refs) - i
+			break
 		}
+		attempts++
 		ictx, cancel := context.WithTimeout(ctx, linearImageFetchTimeout)
 		body, mime, err := f.fetchImage(ictx, cfg, r.URL)
 		cancel()

--- a/mcp_linear_images.go
+++ b/mcp_linear_images.go
@@ -36,13 +36,21 @@ const (
 	linearImageFetchTimeout  = 15 * time.Second
 	// linearImageMaxAttempts bounds total fetch attempts so an issue
 	// littered with broken or oversized image links can't drag the
-	// tool call out to minutes. The success cap above only stops once
+	// tool call out. The success cap above only stops once
 	// linearImageMaxCount images have been *kept*; without a separate
 	// attempt cap, dozens of failing refs would each consume up to
 	// linearImageFetchTimeout. Set generously above the success cap
 	// so a few transient failures still let downstream good URLs
 	// through.
 	linearImageMaxAttempts = linearImageMaxCount * 2
+	// linearImageGatherDeadline bounds the wall-clock time the whole
+	// gather step can spend, regardless of how many individual fetches
+	// it takes. linearImageFetchTimeout is per-request and could still
+	// add up to linearImageMaxAttempts × linearImageFetchTimeout in
+	// the worst case where every attempt hangs near its own timeout.
+	// The cumulative cap is what guarantees linear_get_issue stays
+	// snappy even on stale issues with many broken upload links.
+	linearImageGatherDeadline = 30 * time.Second
 )
 
 // linearImageMarkdownRe matches markdown image syntax `![alt](url)`.
@@ -118,23 +126,29 @@ type linearImageFetcher interface {
 	fetchImage(ctx context.Context, cfg linearMCPConfig, rawURL string) (data []byte, mimeType string, err error)
 }
 
-// linearGatherImages walks refs in order, stopping when either the
-// success-count cap or the total-attempts cap is exhausted. Per-image
-// failures are counted into dropped and otherwise swallowed so a
-// broken CDN entry can't take down the whole tool call.
+// linearGatherImages walks refs in order, stopping when any of three
+// caps trips: linearImageMaxCount successes, linearImageMaxAttempts
+// total fetches, or linearImageGatherDeadline wall-clock elapsed.
+// Per-image failures are counted into dropped and otherwise swallowed
+// so a broken CDN entry can't take down the whole tool call.
 //
-// The attempt cap is what keeps a stale issue with dozens of broken
-// upload links from dragging the tool call into the minutes — without
-// it, len(images) wouldn't advance and the loop would issue one
-// linearImageFetchTimeout-bounded request per ref.
+// The gather deadline is what guarantees a snappy tool call on stale
+// issues with many broken upload links. linearImageFetchTimeout is
+// per-request, so without a cumulative bound the attempts cap alone
+// would still let a hung CDN consume attempts × timeout seconds. The
+// per-fetch ctx is derived from gatherCtx so the last in-flight
+// request is cancelled the moment the deadline trips.
 func linearGatherImages(ctx context.Context, f linearImageFetcher, cfg linearMCPConfig, refs []linearImageRef) (images []linearFetchedImage, dropped int) {
 	if f == nil || len(refs) == 0 {
 		return nil, 0
 	}
+	gatherCtx, cancelGather := context.WithTimeout(ctx, linearImageGatherDeadline)
+	defer cancelGather()
+
 	total := 0
 	attempts := 0
 	for i, r := range refs {
-		if len(images) >= linearImageMaxCount || attempts >= linearImageMaxAttempts {
+		if len(images) >= linearImageMaxCount || attempts >= linearImageMaxAttempts || gatherCtx.Err() != nil {
 			// Caps reached. Count every remaining ref as dropped
 			// in one shot and exit, so we don't keep iterating
 			// the list to no effect.
@@ -142,7 +156,7 @@ func linearGatherImages(ctx context.Context, f linearImageFetcher, cfg linearMCP
 			break
 		}
 		attempts++
-		ictx, cancel := context.WithTimeout(ctx, linearImageFetchTimeout)
+		ictx, cancel := context.WithTimeout(gatherCtx, linearImageFetchTimeout)
 		body, mime, err := f.fetchImage(ictx, cfg, r.URL)
 		cancel()
 		if err != nil {

--- a/mcp_linear_images.go
+++ b/mcp_linear_images.go
@@ -76,15 +76,19 @@ func linearExtractImageURLs(description string, comments []string) []linearImage
 	return out
 }
 
-// isLinearImageURL accepts only https/http URLs whose host matches
+// isLinearImageURL accepts only https URLs whose host matches
 // uploads.linear.app exactly (case-insensitive). External images
 // pasted into a Linear description are deliberately ignored.
+//
+// HTTPS is required because the auth round-tripper attaches the
+// Linear API key on every fetch; a plaintext http:// URL would
+// leak the key to anyone observing the network.
 func isLinearImageURL(raw string) bool {
 	u, err := url.Parse(raw)
 	if err != nil {
 		return false
 	}
-	if u.Scheme != "https" && u.Scheme != "http" {
+	if u.Scheme != "https" {
 		return false
 	}
 	return strings.EqualFold(u.Host, linearImageHost)
@@ -196,13 +200,18 @@ func pluralS(n int) string {
 }
 
 // fetchImage implements linearImageFetcher on linearIssueProvider.
-// Reuses the same cached http.Client that callGraphQL primes so the
+// Reuses the same cached transport that callGraphQL primes so the
 // Authorization round-tripper attaches the personal API key without
 // duplicating the cache invalidation logic on token rotation.
 //
-// SECURITY: the host gate runs here before any HTTP call so the API
-// key never round-trips to a non-Linear CDN, even if a malicious
-// description points at one.
+// SECURITY: two host-gate layers protect the API key.
+//  1. The pre-flight check on rawURL refuses anything that isn't an
+//     https://uploads.linear.app URL outright.
+//  2. The image client wraps the shared transport with a CheckRedirect
+//     that re-runs the same gate on every hop. A 30x from
+//     uploads.linear.app to a third-party host would otherwise let
+//     net/http follow the redirect with the auth header still attached;
+//     re-gating fails the request closed instead.
 func (p *linearIssueProvider) fetchImage(ctx context.Context, cfg linearMCPConfig, rawURL string) ([]byte, string, error) {
 	if !isLinearImageURL(rawURL) {
 		return nil, "", fmt.Errorf("linear image: refusing to fetch non-linear host %q", rawURL)
@@ -223,10 +232,29 @@ func (p *linearIssueProvider) fetchImage(ctx context.Context, cfg linearMCPConfi
 		p.teamIDCache = nil
 		p.teamIDMu.Unlock()
 	}
-	cli := p.httpClient
+	transport := p.httpClient.Transport
 	p.mu.Unlock()
 
-	return linearFetchImageOverHTTP(ctx, cli, rawURL)
+	imageClient := &http.Client{
+		Transport:     transport,
+		Timeout:       linearGraphQLCallTimeout,
+		CheckRedirect: linearImageCheckRedirect,
+	}
+	return linearFetchImageOverHTTP(ctx, imageClient, rawURL)
+}
+
+// linearImageCheckRedirect re-runs isLinearImageURL against every
+// redirect target so the auth round-tripper cannot leak the API key
+// to a non-Linear host that uploads.linear.app might redirect to.
+// Also caps redirect chains so a misbehaving CDN can't loop us.
+func linearImageCheckRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 5 {
+		return fmt.Errorf("linear image: too many redirects")
+	}
+	if !isLinearImageURL(req.URL.String()) {
+		return fmt.Errorf("linear image: blocked redirect to %q (host gate)", req.URL.Host)
+	}
+	return nil
 }
 
 // linearFetchImageOverHTTP is the pure HTTP+parse step behind
@@ -253,7 +281,12 @@ func linearFetchImageOverHTTP(ctx context.Context, cli *http.Client, rawURL stri
 		return nil, "", err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode >= 400 {
+	// Reject 3xx as well as 4xx/5xx: with CheckRedirect refusing
+	// off-host hops, an in-host 30x still indicates the request
+	// didn't actually produce image bytes. Anything other than 200
+	// (e.g. 204, 206) likewise has no usable body for our cap+sniff
+	// logic, so fail closed.
+	if resp.StatusCode != http.StatusOK {
 		return nil, "", fmt.Errorf("linear image: HTTP %d", resp.StatusCode)
 	}
 	body, err := io.ReadAll(io.LimitReader(resp.Body, linearImageMaxBytesEach+1))

--- a/mcp_linear_images_test.go
+++ b/mcp_linear_images_test.go
@@ -266,6 +266,33 @@ func TestLinearGatherImages_FetchErrorCountedAsDropped(t *testing.T) {
 	}
 }
 
+// When every fetch fails, the success cap never advances; without the
+// attempt cap the loop would issue one fetch per ref and a stale issue
+// with dozens of broken uploads would hang the tool call for minutes.
+// Verify the attempt cap stops the gather at linearImageMaxAttempts
+// and credits the remaining refs as dropped.
+func TestLinearGatherImages_AttemptCapBoundsAllFailures(t *testing.T) {
+	const refCount = linearImageMaxAttempts + 4
+	refs := make([]linearImageRef, refCount)
+	resp := map[string]fakeImageResponse{}
+	for i := range refs {
+		u := fmt.Sprintf("https://uploads.linear.app/broken/%d.png", i)
+		refs[i] = linearImageRef{URL: u, Source: "description"}
+		resp[u] = fakeImageResponse{err: errors.New("404 not found")}
+	}
+	f := &fakeLinearImageFetcher{responses: resp}
+	images, dropped := linearGatherImages(context.Background(), f, linearMCPConfig{}, refs)
+	if len(images) != 0 {
+		t.Errorf("all fetches failed but kept=%d", len(images))
+	}
+	if dropped != refCount {
+		t.Errorf("dropped=%d want %d (every ref accounted for)", dropped, refCount)
+	}
+	if len(f.calls) != linearImageMaxAttempts {
+		t.Errorf("fetched %d times, want %d (attempt cap)", len(f.calls), linearImageMaxAttempts)
+	}
+}
+
 func TestLinearGatherImages_NilFetcher(t *testing.T) {
 	refs := []linearImageRef{{URL: "https://uploads.linear.app/a/1.png", Source: "description"}}
 	images, dropped := linearGatherImages(context.Background(), nil, linearMCPConfig{}, refs)

--- a/mcp_linear_images_test.go
+++ b/mcp_linear_images_test.go
@@ -1,0 +1,511 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// -----------------------------------------------------------------------
+// Pure helpers — URL extraction + host gate
+// -----------------------------------------------------------------------
+
+func TestIsLinearImageURL_AcceptsAndRejects(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"https://uploads.linear.app/abc/img.png", true},
+		{"https://UPLOADS.LINEAR.APP/abc/img.png", true},
+		{"http://uploads.linear.app/abc/img.png", true},
+		{"https://uploads.linear.app/abc/img.png?token=x", true},
+		{"https://example.com/abc.png", false},
+		{"https://uploads.linear.app.evil.com/img.png", false},
+		{"file:///tmp/local.png", false},
+		{"", false},
+		{"not a url", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := isLinearImageURL(tc.in); got != tc.want {
+				t.Errorf("isLinearImageURL(%q)=%v want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLinearExtractImageURLs_DescriptionAndComments(t *testing.T) {
+	desc := strings.Join([]string{
+		"# Repro",
+		"![screenshot](https://uploads.linear.app/a/one.png)",
+		"some prose",
+		"![titled](https://uploads.linear.app/a/two.png \"caption\")",
+		"![external](https://i.imgur.com/x.png)",
+		"plain link https://uploads.linear.app/a/three.png does NOT count",
+	}, "\n")
+	comments := []string{
+		"![ditto](https://uploads.linear.app/a/one.png)", // dup of desc
+		"![comment-only](https://uploads.linear.app/c/four.png)",
+		"no images here",
+	}
+	got := linearExtractImageURLs(desc, comments)
+	wantURLs := []string{
+		"https://uploads.linear.app/a/one.png",
+		"https://uploads.linear.app/a/two.png",
+		"https://uploads.linear.app/c/four.png",
+	}
+	if len(got) != len(wantURLs) {
+		t.Fatalf("got %d refs, want %d (%+v)", len(got), len(wantURLs), got)
+	}
+	for i, w := range wantURLs {
+		if got[i].URL != w {
+			t.Errorf("refs[%d].URL=%q want %q", i, got[i].URL, w)
+		}
+	}
+	if got[0].Source != "description" || got[1].Source != "description" {
+		t.Errorf("description refs lost source tag: %+v", got[:2])
+	}
+	if got[2].Source != "comment" {
+		t.Errorf("comment ref lost source tag: %+v", got[2])
+	}
+}
+
+func TestLinearExtractImageURLs_EmptyInputs(t *testing.T) {
+	if refs := linearExtractImageURLs("", nil); len(refs) != 0 {
+		t.Errorf("empty inputs returned refs: %+v", refs)
+	}
+	if refs := linearExtractImageURLs("no images here", []string{"nor here"}); len(refs) != 0 {
+		t.Errorf("text-only inputs returned refs: %+v", refs)
+	}
+}
+
+func TestLinearCommentBodies_ExtractsBodies(t *testing.T) {
+	in := []issueComment{
+		{author: "a", body: "first"},
+		{author: "b", body: "second"},
+	}
+	got := linearCommentBodies(in)
+	want := []string{"first", "second"}
+	if len(got) != len(want) {
+		t.Fatalf("len=%d want %d", len(got), len(want))
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("bodies[%d]=%q want %q", i, got[i], w)
+		}
+	}
+	if got := linearCommentBodies(nil); got != nil {
+		t.Errorf("nil input returned %+v want nil", got)
+	}
+}
+
+// -----------------------------------------------------------------------
+// linearGatherImages — caps + error handling via stub fetcher
+// -----------------------------------------------------------------------
+
+type fakeLinearImageFetcher struct {
+	responses map[string]fakeImageResponse
+	calls     []string
+}
+
+type fakeImageResponse struct {
+	data []byte
+	mime string
+	err  error
+}
+
+func (f *fakeLinearImageFetcher) fetchImage(_ context.Context, _ linearMCPConfig, rawURL string) ([]byte, string, error) {
+	f.calls = append(f.calls, rawURL)
+	r, ok := f.responses[rawURL]
+	if !ok {
+		return nil, "", fmt.Errorf("no fake response for %q", rawURL)
+	}
+	return r.data, r.mime, r.err
+}
+
+func TestLinearGatherImages_HappyPath(t *testing.T) {
+	refs := []linearImageRef{
+		{URL: "https://uploads.linear.app/a/1.png", Source: "description"},
+		{URL: "https://uploads.linear.app/a/2.png", Source: "description"},
+	}
+	f := &fakeLinearImageFetcher{responses: map[string]fakeImageResponse{
+		"https://uploads.linear.app/a/1.png": {data: []byte("PNGDATA1"), mime: "image/png"},
+		"https://uploads.linear.app/a/2.png": {data: []byte("JPGDATA2"), mime: "image/jpeg"},
+	}}
+	images, dropped := linearGatherImages(context.Background(), f, linearMCPConfig{}, refs)
+	if dropped != 0 {
+		t.Errorf("dropped=%d want 0", dropped)
+	}
+	if len(images) != 2 {
+		t.Fatalf("got %d images, want 2", len(images))
+	}
+	if string(images[0].Data) != "PNGDATA1" || images[0].MIMEType != "image/png" {
+		t.Errorf("images[0]=%+v", images[0])
+	}
+	if string(images[1].Data) != "JPGDATA2" || images[1].MIMEType != "image/jpeg" {
+		t.Errorf("images[1]=%+v", images[1])
+	}
+}
+
+func TestLinearGatherImages_CountCapDropsExcess(t *testing.T) {
+	refs := make([]linearImageRef, linearImageMaxCount+2)
+	resp := map[string]fakeImageResponse{}
+	for i := range refs {
+		u := fmt.Sprintf("https://uploads.linear.app/img/%d.png", i)
+		refs[i] = linearImageRef{URL: u, Source: "description"}
+		resp[u] = fakeImageResponse{data: []byte("data"), mime: "image/png"}
+	}
+	f := &fakeLinearImageFetcher{responses: resp}
+	images, dropped := linearGatherImages(context.Background(), f, linearMCPConfig{}, refs)
+	if len(images) != linearImageMaxCount {
+		t.Errorf("kept=%d want %d", len(images), linearImageMaxCount)
+	}
+	if dropped != 2 {
+		t.Errorf("dropped=%d want 2", dropped)
+	}
+}
+
+func TestLinearGatherImages_ByteCapDropsLastImage(t *testing.T) {
+	// First image hugs the budget. Second image would overflow and is
+	// dropped without aborting the call.
+	big := make([]byte, linearImageMaxBytesTotal-100)
+	for i := range big {
+		big[i] = 'A'
+	}
+	overflow := make([]byte, 200)
+	refs := []linearImageRef{
+		{URL: "https://uploads.linear.app/a/big.png", Source: "description"},
+		{URL: "https://uploads.linear.app/a/overflow.png", Source: "description"},
+	}
+	f := &fakeLinearImageFetcher{responses: map[string]fakeImageResponse{
+		"https://uploads.linear.app/a/big.png":      {data: big, mime: "image/png"},
+		"https://uploads.linear.app/a/overflow.png": {data: overflow, mime: "image/png"},
+	}}
+	images, dropped := linearGatherImages(context.Background(), f, linearMCPConfig{}, refs)
+	if len(images) != 1 {
+		t.Errorf("kept=%d want 1", len(images))
+	}
+	if dropped != 1 {
+		t.Errorf("dropped=%d want 1", dropped)
+	}
+}
+
+func TestLinearGatherImages_PerImageCapDropsOversized(t *testing.T) {
+	huge := make([]byte, linearImageMaxBytesEach+1)
+	refs := []linearImageRef{
+		{URL: "https://uploads.linear.app/a/huge.png", Source: "description"},
+		{URL: "https://uploads.linear.app/a/small.png", Source: "description"},
+	}
+	f := &fakeLinearImageFetcher{responses: map[string]fakeImageResponse{
+		"https://uploads.linear.app/a/huge.png":  {data: huge, mime: "image/png"},
+		"https://uploads.linear.app/a/small.png": {data: []byte("ok"), mime: "image/png"},
+	}}
+	images, dropped := linearGatherImages(context.Background(), f, linearMCPConfig{}, refs)
+	if len(images) != 1 || string(images[0].Data) != "ok" {
+		t.Errorf("kept=%+v want only the small image", images)
+	}
+	if dropped != 1 {
+		t.Errorf("dropped=%d want 1", dropped)
+	}
+}
+
+func TestLinearGatherImages_FetchErrorCountedAsDropped(t *testing.T) {
+	refs := []linearImageRef{
+		{URL: "https://uploads.linear.app/a/ok.png", Source: "description"},
+		{URL: "https://uploads.linear.app/a/bad.png", Source: "description"},
+	}
+	f := &fakeLinearImageFetcher{responses: map[string]fakeImageResponse{
+		"https://uploads.linear.app/a/ok.png":  {data: []byte("ok"), mime: "image/png"},
+		"https://uploads.linear.app/a/bad.png": {err: errors.New("transient")},
+	}}
+	images, dropped := linearGatherImages(context.Background(), f, linearMCPConfig{}, refs)
+	if len(images) != 1 || string(images[0].Data) != "ok" {
+		t.Errorf("kept=%+v want only ok.png", images)
+	}
+	if dropped != 1 {
+		t.Errorf("dropped=%d want 1", dropped)
+	}
+}
+
+func TestLinearGatherImages_NilFetcher(t *testing.T) {
+	refs := []linearImageRef{{URL: "https://uploads.linear.app/a/1.png", Source: "description"}}
+	images, dropped := linearGatherImages(context.Background(), nil, linearMCPConfig{}, refs)
+	if len(images) != 0 || dropped != 0 {
+		t.Errorf("nil fetcher: images=%+v dropped=%d", images, dropped)
+	}
+}
+
+// -----------------------------------------------------------------------
+// linearBuildIssueResult — Content slice assembly
+// -----------------------------------------------------------------------
+
+func TestLinearBuildIssueResult_TextOnlyWhenNoImages(t *testing.T) {
+	f := &fakeLinearImageFetcher{}
+	res := linearBuildIssueResult(context.Background(), f, linearMCPConfig{}, `{"foo":"bar"}`, "no images here", []string{"or here"})
+	if len(res.Content) != 1 {
+		t.Fatalf("content=%d blocks, want 1 (%+v)", len(res.Content), res.Content)
+	}
+	if tc, ok := res.Content[0].(*mcp.TextContent); !ok || tc.Text != `{"foo":"bar"}` {
+		t.Errorf("content[0]=%+v", res.Content[0])
+	}
+	if len(f.calls) != 0 {
+		t.Errorf("fetcher called with no images present: %+v", f.calls)
+	}
+}
+
+func TestLinearBuildIssueResult_AppendsImages(t *testing.T) {
+	desc := "![](https://uploads.linear.app/a/1.png)\n![](https://uploads.linear.app/a/2.png)"
+	f := &fakeLinearImageFetcher{responses: map[string]fakeImageResponse{
+		"https://uploads.linear.app/a/1.png": {data: []byte("AAA"), mime: "image/png"},
+		"https://uploads.linear.app/a/2.png": {data: []byte("BBB"), mime: "image/gif"},
+	}}
+	res := linearBuildIssueResult(context.Background(), f, linearMCPConfig{}, "TEXT", desc, nil)
+	if len(res.Content) != 3 {
+		t.Fatalf("content=%d blocks, want 3 (%+v)", len(res.Content), res.Content)
+	}
+	if tc, ok := res.Content[0].(*mcp.TextContent); !ok || tc.Text != "TEXT" {
+		t.Errorf("content[0]=%+v", res.Content[0])
+	}
+	img1, ok := res.Content[1].(*mcp.ImageContent)
+	if !ok || string(img1.Data) != "AAA" || img1.MIMEType != "image/png" {
+		t.Errorf("content[1]=%+v", res.Content[1])
+	}
+	img2, ok := res.Content[2].(*mcp.ImageContent)
+	if !ok || string(img2.Data) != "BBB" || img2.MIMEType != "image/gif" {
+		t.Errorf("content[2]=%+v", res.Content[2])
+	}
+}
+
+func TestLinearBuildIssueResult_DroppedNoteSurfaces(t *testing.T) {
+	// Five Linear images; cap is 4; expect text + 4 images + 1 trailing note.
+	var sb strings.Builder
+	resp := map[string]fakeImageResponse{}
+	for i := 0; i < linearImageMaxCount+1; i++ {
+		u := fmt.Sprintf("https://uploads.linear.app/x/%d.png", i)
+		sb.WriteString(fmt.Sprintf("![](%s)\n", u))
+		resp[u] = fakeImageResponse{data: []byte("data"), mime: "image/png"}
+	}
+	f := &fakeLinearImageFetcher{responses: resp}
+	res := linearBuildIssueResult(context.Background(), f, linearMCPConfig{}, "T", sb.String(), nil)
+	wantBlocks := 1 + linearImageMaxCount + 1
+	if len(res.Content) != wantBlocks {
+		t.Fatalf("content=%d blocks, want %d", len(res.Content), wantBlocks)
+	}
+	tail, ok := res.Content[len(res.Content)-1].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("trailing block is not text: %+v", res.Content[len(res.Content)-1])
+	}
+	if !strings.Contains(tail.Text, "1 image") || !strings.Contains(tail.Text, "omitted") {
+		t.Errorf("trailing note=%q does not mention the drop", tail.Text)
+	}
+}
+
+// -----------------------------------------------------------------------
+// linearFetchImageOverHTTP — auth + MIME + cap behaviors
+// -----------------------------------------------------------------------
+
+func TestLinearFetchImageOverHTTP_AttachesAuthAndDetectsMIME(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "image/png; charset=binary")
+		_, _ = w.Write([]byte("PNG"))
+	}))
+	defer srv.Close()
+	cli := &http.Client{Transport: &linearAPIKeyRoundTripper{base: http.DefaultTransport, token: "lin_api_x"}}
+	data, mime, err := linearFetchImageOverHTTP(context.Background(), cli, srv.URL)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if gotAuth != "lin_api_x" {
+		t.Errorf("Authorization=%q want bare key", gotAuth)
+	}
+	if string(data) != "PNG" {
+		t.Errorf("data=%q want PNG", data)
+	}
+	if mime != "image/png" {
+		t.Errorf("mime=%q want image/png (charset stripped)", mime)
+	}
+}
+
+func TestLinearFetchImageOverHTTP_DetectsMIMEFromBodyWhenHeaderMissing(t *testing.T) {
+	// PNG magic header — http.DetectContentType returns "image/png" for this.
+	pngBytes := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 'I', 'H', 'D', 'R'}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(pngBytes)
+	}))
+	defer srv.Close()
+	cli := &http.Client{}
+	_, mime, err := linearFetchImageOverHTTP(context.Background(), cli, srv.URL)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if mime != "image/png" {
+		t.Errorf("mime=%q want image/png (detected from body)", mime)
+	}
+}
+
+func TestLinearFetchImageOverHTTP_RejectsNonImageContent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html>not an image</html>"))
+	}))
+	defer srv.Close()
+	cli := &http.Client{}
+	_, _, err := linearFetchImageOverHTTP(context.Background(), cli, srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "non-image") {
+		t.Errorf("err=%v want non-image rejection", err)
+	}
+}
+
+func TestLinearFetchImageOverHTTP_HTTPErrorReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+	cli := &http.Client{}
+	_, _, err := linearFetchImageOverHTTP(context.Background(), cli, srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "403") {
+		t.Errorf("err=%v want HTTP 403 surfaced", err)
+	}
+}
+
+func TestLinearFetchImageOverHTTP_CapsResponseSize(t *testing.T) {
+	// Stream way more than the cap to ensure io.LimitReader is wired up.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		chunk := make([]byte, 1024)
+		for i := range chunk {
+			chunk[i] = 'X'
+		}
+		// Write 8 MB.
+		for i := 0; i < 8*1024; i++ {
+			_, _ = w.Write(chunk)
+		}
+	}))
+	defer srv.Close()
+	cli := &http.Client{}
+	data, _, err := linearFetchImageOverHTTP(context.Background(), cli, srv.URL)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if len(data) > linearImageMaxBytesEach+1 {
+		t.Errorf("len(data)=%d exceeds cap+1=%d — io.LimitReader not wired", len(data), linearImageMaxBytesEach+1)
+	}
+}
+
+// -----------------------------------------------------------------------
+// (*linearIssueProvider).fetchImage host gate
+// -----------------------------------------------------------------------
+
+func TestLinearIssueProvider_FetchImage_RejectsNonLinearHost(t *testing.T) {
+	p := &linearIssueProvider{}
+	cfg := linearMCPConfig{Token: "lin_api_x"}
+	_, _, err := p.fetchImage(context.Background(), cfg, "https://evil.example.com/x.png")
+	if err == nil || !strings.Contains(err.Error(), "non-linear host") {
+		t.Errorf("err=%v want host-gate refusal", err)
+	}
+}
+
+// -----------------------------------------------------------------------
+// End-to-end: linearGetTool inlines images from a Linear-hosted URL
+// -----------------------------------------------------------------------
+
+func TestLinearGetTool_InlinesImagesFromDescription(t *testing.T) {
+	mock := newLinearMockServer(t)
+	mock.handlers["AskGetIssue"] = func(vars map[string]any) any {
+		return map[string]any{
+			"issue": map[string]any{
+				"number":      9,
+				"title":       "with image",
+				"description": "![scrn](https://uploads.linear.app/a/scrn.png)",
+				"state":       map[string]any{"type": "started"},
+				"createdAt":   "2026-01-20T00:00:00Z",
+				"comments":    map[string]any{"nodes": []any{}},
+			},
+		}
+	}
+	b, _ := configuredLinearBridge(t, mock.URL())
+
+	// Stub the provider's image fetcher by reaching into the singleton.
+	// The MCP handler calls mcpLinearProvider() which returns the
+	// registry-backed *linearIssueProvider. We swap its httpClient to
+	// point at a one-handler test server so the host gate passes and
+	// the wire-level path is exercised end-to-end.
+	imgSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Confirm the auth header survives the round-trip.
+		if got := r.Header.Get("Authorization"); got != "lin_api_x" {
+			t.Errorf("image GET Authorization=%q want lin_api_x", got)
+		}
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("IMG-BYTES"))
+	}))
+	defer imgSrv.Close()
+
+	// Wire a transport that rewrites uploads.linear.app to the test server.
+	rewriter := &hostRewriteTransport{from: "uploads.linear.app", to: imgSrv.Listener.Addr().String()}
+	cli := &http.Client{Transport: &linearAPIKeyRoundTripper{base: rewriter, token: "lin_api_x"}}
+	p := mcpLinearProvider()
+	p.mu.Lock()
+	p.httpClient = cli
+	p.cachedEndpoint = mock.URL()
+	p.cachedToken = "lin_api_x"
+	p.mu.Unlock()
+	t.Cleanup(func() {
+		p.mu.Lock()
+		p.httpClient = nil
+		p.cachedEndpoint = ""
+		p.cachedToken = ""
+		p.mu.Unlock()
+	})
+
+	res, _, _ := b.linearGetTool(context.Background(), &mcp.CallToolRequest{}, linearGetInput{Number: 9})
+	if res.IsError {
+		t.Fatalf("get errored: %s", textContent(res))
+	}
+	// Expect text + 1 image content block.
+	if len(res.Content) != 2 {
+		t.Fatalf("content=%d blocks, want 2 (%+v)", len(res.Content), res.Content)
+	}
+	img, ok := res.Content[1].(*mcp.ImageContent)
+	if !ok {
+		t.Fatalf("content[1] is not ImageContent: %+v", res.Content[1])
+	}
+	if string(img.Data) != "IMG-BYTES" || img.MIMEType != "image/png" {
+		t.Errorf("image block=%+v", img)
+	}
+}
+
+// hostRewriteTransport rewrites the request URL host to a custom
+// host:port pair before dispatching. Used in TestLinearGetTool_InlinesImagesFromDescription
+// to redirect uploads.linear.app to an httptest server without
+// touching DNS.
+type hostRewriteTransport struct {
+	from string
+	to   string
+}
+
+func (t *hostRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.EqualFold(req.URL.Host, t.from) {
+		clone := req.Clone(req.Context())
+		clone.URL.Scheme = "http"
+		clone.URL.Host = t.to
+		clone.Host = t.to
+		return http.DefaultTransport.RoundTrip(clone)
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+// Compile-time guard: catch accidental unused imports if tests get trimmed.
+var (
+	_ = json.Marshal
+	_ = http.StatusOK
+)

--- a/mcp_linear_images_test.go
+++ b/mcp_linear_images_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -151,13 +152,21 @@ type fakeImageResponse struct {
 	data []byte
 	mime string
 	err  error
+	// hang causes the fake fetcher to block until ctx is cancelled,
+	// returning ctx.Err(). Used by the gather-deadline test to simulate
+	// upstream URLs that accept the connection but never respond.
+	hang bool
 }
 
-func (f *fakeLinearImageFetcher) fetchImage(_ context.Context, _ linearMCPConfig, rawURL string) ([]byte, string, error) {
+func (f *fakeLinearImageFetcher) fetchImage(ctx context.Context, _ linearMCPConfig, rawURL string) ([]byte, string, error) {
 	f.calls = append(f.calls, rawURL)
 	r, ok := f.responses[rawURL]
 	if !ok {
 		return nil, "", fmt.Errorf("no fake response for %q", rawURL)
+	}
+	if r.hang {
+		<-ctx.Done()
+		return nil, "", ctx.Err()
 	}
 	return r.data, r.mime, r.err
 }
@@ -263,6 +272,45 @@ func TestLinearGatherImages_FetchErrorCountedAsDropped(t *testing.T) {
 	}
 	if dropped != 1 {
 		t.Errorf("dropped=%d want 1", dropped)
+	}
+}
+
+// Even with the attempt cap, a CDN that accepts each connection but
+// never responds would still consume attempts × linearImageFetchTimeout
+// of wall time. The cumulative gather deadline must short-circuit the
+// whole loop the moment ctx fires. We drive that by passing a short
+// parent ctx — gatherCtx's WithTimeout inherits whichever deadline is
+// sooner, so the gather should return in well under a second despite
+// many hanging refs.
+func TestLinearGatherImages_GatherDeadlineBoundsWallTime(t *testing.T) {
+	const refCount = 20
+	refs := make([]linearImageRef, refCount)
+	resp := map[string]fakeImageResponse{}
+	for i := range refs {
+		u := fmt.Sprintf("https://uploads.linear.app/hang/%d.png", i)
+		refs[i] = linearImageRef{URL: u, Source: "description"}
+		resp[u] = fakeImageResponse{hang: true}
+	}
+	f := &fakeLinearImageFetcher{responses: resp}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	images, dropped := linearGatherImages(ctx, f, linearMCPConfig{}, refs)
+	elapsed := time.Since(start)
+
+	if len(images) != 0 {
+		t.Errorf("kept=%d images, want 0 (every fetch hung)", len(images))
+	}
+	if dropped != refCount {
+		t.Errorf("dropped=%d want %d (every ref accounted for)", dropped, refCount)
+	}
+	// linearImageMaxAttempts × linearImageFetchTimeout = 120s would be
+	// the unbounded worst case. With the deadline we should be back
+	// well under 1s.
+	if elapsed > time.Second {
+		t.Errorf("gather took %v, want <1s — cumulative deadline not respected", elapsed)
 	}
 }
 

--- a/mcp_linear_images_test.go
+++ b/mcp_linear_images_test.go
@@ -24,7 +24,9 @@ func TestIsLinearImageURL_AcceptsAndRejects(t *testing.T) {
 	}{
 		{"https://uploads.linear.app/abc/img.png", true},
 		{"https://UPLOADS.LINEAR.APP/abc/img.png", true},
-		{"http://uploads.linear.app/abc/img.png", true},
+		// http:// is refused so the auth token is never sent in plaintext,
+		// even when the host is otherwise legitimate.
+		{"http://uploads.linear.app/abc/img.png", false},
 		{"https://uploads.linear.app/abc/img.png?token=x", true},
 		{"https://example.com/abc.png", false},
 		{"https://uploads.linear.app.evil.com/img.png", false},
@@ -38,6 +40,36 @@ func TestIsLinearImageURL_AcceptsAndRejects(t *testing.T) {
 				t.Errorf("isLinearImageURL(%q)=%v want %v", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestLinearImageCheckRedirect_BlocksOffHostRedirects(t *testing.T) {
+	mkReq := func(raw string) *http.Request {
+		req, _ := http.NewRequest("GET", raw, nil)
+		return req
+	}
+	// Same host, https — allowed.
+	if err := linearImageCheckRedirect(mkReq("https://uploads.linear.app/a/2.png"), nil); err != nil {
+		t.Errorf("same-host redirect blocked: %v", err)
+	}
+	// Off-host redirect — blocked.
+	err := linearImageCheckRedirect(mkReq("https://evil.example.com/x.png"), nil)
+	if err == nil || !strings.Contains(err.Error(), "blocked redirect") {
+		t.Errorf("off-host redirect not blocked: %v", err)
+	}
+	// Downgrade to http — blocked (isLinearImageURL refuses http).
+	err = linearImageCheckRedirect(mkReq("http://uploads.linear.app/a/p.png"), nil)
+	if err == nil || !strings.Contains(err.Error(), "blocked redirect") {
+		t.Errorf("plaintext redirect not blocked: %v", err)
+	}
+	// Too many hops — blocked.
+	via := make([]*http.Request, 5)
+	for i := range via {
+		via[i] = mkReq("https://uploads.linear.app/b")
+	}
+	err = linearImageCheckRedirect(mkReq("https://uploads.linear.app/c"), via)
+	if err == nil || !strings.Contains(err.Error(), "too many redirects") {
+		t.Errorf("redirect cap not enforced: %v", err)
 	}
 }
 
@@ -378,6 +410,27 @@ func TestLinearFetchImageOverHTTP_HTTPErrorReturnsError(t *testing.T) {
 	}
 }
 
+// Defense-in-depth: even with CheckRedirect refusing off-host hops,
+// a 30x that somehow lands on the response (e.g. CheckRedirect
+// returning ErrUseLastResponse) should still fail rather than be
+// treated as a successful body.
+func TestLinearFetchImageOverHTTP_RejectsThreeXXResponses(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "https://elsewhere.example.com/x.png")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer srv.Close()
+	cli := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	_, _, err := linearFetchImageOverHTTP(context.Background(), cli, srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "302") {
+		t.Errorf("err=%v want HTTP 302 surfaced", err)
+	}
+}
+
 func TestLinearFetchImageOverHTTP_CapsResponseSize(t *testing.T) {
 	// Stream way more than the cap to ensure io.LimitReader is wired up.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -412,6 +465,54 @@ func TestLinearIssueProvider_FetchImage_RejectsNonLinearHost(t *testing.T) {
 	_, _, err := p.fetchImage(context.Background(), cfg, "https://evil.example.com/x.png")
 	if err == nil || !strings.Contains(err.Error(), "non-linear host") {
 		t.Errorf("err=%v want host-gate refusal", err)
+	}
+}
+
+// End-to-end: a 30x from uploads.linear.app pointing at a third-party
+// host must fail BEFORE the auth header reaches that host. Failing
+// open here would leak the Linear API key to whatever the CDN
+// redirects to.
+func TestLinearIssueProvider_FetchImage_RefusesOffHostRedirect(t *testing.T) {
+	var leaked string
+	finalSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		leaked = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("LEAK"))
+	}))
+	defer finalSrv.Close()
+
+	uploadsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, finalSrv.URL, http.StatusFound)
+	}))
+	defer uploadsSrv.Close()
+
+	rewriter := &hostRewriteTransport{from: "uploads.linear.app", to: uploadsSrv.Listener.Addr().String()}
+	p := mcpLinearProvider()
+	p.mu.Lock()
+	p.httpClient = &http.Client{
+		Transport: &linearAPIKeyRoundTripper{base: rewriter, token: "lin_api_x"},
+		Timeout:   linearGraphQLCallTimeout,
+	}
+	p.cachedEndpoint = "https://api.linear.app/graphql"
+	p.cachedToken = "lin_api_x"
+	p.mu.Unlock()
+	t.Cleanup(func() {
+		p.mu.Lock()
+		p.httpClient = nil
+		p.cachedEndpoint = ""
+		p.cachedToken = ""
+		p.mu.Unlock()
+	})
+
+	_, _, err := p.fetchImage(context.Background(), linearMCPConfig{Token: "lin_api_x"}, "https://uploads.linear.app/abc/img.png")
+	if err == nil {
+		t.Fatal("expected redirect-block error, got nil")
+	}
+	if !strings.Contains(err.Error(), "blocked redirect") && !strings.Contains(err.Error(), "host gate") {
+		t.Errorf("err=%v want host-gate redirect rejection", err)
+	}
+	if leaked != "" {
+		t.Errorf("Authorization leaked to off-host hop: %q — fetch should have failed before this handler ran", leaked)
 	}
 }
 

--- a/mcp_linear_test.go
+++ b/mcp_linear_test.go
@@ -21,7 +21,14 @@ import (
 // methods are dispatched directly, not through the MCP transport).
 func newLinearMCPTestBridge(t *testing.T, cfgFn func(*projectConfig)) (*mcpBridge, string) {
 	t.Helper()
-	cwd := isolateHome(t)
+	// Canonicalize once and use the same path for seed + bridge.
+	// setCwd runs cwd through memoryProjectRoot (EvalSymlinks) before
+	// storing, so on macOS — where t.TempDir() returns a /var/folders/...
+	// path that resolves to /private/var/folders/... — the bridge would
+	// otherwise read its config under a different projectKey than the
+	// seed wrote, and every handler call would fail the
+	// "active issue provider" gate.
+	cwd := memoryProjectRoot(isolateHome(t))
 	if cfgFn != nil {
 		cfg, _ := loadConfig()
 		pc := loadProjectConfig(cfg, cwd)


### PR DESCRIPTION
## Summary

`linear_get_issue` / `linear_update_issue` previously returned the issue description as a single text block. Embedded screenshots came back as markdown links pointing at `uploads.linear.app`, which the chat agent cannot fetch — the CDN requires the same `Authorization` header the GraphQL API uses, and the agent has no way to attach it.

This PR makes the MCP fetch those images server-side with the existing `linearAPIKeyRoundTripper` and appends each one as an `mcp.ImageContent` block in the tool result, alongside the unchanged JSON text payload. The model can now actually see screenshots that were previously invisible.

## Design

- **Host gate.** Only `https://uploads.linear.app` URLs reach the fetcher — the auth round-tripper attaches the API key on every request, so we never round-trip the token to a third-party CDN that a description might reference. `http://` is rejected so the key can't go over plaintext.
- **Redirect gate.** The image client wraps the shared transport with a `CheckRedirect` that re-runs `isLinearImageURL` on every hop. If the CDN ever redirects off-host, the chain fails closed before the auth header reaches the redirected request.
- **Caps.** `linearImageMaxCount = 4` successful images, `linearImageMaxBytesEach = 4 MB`, `linearImageMaxBytesTotal = 8 MB`, `linearImageMaxAttempts = 8` total fetches, `linearImageGatherDeadline = 30s` cumulative wall time. The deadline is the load-bearing one — without it, eight broken refs at the 15s per-fetch timeout would block `linear_get_issue` for ~2 minutes.
- **Drops surface as a note.** When images overflow any cap, a trailing text block tells the agent how many were omitted so the agent doesn't silently lose state.
- **MIME detection.** Prefers `Content-Type` header (charset param stripped). Falls back to `http.DetectContentType` when the header is empty or `application/octet-stream`. Non-`image/*` responses are rejected.
- **Strict status.** Only HTTP 200 is accepted — 3xx (defense-in-depth against the CheckRedirect being bypassed somehow) and 4xx/5xx all fail closed.

## Audit

Audited by codex (gpt-5.5 xhigh) over four rounds:

1. P1: HTTPS-only + off-host redirect leak → fixed in `ad7ac75`.
2. P2: minutes-long hang on many broken upload refs (success cap alone insufficient) → attempt cap added in `ad035b5`.
3. P2: attempt cap × per-fetch timeout still 120s worst case → cumulative gather deadline added in `b66360a`.
4. Clean.

## Drive-by

`newLinearMCPTestBridge` seeded config under `filepath.Abs(cwd)` but stored the bridge cwd via `setCwd`'s `memoryProjectRoot` canonicalization. On macOS those return different paths (`/var/folders/...` vs `/private/var/folders/...`) because `EvalSymlinks` resolves the `/var` → `/private/var` symlink, so every Linear MCP test silently failed the \"active issue provider\" gate. Canonicalizing once in the helper fixes the round-trip.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -run TestLinear ./...` → 206 passing (was 201 + 5 new for security + caps + deadline).
- [x] `go test ./...` → 1042 passing, 3 unrelated `mcp_workflows_test.go` failures that pre-date this branch (same macOS symlink isolation bug as the helper I fixed; verified on clean `origin/main`).
- [ ] Manual: trigger `linear_get_issue` on a Linear issue with embedded screenshots; confirm the agent sees the screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)