### PR TITLE
Defer Ctrl+P/Ctrl+N to an open modal before app-level keybindings

### DIFF
--- a/keymap_dispatch_test.go
+++ b/keymap_dispatch_test.go
@@ -102,22 +102,133 @@ func TestApp_TabNavDefersToModalListNav(t *testing.T) {
 	})
 	defer invalidateKeyMapCache()
 
-	a := testAppWithTwoTabs(t)
-	a.active = 0
-	a.tabs[0].mode = modeConfig
-	a.tabs[0].configKeybindingsPickerActive = true
+	for _, tc := range []struct {
+		name       string
+		key        tea.KeyPressMsg
+		wantCursor int
+	}{
+		{"next", ctrlKey('n'), 1},
+		{"prev", ctrlKey('p'), len(actionMeta) - 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := testAppWithTwoTabs(t)
+			a.active = 0
+			a.tabs[0].mode = modeConfig
+			a.tabs[0].configKeybindingsPickerActive = true
 
-	newA, _ := a.Update(ctrlKey('n'))
-	a2, ok := newA.(app)
-	if !ok {
-		t.Fatalf("Update returned %T, want app", newA)
+			newA, _ := a.Update(tc.key)
+			a2, ok := newA.(app)
+			if !ok {
+				t.Fatalf("Update returned %T, want app", newA)
+			}
+			if a2.active != 0 {
+				t.Fatalf("%s with a modal list open must not switch tabs; active=%d", tc.key.String(), a2.active)
+			}
+			if got := a2.tabs[0].configKeybindingsCursor; got != tc.wantCursor {
+				t.Errorf("%s should move the modal list cursor; got %d want %d", tc.key.String(), got, tc.wantCursor)
+			}
+		})
 	}
-	if a2.active != 0 {
-		t.Fatalf("Ctrl+N with a modal open must not switch tabs; active=%d", a2.active)
+}
+
+func TestApp_TabNavSwitchesWhenModalDoesNotOwnListNav(t *testing.T) {
+	isolateHome(t)
+	setKeyMapForTesting(KeyMap{
+		ActionTabPrev:    {Mod: tea.ModCtrl, Code: 'p'},
+		ActionTabNext:    {Mod: tea.ModCtrl, Code: 'n'},
+		ActionTabNew:     defaultKeyBindings[ActionTabNew],
+		ActionAppSuspend: defaultKeyBindings[ActionAppSuspend],
+	})
+	defer invalidateKeyMapCache()
+
+	cases := []struct {
+		name  string
+		setup func(*model)
+	}{
+		{"cancel turn confirm", func(m *model) { m.cancelTurnConfirming = true }},
+		{"close tab confirm", func(m *model) { m.closeTabConfirming = true }},
+		{"merge PR confirm", func(m *model) { m.mergePRConfirming = true }},
+		{"approval", func(m *model) { m.mode = modeApproval }},
 	}
-	if got := a2.tabs[0].configKeybindingsCursor; got != 1 {
-		t.Errorf("Ctrl+N should advance the modal's list cursor; got %d want 1", got)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := testAppWithTwoTabs(t)
+			a.active = 0
+			tc.setup(a.tabs[0])
+
+			newA, _ := a.Update(ctrlKey('n'))
+			a2, ok := newA.(app)
+			if !ok {
+				t.Fatalf("Update returned %T, want app", newA)
+			}
+			if a2.active != 1 {
+				t.Errorf("Ctrl+N should switch tabs when %s does not own list navigation; active=%d", tc.name, a2.active)
+			}
+		})
 	}
