### PR TITLE
feat: cross-session agent overview (Ctrl+G)

### DIFF
--- a/keymap.go
+++ b/keymap.go
@@ -44,6 +44,7 @@ const (
 	ActionTabPrev         Action = "tab.prev"
 	ActionTabNext         Action = "tab.next"
 	ActionAppSuspend      Action = "app.suspend"
+	ActionAgentOverview   Action = "agent.overview"
 )
 
 // KeyBinding is a parsed Mod+Code pair. The zero value (Mod==0,
@@ -237,6 +238,7 @@ var defaultKeyBindings = map[Action]KeyBinding{
 	ActionTabPrev:         {Mod: tea.ModCtrl, Code: tea.KeyLeft},
 	ActionTabNext:         {Mod: tea.ModCtrl, Code: tea.KeyRight},
 	ActionAppSuspend:      {Mod: tea.ModCtrl, Code: 'z'},
+	ActionAgentOverview:   {Mod: tea.ModCtrl, Code: 'g'},
 }
 
 func init() {
@@ -351,6 +353,7 @@ var actionGroups = []actionMetaGroup{
 		{ActionReload, "Reload issues/PRs"},
 	}},
 	{Heading: "App", Items: []actionMetaItem{
+		{ActionAgentOverview, "Agent overview"},
 		{ActionAppSuspend, "Suspend ask"},
 	}},
 }

--- a/main.go
+++ b/main.go
@@ -123,6 +123,7 @@ func newTab(id int, cfg askConfig) (*model, error) {
 		shellOutIdx:        -1,
 		shellHistoryIdx:    -1,
 		fc:                 &frameCache{},
+		lastActivity:       time.Now(),
 	}
 	// 80 cells gives a Neo4j error (e.g. "create database 'ask_tests':
 	// connectivity: ...") room to wrap across a few lines instead of

