### PR TITLE
feat: highlight busy tab glyph with the theme's tabActive color

### DIFF
--- a/tabs.go
+++ b/tabs.go
@@ -544,12 +544,6 @@ func tabBarLabel(t *model) string {
 	return label
 }
 
-// renderTabPill builds the styled tab segment. Inactive busy tabs
-// get a ▸ painted in the theme's tabActive color so the running
-// indicator pops from the muted label and stays theme-consistent.
-// Active busy tabs render the ▸ in the regular active style — the
-// pill's own background is already tabActive, and you don't need
-// to scan for the tab you're already focused on.
 func renderTabPill(t *model, active bool) string {
 	label := tabBarLabel(t)
 	if active {

--- a/tabs.go
+++ b/tabs.go
@@ -514,13 +514,7 @@ func (a app) renderTabBar() string {
 	parts := make([]string, 0, len(a.tabs))
 	usedWidth := 0
 	for i, t := range a.tabs {
-		label := tabBarLabel(t)
-		var styled string
-		if i == a.active {
-			styled = tabBarActiveStyle.Render(label)
-		} else {
-			styled = tabBarInactiveStyle.Render(label)
-		}
+		styled := renderTabPill(t, i == a.active)
 		if i > 0 {
 			usedWidth += 1 // single-space separator
 		}
@@ -547,9 +541,28 @@ func tabBarLabel(t *model) string {
 	if label == "" {
 		label = "?"
 	}
-	// Tag busy tabs so background work is discoverable at a glance.
-	if t.busy {
-		label = "▸ " + label
+	return label
+}
+
+// renderTabPill builds the styled tab segment. Inactive busy tabs
+// get a ▸ painted in the theme's tabActive color so the running
+// indicator pops from the muted label and stays theme-consistent.
+// Active busy tabs render the ▸ in the regular active style — the
+// pill's own background is already tabActive, and you don't need
+// to scan for the tab you're already focused on.
+func renderTabPill(t *model, active bool) string {
+	label := tabBarLabel(t)
+	if active {
+		body := " " + label + " "
+		if t.busy {
+			body = " ▸ " + label + " "
+		}
+		return tabBarActiveStyle.Render(body)
 	}
-	return " " + label + " "
+	if t.busy {
+		return tabBarInactiveStyle.Render(" ") +
+			tabBarBusyInactiveStyle.Render("▸") +
+			tabBarInactiveStyle.Render(" "+label+" ")
+	}
+	return tabBarInactiveStyle.Render(" " + label + " ")
 }

--- a/tabs_test.go
+++ b/tabs_test.go
@@ -228,6 +228,60 @@ func TestApp_ViewPinsTabBarToBottomDuringIssuesLoad(t *testing.T) {
 	}
 }
 
+// Inactive busy tabs must render the ▸ with the dedicated busy style
+// (theme's tabActive color, bold) so the running indicator pops from
+// the muted label and the user can scan the strip at a glance.
+func TestRenderTabBar_BusyGlyphUsesDedicatedStyleForInactiveTab(t *testing.T) {
+	a := testAppWithTwoTabs(t)
+	a.tabs[0].busy = true
+	a.active = 1
+	a.width = 80
+
+	bar := a.renderTabBar()
+
+	wantGlyph := tabBarBusyInactiveStyle.Render("▸")
+	if !strings.Contains(bar, wantGlyph) {
+		t.Errorf("inactive busy tab missing tabActive-styled glyph in bar:\n  bar=%q\n  want substring=%q", bar, wantGlyph)
+	}
+	// The non-busy active tab must not carry a ▸ — so exactly one ▸
+	// should appear in the bar.
+	if got := strings.Count(bar, "▸"); got != 1 {
+		t.Errorf("bar has %d ▸ glyphs, want 1 (busy inactive tab only):\n%q", got, bar)
+	}
+}
+
+// Active busy tabs still surface the ▸ but in the regular active
+// style — the pill background is already the highlight color, and
+// the user doesn't need to scan for the tab they're already on.
+func TestRenderTabBar_BusyGlyphOnActiveTabRendersInActiveStyle(t *testing.T) {
+	a := testAppWithTwoTabs(t)
+	a.tabs[1].busy = true // active tab is index 1
+	a.width = 80
+
+	bar := a.renderTabBar()
+
+	if !strings.Contains(bar, "▸") {
+		t.Errorf("active busy tab missing ▸ glyph in bar:\n%q", bar)
+	}
+	// The active busy glyph must NOT be styled with the inactive busy
+	// style (warn-on-nothing) — only inactive busy tabs use that.
+	unwanted := tabBarBusyInactiveStyle.Render("▸")
+	if strings.Contains(bar, unwanted) {
+		t.Errorf("active busy tab incorrectly uses inactive-busy style:\n  bar=%q\n  unwanted substring=%q", bar, unwanted)
+	}
+}
+
+// No tab is busy → no ▸ glyph in the bar at all.
+func TestRenderTabBar_IdleTabsHaveNoBusyGlyph(t *testing.T) {
+	a := testAppWithTwoTabs(t)
+	a.width = 80
+
+	bar := a.renderTabBar()
+	if strings.Contains(bar, "▸") {
+		t.Errorf("idle tab bar contains ▸:\n%q", bar)
+	}
+}
+
 func TestApp_VirtualSessionMaterializedStaysOnOwningTab(t *testing.T) {
 	a := testAppWithTwoTabs(t)
 	a.tabs[0].virtualSessionID = "vs-shared"

--- a/tabs_test.go
+++ b/tabs_test.go
@@ -228,9 +228,6 @@ func TestApp_ViewPinsTabBarToBottomDuringIssuesLoad(t *testing.T) {
 	}
 }
 
-// Inactive busy tabs must render the ▸ with the dedicated busy style
-// (theme's tabActive color, bold) so the running indicator pops from
-// the muted label and the user can scan the strip at a glance.
 func TestRenderTabBar_BusyGlyphUsesDedicatedStyleForInactiveTab(t *testing.T) {
 	a := testAppWithTwoTabs(t)
 	a.tabs[0].busy = true
@@ -239,39 +236,37 @@ func TestRenderTabBar_BusyGlyphUsesDedicatedStyleForInactiveTab(t *testing.T) {
 
 	bar := a.renderTabBar()
 
-	wantGlyph := tabBarBusyInactiveStyle.Render("▸")
-	if !strings.Contains(bar, wantGlyph) {
-		t.Errorf("inactive busy tab missing tabActive-styled glyph in bar:\n  bar=%q\n  want substring=%q", bar, wantGlyph)
+	wantPill := tabBarInactiveStyle.Render(" ") +
+		tabBarBusyInactiveStyle.Render("▸") +
+		tabBarInactiveStyle.Render(" "+tabBarLabel(a.tabs[0])+" ")
+	if !strings.Contains(bar, wantPill) {
+		t.Errorf("inactive busy tab missing split-styled pill:\n  bar=%q\n  want substring=%q", bar, wantPill)
 	}
-	// The non-busy active tab must not carry a ▸ — so exactly one ▸
-	// should appear in the bar.
 	if got := strings.Count(bar, "▸"); got != 1 {
 		t.Errorf("bar has %d ▸ glyphs, want 1 (busy inactive tab only):\n%q", got, bar)
 	}
 }
 
-// Active busy tabs still surface the ▸ but in the regular active
-// style — the pill background is already the highlight color, and
-// the user doesn't need to scan for the tab they're already on.
 func TestRenderTabBar_BusyGlyphOnActiveTabRendersInActiveStyle(t *testing.T) {
 	a := testAppWithTwoTabs(t)
-	a.tabs[1].busy = true // active tab is index 1
+	a.tabs[1].busy = true
 	a.width = 80
 
 	bar := a.renderTabBar()
 
-	if !strings.Contains(bar, "▸") {
-		t.Errorf("active busy tab missing ▸ glyph in bar:\n%q", bar)
+	wantPill := tabBarActiveStyle.Render(" ▸ " + tabBarLabel(a.tabs[1]) + " ")
+	if !strings.Contains(bar, wantPill) {
+		t.Errorf("active busy tab missing active-styled pill:\n  bar=%q\n  want substring=%q", bar, wantPill)
 	}
-	// The active busy glyph must NOT be styled with the inactive busy
-	// style (warn-on-nothing) — only inactive busy tabs use that.
+	if got := strings.Count(bar, "▸"); got != 1 {
+		t.Errorf("bar has %d ▸ glyphs, want 1 (busy active tab only):\n%q", got, bar)
+	}
 	unwanted := tabBarBusyInactiveStyle.Render("▸")
 	if strings.Contains(bar, unwanted) {
 		t.Errorf("active busy tab incorrectly uses inactive-busy style:\n  bar=%q\n  unwanted substring=%q", bar, unwanted)
 	}
 }
 
-// No tab is busy → no ▸ glyph in the bar at all.
 func TestRenderTabBar_IdleTabsHaveNoBusyGlyph(t *testing.T) {
 	a := testAppWithTwoTabs(t)
 	a.width = 80

--- a/themes.go
+++ b/themes.go
@@ -519,8 +519,9 @@ var (
 	themePickerHelpStyle  lipgloss.Style
 	themePickerRowStyle   lipgloss.Style
 
-	tabBarActiveStyle   lipgloss.Style
-	tabBarInactiveStyle lipgloss.Style
+	tabBarActiveStyle       lipgloss.Style
+	tabBarInactiveStyle     lipgloss.Style
+	tabBarBusyInactiveStyle lipgloss.Style
 
 	themeBackground color.Color
 	themeForeground color.Color
@@ -646,6 +647,12 @@ func applyTheme(t theme) {
 		Background(t.tabActive).
 		Bold(true)
 	tabBarInactiveStyle = lipgloss.NewStyle().Foreground(t.muted)
+	// Inactive busy tabs paint the ▸ in the theme's tabActive color so
+	// each theme picks its own play-button hue and the indicator pops
+	// from the muted label. The active tab pill is already tabActive,
+	// so its busy glyph stays in the regular active style — there's
+	// nothing to scan for when you're already looking at it.
+	tabBarBusyInactiveStyle = lipgloss.NewStyle().Foreground(t.tabActive).Bold(true)
 }
 
 func init() {

--- a/themes.go
+++ b/themes.go
@@ -647,11 +647,6 @@ func applyTheme(t theme) {
 		Background(t.tabActive).
 		Bold(true)
 	tabBarInactiveStyle = lipgloss.NewStyle().Foreground(t.muted)
-	// Inactive busy tabs paint the ▸ in the theme's tabActive color so
-	// each theme picks its own play-button hue and the indicator pops
-	// from the muted label. The active tab pill is already tabActive,
-	// so its busy glyph stays in the regular active style — there's
-	// nothing to scan for when you're already looking at it.
 	tabBarBusyInactiveStyle = lipgloss.NewStyle().Foreground(t.tabActive).Bold(true)
 }
 


### PR DESCRIPTION
## What

The play-button `▸` on busy **inactive** tabs previously inherited the same muted foreground as the rest of the label, so it blended in and was hard to scan across a tab strip. This splits the glyph into its own `tabBarBusyInactiveStyle` (theme `tabActive` fg, bold) and refactors `renderTabBar` through a new `renderTabPill` helper that applies it.

The **active** tab's pill background is already `tabActive`, so a `tabActive` foreground would disappear there — active busy tabs keep the `▸` inside the regular active style instead, since the pill itself is already the focal point and there's nothing to scan for. Using `tabActive` (rather than a fixed color like `warn`) means each theme automatically picks its own play-button hue and stays internally consistent.

## Tests

`tabs_test.go` — behavioral, covering all three cases:
- inactive busy renders the dedicated style,
- active busy carries the `▸` without leaking the inactive-busy style,
- an all-idle bar has no `▸` at all.

`go build ./...` / `go vet ./...` / `go test ./...` clean (aside from pre-existing, unrelated `mcp_workflows` failures on `main`).

## Files

`tabs.go` (`renderTabPill` helper + `renderTabBar` refactor), `themes.go` (`tabBarBusyInactiveStyle`), `tabs_test.go` (tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)