+}
+
+func TestApp_CtrlListNavDeferralKeepsHigherPriorityAppActions(t *testing.T) {
+	isolateHome(t)
+	defer invalidateKeyMapCache()
+
+	t.Run("suspend", func(t *testing.T) {
+		setKeyMapForTesting(KeyMap{
+			ActionAppSuspend: {Mod: tea.ModCtrl, Code: 'n'},
+			ActionTabNew:     defaultKeyBindings[ActionTabNew],
+			ActionTabPrev:    {Mod: tea.ModCtrl, Code: 'p'},
+			ActionTabNext:    {Mod: tea.ModCtrl, Code: 'n'},
+		})
+
+		a := testAppWithTwoTabs(t)
+		a.active = 0
+		a.tabs[0].mode = modeConfig
+		a.tabs[0].configKeybindingsPickerActive = true
+
+		newA, cmd := a.Update(ctrlKey('n'))
+		a2, ok := newA.(app)
+		if !ok {
+			t.Fatalf("Update returned %T, want app", newA)
+		}
+		if cmd == nil {
+			t.Fatal("Ctrl+N rebound to suspend must not be swallowed by list-nav deferral")
+		}
+		if msg := cmd(); msg != (tea.SuspendMsg{}) {
+			t.Fatalf("cmd should yield tea.SuspendMsg{}, got %T", msg)
+		}
+		if !a2.suspending {
+			t.Error("suspend action should set app.suspending")
+		}
+		if got := a2.tabs[0].configKeybindingsCursor; got != 0 {
+			t.Errorf("suspend should win before modal list nav; cursor=%d", got)
+		}
+	})
+
+	t.Run("new tab", func(t *testing.T) {
+		setKeyMapForTesting(KeyMap{
+			ActionAppSuspend: defaultKeyBindings[ActionAppSuspend],
+			ActionTabNew:     {Mod: tea.ModCtrl, Code: 'n'},
+			ActionTabPrev:    {Mod: tea.ModCtrl, Code: 'p'},
+			ActionTabNext:    {Mod: tea.ModCtrl, Code: 'n'},
+		})
+
+		a := testAppWithTwoTabs(t)
+		a.active = 0
+		a.tabs[0].mode = modeConfig
+		a.tabs[0].configKeybindingsPickerActive = true
+
+		newA, _ := a.Update(ctrlKey('n'))
+		a2, ok := newA.(app)
+		if !ok {
+			t.Fatalf("Update returned %T, want app", newA)
+		}
+		if len(a2.tabs) != 3 || a2.active != 2 {
+			t.Fatalf("Ctrl+N rebound to tab.new should open a third active tab; len=%d active=%d", len(a2.tabs), a2.active)
+		}
+		if got := a2.tabs[0].configKeybindingsCursor; got != 0 {
+			t.Errorf("tab.new should win before modal list nav; cursor=%d", got)
+		}
+	})
 }
 
 // TestApp_TabNavSwitchesWithoutModal is the companion guard: with the

--- a/keymap_dispatch_test.go
+++ b/keymap_dispatch_test.go
@@ -86,6 +86,67 @@ func TestApp_TabNavigationIgnoresLockModifiers(t *testing.T) {
 	}
 }
 