--- a/overview.go
+++ b/overview.go
@@ -1,0 +1,466 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	lipgloss "charm.land/lipgloss/v2"
+	xansi "github.com/charmbracelet/x/ansi"
+)
+
+// The agent overview is an app-level, full-screen "inbox" of every open
+// tab (each tab = one running agent session). It lives on `app` rather
+// than as a per-tab `screen` because a screen only ever sees its own
+// model — the overview has to enumerate siblings, which only the app
+// layer can. Opening it with ActionAgentOverview (Ctrl+G by default)
+// hands the whole keyboard to overviewHandleKey; all non-key messages
+// keep flowing to the tabs underneath, so the list reflects live state
+// on every frame.
+
+// agentStatus is the coarse state shown per session. The order of the
+// constants is the precedence used by agentStatusOf when several could
+// apply (a finalised workflow wins over busy, "needs you" wins over a
+// generic working state, etc.).
+type agentStatus int
+
+const (
+	statusIdle agentStatus = iota
+	statusWorking
+	statusNeedsYou
+	statusDone
+	statusFailed
+)
+
+// overviewRow is the projection of one tab the renderer consumes. It is
+// produced by overviewRowFor so tests can assert on the derived fields
+// without touching styled output.
+type overviewRow struct {
+	tabID         int
+	title         string
+	project       string
+	providerModel string
+	status        agentStatus
+	statusText    string // live m.status while working ("Thinking…")
+	spinnerFrame  string // t.spinner.View() while working
+	stepInfo      string // "step 2/3" for workflow tabs
+	idle          time.Duration
+	busy          bool
+	active        bool
+}
+
+// agentStatusOf classifies a session. Precedence: a finalised workflow
+// (failed/done) first, then a tab blocked on a question/approval
+// ("needs you"), then a busy tab, else idle.
+func agentStatusOf(t *model) agentStatus {
+	if t == nil {
+		return statusIdle
+	}
+	if t.workflowRun != nil {
+		switch {
+		case t.workflowRun.failed:
+			return statusFailed
+		case t.workflowRun.done:
+			return statusDone
+		}
+	}
+	switch t.mode {
+	case modeAskQuestion, modeApproval:
+		return statusNeedsYou
+	}
+	if t.busy {
+		return statusWorking
+	}
+	return statusIdle
+}
+
+// overviewTitle is the one-line "what is this session about" label. A
+// user-set overviewLabel wins; otherwise a workflow tab names its
+// pipeline + source, and a chat tab uses its first user message. New
+// tabs with nothing typed yet read "new session".
+func overviewTitle(t *model) string {
+	if t == nil {
+		return "new session"
+	}
+	if s := strings.TrimSpace(t.overviewLabel); s != "" {
+		return s
+	}
+	if t.workflowRun != nil {
+		name := t.workflowRun.Workflow.Name
+		if name == "" {
+			name = "workflow"
+		}
+		if d := t.workflowRun.Source.Display(); d != "" {
+			return fmt.Sprintf("workflow %q · %s", name, d)
+		}
+		return fmt.Sprintf("workflow %q", name)
+	}
+	for _, e := range t.history {
+		if e.kind != histUser {
+			continue
+		}
+		txt := strings.TrimSpace(strings.ReplaceAll(e.text, "\n", " "))
+		if txt != "" {
+			return txt
+		}
+	}
+	return "new session"
+}
+
+// overviewRowFor derives the full row projection for a tab. active is
+// passed in (the app knows which index is focused) rather than read off
+// the model.
+func overviewRowFor(t *model, active bool) overviewRow {
+	row := overviewRow{
+		tabID:   t.id,
+		title:   overviewTitle(t),
+		project: shortCwdOf(t.cwd),
+		status:  agentStatusOf(t),
+		busy:    t.busy,
+		active:  active,
+		idle:    time.Since(t.lastActivity),
+	}
+	if t.provider != nil {
+		row.providerModel = t.provider.DisplayName()
+		if t.providerModel != "" {
+			row.providerModel += "/" + t.providerModel
+		}
+	}
+	if t.busy {
+		row.statusText = strings.TrimSpace(t.status)
+		row.spinnerFrame = t.spinner.View()
+	}
+	if t.workflowRun != nil {
+		if n := len(t.workflowRun.Workflow.Steps); n > 0 {
+			row.stepInfo = fmt.Sprintf("step %d/%d", t.workflowRun.StepIdx+1, n)
+		}
+	}
+	return row
+}
+
+// openOverview enters the overview, parks the cursor on the currently
+// active tab so the user is oriented, and starts the refresh tick.
+func (a app) openOverview() (tea.Model, tea.Cmd) {
+	a.overviewOpen = true
+	a.overviewConfirmClose = false
+	a.overviewRenaming = false
+	a.overviewRenameBuf = ""
+	a.overviewCursor = a.active
+	a.clampOverviewCursor()
+	return a, overviewTickCmd()
+}
+
+// closeOverviewState clears every overview sub-mode and returns the app
+// with the overlay shut. The caller decides the accompanying cmd.
+func (a app) closeOverviewState() app {
+	a.overviewOpen = false
+	a.overviewConfirmClose = false
+	a.overviewRenaming = false
+	a.overviewRenameBuf = ""
+	return a
+}
+
+func (a *app) clampOverviewCursor() {
+	n := len(a.tabs)
+	switch {
+	case n == 0:
+		a.overviewCursor = 0
+	case a.overviewCursor < 0:
+		a.overviewCursor = 0
+	case a.overviewCursor >= n:
+		a.overviewCursor = n - 1
+	}
+}
+
+// overviewTickCmd re-renders the overview once a second so idle ages and
+// the "needs you" flag stay fresh when nothing is streaming. Busy tabs
+// already drive renders via spinner ticks; this just covers the quiet
+// case. tea.Tick mirrors issueLoadingTickCmd.
+func overviewTickCmd() tea.Cmd {
+	return tea.Tick(time.Second, func(time.Time) tea.Msg {
+		return overviewTickMsg{}
+	})
+}
+
+// overviewHandleKey owns the keyboard while the overview is open. Sub-
+// modes (rename, confirm-close) are checked first so their keys can't
+// leak into list navigation. Ctrl+G toggles the overview shut and Ctrl+C
+// also just closes it — the app quit lives on the normal screen, not
+// here.
+func (a app) overviewHandleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if a.overviewRenaming {
+		return a.overviewRenameKey(msg)
+	}
+	if msg.Mod == tea.ModCtrl && (msg.Code == 'g' || msg.Code == 'c') {
+		return a.closeOverviewState(), nil
+	}
+	// A pending close confirm is modal: only y / n / enter / esc matter.
+	if a.overviewConfirmClose {
+		if msg.Mod == 0 {
+			switch msg.Code {
+			case 'y', 'Y', tea.KeyEnter:
+				return a.overviewConfirmCloseSelected()
+			case 'n', 'N', tea.KeyEsc:
+				a.overviewConfirmClose = false
+			}
+		}
+		return a, nil
+	}
+	// List navigation matches every other ask picker: ↑/↓ plus
+	// Ctrl+P/Ctrl+N (listNavPrev/listNavNext in list_nav.go), and it
+	// wraps top↔bottom via listNavWrap like all of them do. No j/k —
+	// that's the kanban's 2-D board idiom, not the vertical-list one.
+	switch {
+	case listNavPrev(msg):
+		a.overviewCursor = listNavWrap(a.overviewCursor, -1, len(a.tabs))
+		return a, nil
+	case listNavNext(msg):
+		a.overviewCursor = listNavWrap(a.overviewCursor, +1, len(a.tabs))
+		return a, nil
+	}
+	// Remaining keys are all unmodified.
+	if msg.Mod != 0 {
+		return a, nil
+	}
+	switch msg.Code {
+	case tea.KeyEsc, 'q':
+		return a.closeOverviewState(), nil
+	case tea.KeyEnter:
+		return a.overviewJumpToCursor()
+	case tea.KeyHome:
+		a.overviewCursor = 0
+	case tea.KeyEnd:
+		a.overviewCursor = len(a.tabs) - 1
+		a.clampOverviewCursor()
+	case 'd':
+		if len(a.tabs) > 0 {
+			a.overviewConfirmClose = true
+		}
+	case 'n':
+		return a.overviewNewTab()
+	case 'r':
+		if len(a.tabs) > 0 {
+			a.clampOverviewCursor()
+			a.overviewRenaming = true
+			a.overviewRenameBuf = a.tabs[a.overviewCursor].overviewLabel
+		}
+	}
+	return a, nil
+}
+
+// overviewRenameKey runs the inline rename editor. Enter commits the
+// trimmed buffer onto the selected tab's overviewLabel; Esc cancels.
+// Tabs are pointers, so writing through a.tabs[i] persists past the
+// value-receiver copy.
+func (a app) overviewRenameKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.Code {
+	case tea.KeyEsc:
+		a.overviewRenaming = false
+		a.overviewRenameBuf = ""
+		return a, nil
+	case tea.KeyEnter:
+		a.clampOverviewCursor()
+		if len(a.tabs) > 0 {
+			a.tabs[a.overviewCursor].overviewLabel = strings.TrimSpace(a.overviewRenameBuf)
+		}
+		a.overviewRenaming = false
+		a.overviewRenameBuf = ""
+		return a, nil
+	case tea.KeyBackspace:
+		if a.overviewRenameBuf != "" {
+			r := []rune(a.overviewRenameBuf)
+			a.overviewRenameBuf = string(r[:len(r)-1])
+		}
+		return a, nil
+	}
+	if msg.Text != "" {
+		a.overviewRenameBuf += msg.Text
+	}
+	return a, nil
+}
+
+// overviewJumpToCursor focuses the session under the cursor and closes
+// the overview. focusTab is a no-op when the cursor is already the
+// active tab, so this also doubles as "Enter returns to where I was".
+func (a app) overviewJumpToCursor() (tea.Model, tea.Cmd) {
+	a.clampOverviewCursor()
+	if a.overviewCursor >= 0 && a.overviewCursor < len(a.tabs) {
+		if na, ok := a.focusTab(a.overviewCursor); ok {
+			a = na
+		}
+	}
+	return a.closeOverviewState(), nil
+}
+
+// overviewConfirmCloseSelected tears down the session under the cursor
+// via the shared app.closeTab path (which returns tea.Quit when it was
+// the last tab). The overview stays open on a non-last close so the user
+// can keep triaging; the cursor re-clamps onto the shrunken list.
+func (a app) overviewConfirmCloseSelected() (tea.Model, tea.Cmd) {
+	a.overviewConfirmClose = false
+	a.clampOverviewCursor()
+	if a.overviewCursor < 0 || a.overviewCursor >= len(a.tabs) {
+		return a, nil
+	}
+	tabID := a.tabs[a.overviewCursor].id
+	res, cmd := a.closeTab(tabID)
+	na, ok := res.(app)
+	if !ok {
+		return res, cmd // last tab → quitting
+	}
+	na.clampOverviewCursor()
+	return na, cmd
+}
+
+// overviewNewTab opens a fresh session and lands the user on it (closing
+// the overview), matching the "I'm done triaging, start working" intent.
+func (a app) overviewNewTab() (tea.Model, tea.Cmd) {
+	res, cmd := a.openTab()
+	na, ok := res.(app)
+	if !ok {
+		return res, cmd
+	}
+	return na.closeOverviewState(), cmd
+}
+
+// overviewTopPad is the blank-row top margin above the header. It
+// matches the chat viewport's PaddingTop(1) so the overview lines up
+// with the other full-screen views instead of sitting flush against the
+// terminal's top edge. The left margin is the shared issueScreenIndent
+// (5), applied to the whole composed body by indentLines below — the
+// same uniform-indent approach the issues / PRs screens use.
+const overviewTopPad = 1
+
+func (a app) renderOverview() string {
+	var b strings.Builder
+	// Compose flush-left and width-bound to the post-indent content
+	// width; indentLines then applies the shared left margin to every
+	// line (header, rows, footer), exactly like the issues screen.
+	contentW := max(20, a.width-issueScreenIndent-1)
+	n := len(a.tabs)
+	b.WriteString(promptStyle.Render("Agent overview") +
+		dimStyle.Render(" · "+sessionCountLabel(n)))
+	b.WriteString("\n\n")
+	if n == 0 {
+		b.WriteString(dimStyle.Render("no open sessions"))
+		b.WriteString("\n")
+	}
+	for i, t := range a.tabs {
+		row := overviewRowFor(t, i == a.active)
+		b.WriteString(renderOverviewRow(row, i == a.overviewCursor, contentW))
+		b.WriteString("\n\n")
+	}
+	b.WriteString("\n")
+	b.WriteString(overviewFooter(a))
+	return strings.Repeat("\n", overviewTopPad) + indentLines(b.String(), issueScreenIndent)
+}
+
+// renderOverviewRow draws one two-line session row: a status badge +
+// title, then a dim subline of project · provider/model · live-status or
+// idle-age. Glyphs stay inside the codebase's allowed set (✓ ✗ ▸ ›) plus
+// plain ASCII — no new emoji.
+func renderOverviewRow(row overviewRow, selected bool, width int) string {
+	badgeText, badgeStyle := agentStatusBadge(row.status)
+
+	marker := "  "
+	titleStyle := lipgloss.NewStyle()
+	if selected {
+		marker = selectedStyle.Render("›") + " "
+		titleStyle = selectedStyle
+	}
+
+	tag := ""
+	if row.active {
+		tag = dimStyle.Render(" (current)")
+	}
+
+	const badgeCell = 11
+	avail := width - lipgloss.Width(marker) - badgeCell - 1 - lipgloss.Width(tag)
+	if avail < 8 {
+		avail = 8
+	}
+	title := xansi.Truncate(row.title, avail, "…")
+
+	line1 := marker + badgeStyle.Render(padRight(badgeText, badgeCell)) + " " +
+		titleStyle.Render(title) + tag
+
+	sep := dimStyle.Render(" · ")
+	var segs []string
+	if row.project != "" {
+		segs = append(segs, dimStyle.Render(row.project))
+	}
+	if row.providerModel != "" {
+		segs = append(segs, dimStyle.Render(row.providerModel))
+	}
+	switch {
+	case row.busy:
+		st := row.statusText
+		if st == "" {
+			st = "working…"
+		}
+		if row.stepInfo != "" {
+			st = row.stepInfo + " · " + st
+		}
+		st = xansi.Truncate(st, 72, "…")
+		live := dimStyle.Render(st)
+		if f := strings.TrimRight(row.spinnerFrame, " \n"); f != "" {
+			live = f + " " + live
+		}
+		segs = append(segs, live)
+	case row.stepInfo != "":
+		segs = append(segs, dimStyle.Render(row.stepInfo))
+	default:
+		segs = append(segs, dimStyle.Render("idle "+humanDuration(row.idle)))
+	}
+	// Subline nests two cells in (under the badge column) so it reads as
+	// detail of the row above it.
+	line2 := "  " + strings.Join(segs, sep)
+
+	return line1 + "\n" + line2
+}
+
+// agentStatusBadge maps a status to its padded label text and style. The
+// caller pads to a fixed cell so titles line up regardless of badge.
+func agentStatusBadge(s agentStatus) (string, lipgloss.Style) {
+	switch s {
+	case statusFailed:
+		return "✗ failed", errStyle
+	case statusDone:
+		return "✓ done", promptStyle
+	case statusNeedsYou:
+		return "! needs you", overviewWarnStyle()
+	case statusWorking:
+		return "▸ working", promptStyle
+	default:
+		return "idle", dimStyle
+	}
+}
+
+// overviewWarnStyle is the attention color used by the "needs you"
+// badge, reusing the theme's warn role (same color approvalTitleStyle
+// uses for the approval modal heading).
+func overviewWarnStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(activeTheme.warn)
+}
+
+func overviewFooter(a app) string {
+	if a.overviewRenaming {
+		return dimStyle.Render("name: ") + a.overviewRenameBuf + selectedStyle.Render("▏") +
+			"  " + dimStyle.Render(joinHintClauses("enter save", "esc cancel"))
+	}
+	if a.overviewConfirmClose {
+		return overviewWarnStyle().Render("close this session?") + " " +
+			dimStyle.Render(joinHintClauses("y close", "n cancel"))
+	}
+	return dimStyle.Render(joinHintClauses(
+		"enter jump", "d close", "n new", "r rename", "↑↓ move", "esc back",
+	))
+}
+
+func sessionCountLabel(n int) string {
+	if n == 1 {
+		return "1 session"
+	}
+	return fmt.Sprintf("%d sessions", n)
+}