+// TestApp_TabNavDefersToModalListNav proves the app-level tab switcher
+// yields Ctrl+P/Ctrl+N to a modal in the active tab. With tab.prev /
+// tab.next rebound onto those keys (a real user config), pressing
+// Ctrl+N while a modal list — here the /config keybindings picker — is
+// open must navigate that list, NOT switch tabs. Without the deferral
+// the app layer would intercept the key before the tab ever saw it.
+func TestApp_TabNavDefersToModalListNav(t *testing.T) {
+	isolateHome(t)
+	setKeyMapForTesting(KeyMap{
+		ActionTabPrev:    {Mod: tea.ModCtrl, Code: 'p'},
+		ActionTabNext:    {Mod: tea.ModCtrl, Code: 'n'},
+		ActionTabNew:     defaultKeyBindings[ActionTabNew],
+		ActionAppSuspend: defaultKeyBindings[ActionAppSuspend],
+	})
+	defer invalidateKeyMapCache()
+
+	a := testAppWithTwoTabs(t)
+	a.active = 0
+	a.tabs[0].mode = modeConfig
+	a.tabs[0].configKeybindingsPickerActive = true
+
+	newA, _ := a.Update(ctrlKey('n'))
+	a2, ok := newA.(app)
+	if !ok {
+		t.Fatalf("Update returned %T, want app", newA)
+	}
+	if a2.active != 0 {
+		t.Fatalf("Ctrl+N with a modal open must not switch tabs; active=%d", a2.active)
+	}
+	if got := a2.tabs[0].configKeybindingsCursor; got != 1 {
+		t.Errorf("Ctrl+N should advance the modal's list cursor; got %d want 1", got)
+	}
+}
+
+// TestApp_TabNavSwitchesWithoutModal is the companion guard: with the
+// same Ctrl+N → tab.next rebind but no modal open, Ctrl+N must still do
+// its normal job and switch tabs. The deferral is conditional on a
+// modal/popover owning the keyboard, not a blanket suppression.
+func TestApp_TabNavSwitchesWithoutModal(t *testing.T) {
+	isolateHome(t)
+	setKeyMapForTesting(KeyMap{
+		ActionTabPrev:    {Mod: tea.ModCtrl, Code: 'p'},
+		ActionTabNext:    {Mod: tea.ModCtrl, Code: 'n'},
+		ActionTabNew:     defaultKeyBindings[ActionTabNew],
+		ActionAppSuspend: defaultKeyBindings[ActionAppSuspend],
+	})
+	defer invalidateKeyMapCache()
+
+	a := testAppWithTwoTabs(t)
+	a.active = 0 // default tab state: modeInput, empty input — no modal/popover
+
+	newA, _ := a.Update(ctrlKey('n'))
+	a2, ok := newA.(app)
+	if !ok {
+		t.Fatalf("Update returned %T, want app", newA)
+	}
+	if a2.active != 1 {
+		t.Errorf("Ctrl+N with no modal open must switch tabs; active=%d", a2.active)
+	}
+}
+
 func TestUpdate_ScreenShortcutIgnoresLockModifiers(t *testing.T) {
 	isolateHome(t)
 	invalidateKeyMapCache()

--- a/keymap_dispatch_test.go
+++ b/keymap_dispatch_test.go
@@ -168,11 +168,16 @@ func TestApp_TabNavSwitchesWhenModalDoesNotOwnListNav(t *testing.T) {
 	}
 }
 