--- a/overview.go
+++ b/overview.go
@@ -133,7 +133,14 @@ func overviewRowFor(t *model, active bool) overviewRow {
 	}
 	if t.workflowRun != nil {
 		if n := len(t.workflowRun.Workflow.Steps); n > 0 {
-			row.stepInfo = fmt.Sprintf("step %d/%d", t.workflowRun.StepIdx+1, n)
+			idx := t.workflowRun.StepIdx
+			if idx < 0 {
+				idx = 0
+			}
+			if idx >= n {
+				idx = n - 1
+			}
+			row.stepInfo = fmt.Sprintf("step %d/%d", idx+1, n)
 		}
 	}
 	return row
@@ -183,17 +190,17 @@ func overviewTickCmd() tea.Cmd {
 	})
 }
 
-// overviewHandleKey owns the keyboard while the overview is open. Sub-
-// modes (rename, confirm-close) are checked first so their keys can't
-// leak into list navigation. Ctrl+G toggles the overview shut and Ctrl+C
-// also just closes it — the app quit lives on the normal screen, not
-// here.
+// overviewHandleKey owns the keyboard while the overview is open. Close
+// accelerators are checked first so the remapped overview binding still
+// toggles shut inside sub-modes. Ctrl+C also just closes it — the app
+// quit lives on the normal screen, not here.
 func (a app) overviewHandleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if currentKeyMap().Matches(ActionAgentOverview, msg) ||