-func TestApp_CtrlListNavDeferralKeepsHigherPriorityAppActions(t *testing.T) {
+// TestApp_ModalListNavWinsOverReboundAppActions proves the deferral runs
+// before every app-level action, not just tab switching: when a modal
+// owns list navigation, Ctrl+P/Ctrl+N navigate the list regardless of
+// what the user has bound onto them (suspend, new tab, ...). Without the
+// gate sitting first, those binds would shadow in-modal navigation.
+func TestApp_ModalListNavWinsOverReboundAppActions(t *testing.T) {
 	isolateHome(t)
 	defer invalidateKeyMapCache()
 
-	t.Run("suspend", func(t *testing.T) {
+	t.Run("suspend rebound onto Ctrl+N", func(t *testing.T) {
 		setKeyMapForTesting(KeyMap{
 			ActionAppSuspend: {Mod: tea.ModCtrl, Code: 'n'},
 			ActionTabNew:     defaultKeyBindings[ActionTabNew],
@@ -190,21 +195,20 @@ func TestApp_CtrlListNavDeferralKeepsHigherPriorityAppActions(t *testing.T) {
 		if !ok {
 			t.Fatalf("Update returned %T, want app", newA)
 		}
-		if cmd == nil {
-			t.Fatal("Ctrl+N rebound to suspend must not be swallowed by list-nav deferral")
+		if a2.suspending {
+			t.Error("modal list-nav must win: Ctrl+N should not suspend the app")
 		}
-		if msg := cmd(); msg != (tea.SuspendMsg{}) {
-			t.Fatalf("cmd should yield tea.SuspendMsg{}, got %T", msg)
+		if cmd != nil {
+			if msg := cmd(); msg == (tea.SuspendMsg{}) {
+				t.Fatal("Ctrl+N should navigate the modal, not emit tea.SuspendMsg")
+			}
 		}
-		if !a2.suspending {
-			t.Error("suspend action should set app.suspending")
-		}
-		if got := a2.tabs[0].configKeybindingsCursor; got != 0 {
-			t.Errorf("suspend should win before modal list nav; cursor=%d", got)
+		if got := a2.tabs[0].configKeybindingsCursor; got != 1 {
+			t.Errorf("Ctrl+N should advance the modal list cursor; got %d want 1", got)
 		}
 	})
 
-	t.Run("new tab", func(t *testing.T) {
+	t.Run("new-tab rebound onto Ctrl+N", func(t *testing.T) {
 		setKeyMapForTesting(KeyMap{
 			ActionAppSuspend: defaultKeyBindings[ActionAppSuspend],
 			ActionTabNew:     {Mod: tea.ModCtrl, Code: 'n'},
@@ -222,11 +226,11 @@ func TestApp_CtrlListNavDeferralKeepsHigherPriorityAppActions(t *testing.T) {
 		if !ok {
 			t.Fatalf("Update returned %T, want app", newA)
 		}
-		if len(a2.tabs) != 3 || a2.active != 2 {
-			t.Fatalf("Ctrl+N rebound to tab.new should open a third active tab; len=%d active=%d", len(a2.tabs), a2.active)
+		if len(a2.tabs) != 2 || a2.active != 0 {
+			t.Fatalf("modal list-nav must win: Ctrl+N should not open a tab; len=%d active=%d", len(a2.tabs), a2.active)
 		}
-		if got := a2.tabs[0].configKeybindingsCursor; got != 0 {
-			t.Errorf("tab.new should win before modal list nav; cursor=%d", got)
+		if got := a2.tabs[0].configKeybindingsCursor; got != 1 {
+			t.Errorf("Ctrl+N should advance the modal list cursor; got %d want 1", got)
 		}
 	})
 }

--- a/tabs.go
+++ b/tabs.go
@@ -93,6 +93,39 @@ func (a app) Init() tea.Cmd {
 	return tea.Batch(cmds...)
 }
 
+func (m model) ownsCtrlListNav() bool {
+	if m.popoverOpen() {
+		return true
+	}
+	switch m.mode {
+	case modeSessionPicker, modeProviderSwitch:
+		return true
+	case modeAskQuestion:
+		return m.askOwnsCtrlListNav()
+	case modeConfig:
+		return m.configOwnsCtrlListNav()
+	default:
+		return false
+	}
+}
+
+func (m model) askOwnsCtrlListNav() bool {
+	if m.askConfirmingCancel || m.askOllamaActive || m.askEditing == askEditNote || m.isOnConfirmTab() {
+		return false
+	}
+	return m.askTab >= 0 && m.askTab < len(m.askQuestions)
+}
+
+func (m model) configOwnsCtrlListNav() bool {
+	if m.configMemoryPickerActive && m.configMemoryFieldEditing != "" {
+		return false
+	}
+	if m.configProjectPickerActive && m.configProjectFieldEditing != "" {
+		return false
+	}
+	return true
+}
+
 func (a app) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch m := msg.(type) {
 	case closeTabMsg:
@@ -110,21 +143,13 @@ func (a app) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		m = normalizeKeyPressMsg(m)
 		km := currentKeyMap()
-		// A modal or inline popover in the active tab owns the list-nav
-		// keys (Ctrl+P/Ctrl+N) for its own cursor. Defer them to the tab
-		// even when the user has bound tab.prev/tab.next onto those keys,
-		// so in-list navigation wins while a modal is up. Outside a modal
-		// they fall through to the tab switching below.
-		if isCtrlListNav(m) {
-			if at := a.activeTab(); at.modalOpen() || at.popoverOpen() {
-				return a.dispatchActive(msg)
-			}
-		}
 		switch {
 		case km.Matches(ActionAppSuspend, m):
 			return a.suspendApp()
 		case km.Matches(ActionTabNew, m):
 			return a.openTab()
+		case isCtrlListNav(m) && a.activeTab().ownsCtrlListNav():
+			return a.dispatchActive(msg)
 		case km.Matches(ActionTabPrev, m):
 			return a.switchTab(a.active - 1)
 		case km.Matches(ActionTabNext, m):

--- a/tabs.go
+++ b/tabs.go
@@ -110,6 +110,16 @@ func (a app) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		m = normalizeKeyPressMsg(m)
 		km := currentKeyMap()
+		// A modal or inline popover in the active tab owns the list-nav
+		// keys (Ctrl+P/Ctrl+N) for its own cursor. Defer them to the tab
+		// even when the user has bound tab.prev/tab.next onto those keys,
+		// so in-list navigation wins while a modal is up. Outside a modal
+		// they fall through to the tab switching below.
+		if isCtrlListNav(m) {
+			if at := a.activeTab(); at.modalOpen() || at.popoverOpen() {
+				return a.dispatchActive(msg)
+			}
+		}
 		switch {
 		case km.Matches(ActionAppSuspend, m):
 			return a.suspendApp()

--- a/tabs.go
+++ b/tabs.go
@@ -144,12 +144,18 @@ func (a app) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m = normalizeKeyPressMsg(m)
 		km := currentKeyMap()
 		switch {
+		// A modal or inline popover that navigates with Ctrl+P/Ctrl+N
+		// owns those keys: defer them to the active tab before any
+		// app-level keymap action, so whatever the user has bound onto
+		// Ctrl+P/Ctrl+N (tab switch, new tab, suspend, ...) cannot shadow
+		// in-modal list navigation. Outside such a modal the keys fall
+		// through to the normal app actions below.
+		case isCtrlListNav(m) && a.activeTab().ownsCtrlListNav():
+			return a.dispatchActive(msg)
 		case km.Matches(ActionAppSuspend, m):
 			return a.suspendApp()
 		case km.Matches(ActionTabNew, m):
 			return a.openTab()
-		case isCtrlListNav(m) && a.activeTab().ownsCtrlListNav():
-			return a.dispatchActive(msg)
 		case km.Matches(ActionTabPrev, m):
 			return a.switchTab(a.active - 1)
 		case km.Matches(ActionTabNext, m):


### PR DESCRIPTION
## Problem

App-level key dispatch in `app.Update` (`tabs.go`) matches keymap actions (`tab.prev`/`tab.next`/`tab.new`/`app.suspend`) and returns *before* delegating to the active tab — so it runs before any modal in that tab can see the key.

`Ctrl+P`/`Ctrl+N` (`list_nav.go`) are alternates to the arrow keys for navigating **in-modal lists** — `/config`, the ask-question modal, inline pickers. The keybindings config lets you rebind any app-level action onto other keys, including `Ctrl+P`/`Ctrl+N`. When you do, the app layer consumes the keypress for that action and the modal never sees it — so the keys switch tabs, open a tab, or suspend instead of navigating the open list. The model-layer popover deferral in `update.go` never runs because `dispatchActive` is skipped.

(By default, tab nav is `Ctrl+Left`/`Ctrl+Right` and `Ctrl+P`/`Ctrl+N` aren't bound to any app action, so they already reach the modal — this only bites once an app action is rebound onto the list-nav keys.)

## Fix

When the active tab's modal/popover owns list navigation (`ownsCtrlListNav()`) and the key is a Ctrl list-nav key, dispatch it to the tab **before any app-level action** — so in a modal, `Ctrl+P`/`Ctrl+N` always navigate the list regardless of what's bound to them. Outside such a modal the keys fall through to normal app handling, so a rebind keeps working everywhere else.

`ownsCtrlListNav()` is intentionally narrow: confirm/approval overlays and field-editing sub-states do not consume the keys, so they keep their normal app behavior rather than swallowing the keypress. The predicate mirrors each modal's own list-nav guards (e.g. the ask modal's `askConfirmingCancel`/`askOllamaActive`/`askEditNote` early-returns).

## Tests

`keymap_dispatch_test.go`: with `tab.prev`/`tab.next`, `tab.new`, or `app.suspend` rebound onto `Ctrl+P`/`Ctrl+N`, those keys navigate the `/config` list without switching/opening tabs or suspending; confirm/approval modals fall through to normal handling; and with no modal open the rebind still performs its app action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