+		(msg.Mod == tea.ModCtrl && (msg.Code == 'g' || msg.Code == 'c')) {
+		return a.closeOverviewState(), nil
+	}
 	if a.overviewRenaming {
 		return a.overviewRenameKey(msg)
-	}
-	if msg.Mod == tea.ModCtrl && (msg.Code == 'g' || msg.Code == 'c') {
-		return a.closeOverviewState(), nil
 	}
 	// A pending close confirm is modal: only y / n / enter / esc matter.
 	if a.overviewConfirmClose {

--- a/overview_test.go
+++ b/overview_test.go
@@ -1,0 +1,403 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func ovPress(code rune) tea.KeyPressMsg { return tea.KeyPressMsg{Code: code} }
+func ovCtrl(code rune) tea.KeyPressMsg  { return tea.KeyPressMsg{Code: code, Mod: tea.ModCtrl} }
+func ovType(s string) tea.KeyPressMsg   { return tea.KeyPressMsg{Code: []rune(s)[0], Text: s} }
+
+// ovApply feeds msg to the app and returns the new app value, failing if
+// Update ever hands back something other than an app.
+func ovApply(t *testing.T, a app, msg tea.Msg) app {
+	t.Helper()
+	res, _ := a.Update(msg)
+	na, ok := res.(app)
+	if !ok {
+		t.Fatalf("Update returned %T, want app", res)
+	}
+	return na
+}
+
+func overviewAppWithThreeTabs(t *testing.T) app {
+	t.Helper()
+	var tabs []*model
+	for i := 1; i <= 3; i++ {
+		m := newTestModel(t, newFakeProvider())
+		m.id = i
+		tabs = append(tabs, &m)
+	}
+	return app{tabs: tabs, active: 0, nextID: 4, width: 100, height: 30}
+}
+
+// overviewRestoreCwd pins the process cwd back after a test that triggers
+// focusTab/closeTab/openTab (all of which os.Chdir into a tab's cwd).
+func overviewRestoreCwd(t *testing.T) {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+}
+
+func TestOverview_ToggleOpenClose(t *testing.T) {
+	a := testAppWithTwoTabs(t) // active = 1
+
+	res, cmd := a.Update(ovCtrl('g'))
+	a = res.(app)
+	if !a.overviewOpen {
+		t.Fatal("Ctrl+G should open the overview")
+	}
+	if cmd == nil {
+		t.Error("opening the overview should arm the refresh tick")
+	}
+	if a.overviewCursor != a.active {
+		t.Errorf("cursor=%d want active=%d on open", a.overviewCursor, a.active)
+	}
+
+	a = ovApply(t, a, ovCtrl('g'))
+	if a.overviewOpen {
+		t.Error("Ctrl+G again should toggle the overview closed")
+	}
+
+	a = ovApply(t, a, ovCtrl('g'))
+	a = ovApply(t, a, ovPress(tea.KeyEsc))
+	if a.overviewOpen {
+		t.Error("Esc should close the overview")
+	}
+}
+
+func TestOverview_TickReArmsOnlyWhileOpen(t *testing.T) {
+	a := testAppWithTwoTabs(t)
+
+	a.overviewOpen = true
+	if _, cmd := a.Update(overviewTickMsg{}); cmd == nil {
+		t.Error("overviewTickMsg should re-arm while the overview is open")
+	}
+	a.overviewOpen = false
+	if _, cmd := a.Update(overviewTickMsg{}); cmd != nil {
+		t.Error("overviewTickMsg should not re-arm once the overview is closed")
+	}
+}
+
+func TestOverview_ViewFillsHeightAndShowsHeader(t *testing.T) {
+	a := testAppWithTwoTabs(t)
+	a.overviewOpen = true
+
+	v := a.View()
+	if !v.AltScreen {
+		t.Error("overview View must run in altscreen so it doesn't leak into host scrollback")
+	}
+	if got := renderedLineCount(v.Content); got != a.height {
+		t.Errorf("overview View line count=%d want app height=%d", got, a.height)
+	}
+	if !strings.Contains(v.Content, "Agent overview") {
+		t.Errorf("overview View should contain the header; content=%q", v.Content)
+	}
+}
+
+func TestOverview_CursorNavWraps(t *testing.T) {
+	a := overviewAppWithThreeTabs(t) // 3 tabs, active = 0
+	a.overviewOpen = true
+	a.overviewCursor = 0
+
+	// Up / Ctrl+P at the top wraps to the last row.
+	a = ovApply(t, a, ovPress(tea.KeyUp))
+	if a.overviewCursor != 2 {
+		t.Errorf("up at top should wrap to last: cursor=%d want 2", a.overviewCursor)
+	}
+	// Down / Ctrl+N at the bottom wraps back to the first row.
+	a = ovApply(t, a, ovPress(tea.KeyDown))
+	if a.overviewCursor != 0 {
+		t.Errorf("down at bottom should wrap to first: cursor=%d want 0", a.overviewCursor)
+	}
+	// Ctrl+N / Ctrl+P step normally through the middle.
+	a = ovApply(t, a, ovCtrl('n')) // 1
+	a = ovApply(t, a, ovCtrl('n')) // 2
+	if a.overviewCursor != 2 {
+		t.Errorf("ctrl+n twice: cursor=%d want 2", a.overviewCursor)
+	}
+	a = ovApply(t, a, ovCtrl('p')) // 1
+	if a.overviewCursor != 1 {
+		t.Errorf("ctrl+p: cursor=%d want 1", a.overviewCursor)
+	}
+	// Home/End jump to the ends.
+	a = ovApply(t, a, ovPress(tea.KeyHome))
+	if a.overviewCursor != 0 {
+		t.Errorf("home: cursor=%d want 0", a.overviewCursor)
+	}
+	a = ovApply(t, a, ovPress(tea.KeyEnd))
+	if a.overviewCursor != 2 {
+		t.Errorf("end: cursor=%d want 2", a.overviewCursor)
+	}
+	// Plain 'j' must NOT navigate — the vim keys were removed in favour
+	// of the arrows + Ctrl+P/N convention.
+	a = ovApply(t, a, ovPress(tea.KeyHome))
+	before := a.overviewCursor
+	a = ovApply(t, a, ovPress('j'))
+	if a.overviewCursor != before {
+		t.Errorf("'j' should be inert (no vim nav): cursor moved %d→%d", before, a.overviewCursor)
+	}
+}
+
+func TestOverview_EnterJumpsToSessionAndCloses(t *testing.T) {
+	overviewRestoreCwd(t)
+	a := testAppWithTwoTabs(t) // active = 1
+	a.overviewOpen = true
+	a.overviewCursor = 0
+
+	a = ovApply(t, a, ovPress(tea.KeyEnter))
+	if a.overviewOpen {
+		t.Error("Enter should close the overview after jumping")
+	}
+	if a.active != 0 {
+		t.Errorf("active=%d want 0 after jumping to the cursor row", a.active)
+	}
+}
+
+func TestAgentStatusOf(t *testing.T) {
+	cases := []struct {
+		name string
+		m    *model
+		want agentStatus
+	}{
+		{"nil", nil, statusIdle},
+		{"fresh", &model{}, statusIdle},
+		{"busy", &model{busy: true}, statusWorking},
+		{"ask-question", &model{mode: modeAskQuestion}, statusNeedsYou},
+		{"approval", &model{mode: modeApproval}, statusNeedsYou},
+		{"wf-done", &model{workflowRun: &workflowRunState{done: true}}, statusDone},
+		{"wf-failed", &model{workflowRun: &workflowRunState{failed: true}}, statusFailed},
+		{"wf-running", &model{busy: true, workflowRun: &workflowRunState{}}, statusWorking},
+		// Precedence: a finalised workflow and "needs you" both beat busy.
+		{"failed-beats-busy", &model{busy: true, workflowRun: &workflowRunState{failed: true}}, statusFailed},
+		{"done-beats-busy", &model{busy: true, workflowRun: &workflowRunState{done: true}}, statusDone},
+		{"needsyou-beats-busy", &model{busy: true, mode: modeAskQuestion}, statusNeedsYou},
+	}
+	for _, c := range cases {
+		if got := agentStatusOf(c.m); got != c.want {
+			t.Errorf("%s: agentStatusOf=%d want %d", c.name, got, c.want)
+		}
+	}
+}
+
+func TestOverviewTitle(t *testing.T) {
+	first := &model{history: []historyEntry{
+		{kind: histPrerendered, text: "tool output"},
+		{kind: histUser, text: "fix the auth bug\nplease"},
+		{kind: histUser, text: "second message"},
+	}}
+	if got := overviewTitle(first); got != "fix the auth bug please" {
+		t.Errorf("first-user title=%q want collapsed first user message", got)
+	}
+
+	if got := overviewTitle(&model{}); got != "new session" {
+		t.Errorf("empty title=%q want %q", got, "new session")
+	}
+
+	labelled := &model{
+		overviewLabel: "My Task",
+		history:       []historyEntry{{kind: histUser, text: "ignored"}},
+	}
+	if got := overviewTitle(labelled); got != "My Task" {
+		t.Errorf("labelled title=%q want overviewLabel to win", got)
+	}
+
+	wf := &model{workflowRun: &workflowRunState{Workflow: workflowDef{Name: "review"}}}
+	if got := overviewTitle(wf); !strings.Contains(got, "review") {
+		t.Errorf("workflow title=%q want it to name the pipeline", got)
+	}
+}
+
+func TestOverviewRowFor_DerivedFields(t *testing.T) {
+	m := newTestModel(t, newFakeProvider()) // DisplayName "Fake"
+	m.providerModel = "m-one"
+	m.busy = true
+	m.status = "Thinking…"
+	m.history = []historyEntry{{kind: histUser, text: "do the thing"}}
+
+	row := overviewRowFor(&m, true)
+	if row.status != statusWorking {
+		t.Errorf("status=%d want statusWorking", row.status)
+	}
+	if !row.active {
+		t.Error("row.active should reflect the passed-in flag")
+	}
+	if row.title != "do the thing" {
+		t.Errorf("title=%q want first user message", row.title)
+	}
+	if row.providerModel != "Fake/m-one" {
+		t.Errorf("providerModel=%q want %q", row.providerModel, "Fake/m-one")
+	}
+	if row.statusText != "Thinking…" {
+		t.Errorf("statusText=%q want the live status", row.statusText)
+	}
+
+	wf := newTestModel(t, newFakeProvider())
+	wf.workflowRun = &workflowRunState{
+		Workflow: workflowDef{Name: "rev", Steps: []workflowStep{{}, {}, {}}},
+		StepIdx:  1,
+	}
+	if got := overviewRowFor(&wf, false).stepInfo; got != "step 2/3" {
+		t.Errorf("stepInfo=%q want %q", got, "step 2/3")
+	}
+}
+
+func TestOverview_ConfirmCloseRemovesSession(t *testing.T) {
+	overviewRestoreCwd(t)
+	a := overviewAppWithThreeTabs(t) // ids 1,2,3
+	a.overviewOpen = true
+	a.overviewCursor = 1 // session id 2
+
+	// d arms the confirm; a stray 'n' cancels without closing.
+	a = ovApply(t, a, ovPress('d'))
+	if !a.overviewConfirmClose {
+		t.Fatal("d should arm the close confirm")
+	}
+	cancelled := ovApply(t, a, ovPress('n'))
+	if cancelled.overviewConfirmClose {
+		t.Error("n should cancel the close confirm")
+	}
+	if len(cancelled.tabs) != 3 {
+		t.Errorf("n cancel: tabs=%d want 3 (no close)", len(cancelled.tabs))
+	}
+
+	// Re-arm and confirm with y.
+	a = ovApply(t, a, ovPress('d'))
+	a = ovApply(t, a, ovPress('y'))
+	if !a.overviewOpen {
+		t.Error("closing a non-last session should leave the overview open")
+	}
+	if len(a.tabs) != 2 {
+		t.Fatalf("after close: tabs=%d want 2", len(a.tabs))
+	}
+	for _, tb := range a.tabs {
+		if tb.id == 2 {
+			t.Errorf("session id 2 should have been closed; tabs=%v", a.tabs)
+		}
+	}
+	if a.overviewCursor < 0 || a.overviewCursor >= len(a.tabs) {
+		t.Errorf("cursor=%d out of range after close", a.overviewCursor)
+	}
+}
+
+func TestOverview_ConfirmCloseLastSessionQuits(t *testing.T) {
+	overviewRestoreCwd(t)
+	tab := newTabModelStub(t, 1, "vs-active")
+	a := app{tabs: []*model{tab}, active: 0, nextID: 2, width: 100, height: 30}
+	a.overviewOpen = true
+	a.overviewCursor = 0
+
+	a = ovApply(t, a, ovPress('d'))
+	res, cmd := a.Update(ovPress('y'))
+	if cmd == nil {
+		t.Fatal("closing the last session must return a quit cmd")
+	}
+	if msg := cmd(); msg != (tea.QuitMsg{}) {
+		t.Errorf("cmd yielded %T, want tea.QuitMsg{}", msg)
+	}
+	if na, ok := res.(app); !ok || !na.quitting {
+		t.Error("closing the last session should arm the quitting flag")
+	}
+}
+
+func TestOverview_NewTabOpensSessionAndCloses(t *testing.T) {
+	overviewRestoreCwd(t)
+	isolateHome(t)
+	withRegisteredProviders(t, newFakeProvider())
+	if err := saveConfig(askConfig{Provider: "fake"}); err != nil {
+		t.Fatalf("saveConfig: %v", err)
+	}
+	a := testAppWithTwoTabs(t)
+	a.overviewOpen = true
+	a.overviewCursor = 0
+
+	res, _ := a.Update(ovPress('n'))
+	na := res.(app)
+	// Stop any bridge the new tab bound so its loopback listener fd
+	// doesn't leak past the test.
+	for i := range na.tabs {
+		if b := na.tabs[i].mcpBridge; b != nil {
+			t.Cleanup(b.stop)
+		}
+	}
+
+	if na.overviewOpen {
+		t.Error("'n' should close the overview and land on the new session")
+	}
+	if len(na.tabs) != 3 {
+		t.Fatalf("tabs=%d want 3 after 'n'", len(na.tabs))
+	}
+	if na.active != 2 {
+		t.Errorf("active=%d want the new tab index 2", na.active)
+	}
+}
+
+func TestOverview_RenameSetsLabel(t *testing.T) {
+	a := overviewAppWithThreeTabs(t)
+	a.overviewOpen = true
+	a.overviewCursor = 1
+
+	a = ovApply(t, a, ovPress('r'))
+	if !a.overviewRenaming {
+		t.Fatal("r should enter the rename editor")
+	}
+	for _, s := range []string{"a", "u", "t", "h"} {
+		a = ovApply(t, a, ovType(s))
+	}
+	a = ovApply(t, a, ovPress(tea.KeyBackspace))
+	a = ovApply(t, a, ovPress(tea.KeyEnter))
+
+	if a.overviewRenaming {
+		t.Error("Enter should leave the rename editor")
+	}
+	if got := a.tabs[1].overviewLabel; got != "aut" {
+		t.Errorf("overviewLabel=%q want %q after type+backspace+commit", got, "aut")
+	}
+	if got := overviewTitle(a.tabs[1]); got != "aut" {
+		t.Errorf("overviewTitle=%q want the renamed label to win", got)
+	}
+}
+
+func TestOverview_RenameEscCancels(t *testing.T) {
+	a := overviewAppWithThreeTabs(t)
+	a.tabs[0].overviewLabel = "original"
+	a.overviewOpen = true
+	a.overviewCursor = 0
+
+	a = ovApply(t, a, ovPress('r'))
+	a = ovApply(t, a, ovType("x"))
+	a = ovApply(t, a, ovPress(tea.KeyEsc))
+
+	if a.overviewRenaming {
+		t.Error("Esc should leave the rename editor")
+	}
+	if got := a.tabs[0].overviewLabel; got != "original" {
+		t.Errorf("overviewLabel=%q want %q (Esc must not commit)", got, "original")
+	}
+}
+
+// The default binding is Ctrl+G and the action is surfaced in the
+// /config keybindings list. (TestDefaultKeyMap_CoversAllActions already
+// guarantees coverage; this pins the intended key + label.)
+func TestOverview_DefaultKeybinding(t *testing.T) {
+	want := KeyBinding{Mod: tea.ModCtrl, Code: 'g'}
+	if got := DefaultKeyMap().Binding(ActionAgentOverview); got != want {
+		t.Errorf("ActionAgentOverview default=%+v want %+v", got, want)
+	}
+	found := false
+	for _, am := range actionMeta {
+		if am.Action == ActionAgentOverview {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("ActionAgentOverview should appear in actionMeta (the /config keybindings list)")
+	}
+}

--- a/overview_test.go
+++ b/overview_test.go
@@ -10,6 +10,7 @@ import (
 
 func ovPress(code rune) tea.KeyPressMsg { return tea.KeyPressMsg{Code: code} }
 func ovCtrl(code rune) tea.KeyPressMsg  { return tea.KeyPressMsg{Code: code, Mod: tea.ModCtrl} }
+func ovAlt(code rune) tea.KeyPressMsg   { return tea.KeyPressMsg{Code: code, Mod: tea.ModAlt} }
 func ovType(s string) tea.KeyPressMsg   { return tea.KeyPressMsg{Code: []rune(s)[0], Text: s} }
 
 // ovApply feeds msg to the app and returns the new app value, failing if
@@ -46,7 +47,14 @@ func overviewRestoreCwd(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chdir(wd) })
 }
 
+func overviewUseDefaultKeyMap(t *testing.T) {
+	t.Helper()
+	setKeyMapForTesting(DefaultKeyMap())
+	t.Cleanup(invalidateKeyMapCache)
+}
+
 func TestOverview_ToggleOpenClose(t *testing.T) {
+	overviewUseDefaultKeyMap(t)
 	a := testAppWithTwoTabs(t) // active = 1
 
 	res, cmd := a.Update(ovCtrl('g'))
@@ -70,6 +78,38 @@ func TestOverview_ToggleOpenClose(t *testing.T) {
 	a = ovApply(t, a, ovPress(tea.KeyEsc))
 	if a.overviewOpen {
 		t.Error("Esc should close the overview")
+	}
+}
+
+func TestOverview_ReboundToggleCloses(t *testing.T) {
+	setKeyMapForTesting(KeyMap{
+		ActionAgentOverview: {Mod: tea.ModAlt, Code: 'g'},
+	})
+	defer invalidateKeyMapCache()
+
+	a := testAppWithTwoTabs(t)
+	res, _ := a.Update(ovAlt('g'))
+	a = res.(app)
+	if !a.overviewOpen {
+		t.Fatal("rebound overview key should open the overview")
+	}
+
+	a = ovApply(t, a, ovAlt('g'))
+	if a.overviewOpen {
+		t.Error("rebound overview key should toggle the overview closed")
+	}
+}
+
+func TestOverview_CloseShortcutWinsDuringRename(t *testing.T) {
+	overviewUseDefaultKeyMap(t)
+	a := testAppWithTwoTabs(t)
+	a.overviewOpen = true
+	a.overviewRenaming = true
+	a.overviewRenameBuf = "draft"
+
+	a = ovApply(t, a, ovCtrl('g'))
+	if a.overviewOpen {
+		t.Error("Ctrl+G should close the overview even while renaming")
 	}
 }
 
@@ -103,6 +143,7 @@ func TestOverview_ViewFillsHeightAndShowsHeader(t *testing.T) {
 }
 
 func TestOverview_CursorNavWraps(t *testing.T) {
+	overviewUseDefaultKeyMap(t)
 	a := overviewAppWithThreeTabs(t) // 3 tabs, active = 0
 	a.overviewOpen = true
 	a.overviewCursor = 0
@@ -147,6 +188,7 @@ func TestOverview_CursorNavWraps(t *testing.T) {
 }
 
 func TestOverview_EnterJumpsToSessionAndCloses(t *testing.T) {
+	overviewUseDefaultKeyMap(t)
 	overviewRestoreCwd(t)
 	a := testAppWithTwoTabs(t) // active = 1
 	a.overviewOpen = true
@@ -247,9 +289,16 @@ func TestOverviewRowFor_DerivedFields(t *testing.T) {
 	if got := overviewRowFor(&wf, false).stepInfo; got != "step 2/3" {
 		t.Errorf("stepInfo=%q want %q", got, "step 2/3")
 	}
+
+	wf.workflowRun.StepIdx = len(wf.workflowRun.Workflow.Steps)
+	wf.workflowRun.done = true
+	if got := overviewRowFor(&wf, false).stepInfo; got != "step 3/3" {
+		t.Errorf("completed stepInfo=%q want capped final step %q", got, "step 3/3")
+	}
 }
 
 func TestOverview_ConfirmCloseRemovesSession(t *testing.T) {
+	overviewUseDefaultKeyMap(t)
 	overviewRestoreCwd(t)
 	a := overviewAppWithThreeTabs(t) // ids 1,2,3
 	a.overviewOpen = true
@@ -288,6 +337,7 @@ func TestOverview_ConfirmCloseRemovesSession(t *testing.T) {
 }
 
 func TestOverview_ConfirmCloseLastSessionQuits(t *testing.T) {
+	overviewUseDefaultKeyMap(t)
 	overviewRestoreCwd(t)
 	tab := newTabModelStub(t, 1, "vs-active")
 	a := app{tabs: []*model{tab}, active: 0, nextID: 2, width: 100, height: 30}
@@ -308,6 +358,7 @@ func TestOverview_ConfirmCloseLastSessionQuits(t *testing.T) {
 }
 
 func TestOverview_NewTabOpensSessionAndCloses(t *testing.T) {
+	overviewUseDefaultKeyMap(t)
 	overviewRestoreCwd(t)
 	isolateHome(t)
 	withRegisteredProviders(t, newFakeProvider())
@@ -340,6 +391,7 @@ func TestOverview_NewTabOpensSessionAndCloses(t *testing.T) {
 }
 
 func TestOverview_RenameSetsLabel(t *testing.T) {
+	overviewUseDefaultKeyMap(t)
 	a := overviewAppWithThreeTabs(t)
 	a.overviewOpen = true
 	a.overviewCursor = 1
@@ -366,6 +418,7 @@ func TestOverview_RenameSetsLabel(t *testing.T) {
 }
 
 func TestOverview_RenameEscCancels(t *testing.T) {
+	overviewUseDefaultKeyMap(t)
 	a := overviewAppWithThreeTabs(t)
 	a.tabs[0].overviewLabel = "original"
 	a.overviewOpen = true

--- a/tabs.go
+++ b/tabs.go
@@ -34,6 +34,18 @@ type app struct {
 	// users who never started a session don't see a stray banner.
 	quitting    bool
 	quittingVID string
+
+	// overviewOpen drives the app-level agent overview (the cross-tab
+	// "inbox"). While true, overviewHandleKey owns the keyboard and
+	// View renders renderOverview instead of the active tab. The other
+	// fields are its sub-modes: a y/n confirm before closing a session,
+	// and an inline rename editor whose buffer is overviewRenameBuf.
+	// overviewCursor indexes into tabs. See overview.go.
+	overviewOpen         bool
+	overviewCursor       int
+	overviewConfirmClose bool
+	overviewRenaming     bool
+	overviewRenameBuf    string
 }
 
 // newApp wraps the first tab in the app struct. Config is deliberately
@@ -102,6 +114,14 @@ func (a app) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.suspending = false
 		return a, nil
 
+	case overviewTickMsg:
+		// Keep re-arming only while the overview is open; a tick that
+		// lands after it closed is a silent no-op.
+		if a.overviewOpen {
+			return a, overviewTickCmd()
+		}
+		return a, nil
+
 	case tea.WindowSizeMsg:
 		a.width = m.Width
 		a.height = m.Height
@@ -109,8 +129,15 @@ func (a app) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyPressMsg:
 		m = normalizeKeyPressMsg(m)
+		// While the agent overview is up it owns the whole keyboard, so
+		// route every keystroke there before any tab/app action can fire.
+		if a.overviewOpen {
+			return a.overviewHandleKey(m)
+		}
 		km := currentKeyMap()
 		switch {
+		case km.Matches(ActionAgentOverview, m):
+			return a.openOverview()
 		case km.Matches(ActionAppSuspend, m):
 			return a.suspendApp()
 		case km.Matches(ActionTabNew, m):
@@ -124,6 +151,11 @@ func (a app) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.MouseClickMsg, tea.MouseMotionMsg, tea.MouseReleaseMsg,
 		tea.MouseWheelMsg, tea.PasteMsg, imagePastedMsg:
+		// The overview is keyboard-only; swallow pointer/paste events so
+		// they don't reach (and mutate) the tab hidden behind it.
+		if a.overviewOpen {
+			return a, nil
+		}
 		return a.dispatchActive(msg)
 
 	case spawnWorkflowTabMsg:
@@ -183,6 +215,19 @@ func (a app) View() tea.View {
 		// before QuitMsg fires, so cursed_renderer.close exits altscreen
 		// and the inline content lands in the host terminal scrollback.
 		return tea.View{Content: "last session: " + a.quittingVID + "\n"}
+	}
+	if a.overviewOpen {
+		// Match the normal view's terminal setup (altscreen + theme
+		// colors + mouse mode) so the overview paints over a clean ask
+		// canvas instead of leaking into the host terminal scrollback.
+		// No cursor — the rename editor draws its own inline caret.
+		return tea.View{
+			Content:         bodyContentAtHeight(a.renderOverview(), a.height),
+			AltScreen:       true,
+			MouseMode:       tea.MouseModeCellMotion,
+			BackgroundColor: themeBackground,
+			ForegroundColor: themeForeground,
+		}
 	}
 	v := a.activeTab().View()
 	if len(a.tabs) <= 1 {

--- a/types.go
+++ b/types.go
@@ -278,6 +278,13 @@ type focusTabMsg struct {
 	tabID int
 }
 
+// overviewTickMsg re-renders the agent overview on a slow cadence
+// while it's open so elapsed/idle ages and the "needs you" flag stay
+// fresh even when no tab is streaming (busy tabs already drive renders
+// via spinner ticks). A tick that lands after the overview closed is a
+// silent no-op — the handler stops re-arming once overviewOpen is false.
+type overviewTickMsg struct{}
+
 // spawnWorkflowTabMsg asks the app layer to open a new tab dedicated
 // to running `Workflow` against `Source`, rooted at `Cwd`. Issued by
 // the issues screen when the user hits `f` (Source carries an
@@ -579,6 +586,19 @@ type model struct {
 	historyDraft string
 
 	exitArmed bool
+
+	// lastActivity is bumped whenever the session does something
+	// observable (a turn starts streaming, a turn ends). The agent
+	// overview renders humanDuration(time.Since(lastActivity)) as the
+	// idle age of an otherwise-quiet session. Stamped in newTab so a
+	// brand-new tab reads "now" rather than the zero time.
+	lastActivity time.Time
+
+	// overviewLabel is the user-set name shown in the agent overview
+	// (set with `r` there). Empty means the overview derives a title
+	// from the workflow / first user message instead. Lives for the
+	// tab's lifetime only — tabs aren't persisted across restarts.
+	overviewLabel string
 
 	todos []todoItem
 

--- a/update.go
+++ b/update.go
@@ -305,6 +305,7 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 		wasIdle := !m.busy
 		m.busy = true
 		m.status = msg.status
+		m.lastActivity = time.Now()
 		var cmds []tea.Cmd
 		if m.streamCh != nil {
 			cmds = append(cmds, nextStreamCmd(m.streamCh))
@@ -570,6 +571,10 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 		if msg.proc != m.proc {
 			return m, nil
 		}
+		// providerDoneMsg fires at the end of every turn (clean or
+		// errored), so it's the universal "this session just did
+		// something" signal for the overview's idle clock.
+		m.lastActivity = time.Now()
 		debugLog("providerDoneMsg err=%v isError=%v resultLen=%d",
 			msg.err, msg.res.IsError, len(msg.res.Result))
 		m.dismissCancelTurnConfirmIfIdle()


### PR DESCRIPTION
## What

Adds an app-level **agent overview** — a full-screen, vertical "inbox" of every open tab (each one a running agent session), reached with **Ctrl+G** (remappable via `/config → Keybindings`). Once you have more than a couple of sessions, the one-row tab bar is a poor way to answer "which agent is which, what's it doing, and which one needs me." This is the better view.

## Per-session row

Two lines per session:

- **Status badge** (precedence): `✗ failed` › `✓ done` › `! needs you` (blocked on a question/approval) › `▸ working` (with the live spinner, stream status, and `step x/y` on workflow tabs) › `idle <age>`.
- **Title**: the first user message, the workflow name, or a custom rename — so you can tell what each session is about.
- Plus project (`shortCwdOf`), provider/model, and idle age.

## Keys

`Enter` jump to a session · `d` close (with confirm; quits on the last tab) · `n` new session · `r` rename · `↑/↓` + `Ctrl+P/Ctrl+N` navigate (wrapping) · `Home`/`End` jump to ends · `Esc`/`Ctrl+G` close.

## Design

- Lives at the **app layer** (`app.Update`/`app.View`), not as a per-tab `screen`: a screen only sees its own model, but the overview has to enumerate siblings, which only the app owns — the same place the tab bar already lives.
- While open it owns the keyboard (`overviewHandleKey`); every other message keeps flowing to the tabs underneath, so the list reflects live state on each frame. Busy tabs animate via the existing spinner broadcast, plus a 1s refresh tick keeps idle ages fresh.
- Navigation/wrapping reuse the shared `listNavPrev`/`listNavNext`/`listNavWrap` helpers (same as every other picker); spacing matches the issues screen (`issueScreenIndent` via `indentLines`) and the chat viewport's `PaddingTop(1)`.
- No new dependencies; glyphs stay within the existing set (`✓ ✗ ▸ ›`).

## Tests

New `overview_test.go`, behavioral only (asserts on model/app state and emitted messages — no rendering snapshots): open/close toggle, cursor nav + wrap, enter-jumps, status classification + precedence, title derivation, close (incl. last-tab → quit), new-tab, rename, rebound-key toggle, and keymap coverage. `go build` / `go vet` / `gofmt` clean.

## Files

`overview.go` (+ `overview_test.go`); `tabs.go` (app overview state + Update key interception + View branch); `types.go` (`lastActivity`, `overviewLabel`, `overviewTickMsg`); `keymap.go` (`ActionAgentOverview`, Ctrl+G); `update.go`/`main.go` (activity timestamp at turn start/end + tab init).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
