### PR TITLE
feat(linear): surface Slack threads and synced-comment authorship

### DIFF
--- a/issue_provider_linear.go
+++ b/issue_provider_linear.go
@@ -273,12 +273,13 @@ func (p *linearIssueProvider) ListIssues(ctx context.Context, cfg projectConfig,
 	}, nil
 }
 
-// GetIssue hydrates one issue with description and comments via
-// the top-level `issue(id:)` query, which accepts the shorthand
-// <TEAM>-<NUMBER> identifier as well as a UUID. We reconstruct the
-// identifier from cfg.MCP.Linear.TeamKey + the requested number.
-// Comments are pulled in the same query (single round trip) and
-// capped at 100, mirroring github's coverage.
+// GetIssue hydrates one issue with description, comments, and
+// attachments (Slack threads, linked PRs, …) via the top-level
+// `issue(id:)` query, which accepts the shorthand <TEAM>-<NUMBER>
+// identifier as well as a UUID. We reconstruct the identifier from
+// cfg.MCP.Linear.TeamKey + the requested number. Comments (capped at
+// 100, mirroring github) and attachments (capped at 50) are pulled in
+// the same query — a single round trip.
 func (p *linearIssueProvider) GetIssue(ctx context.Context, cfg projectConfig, cwd string, number int) (issue, error) {
 	if cfg.MCP.Linear.Token == "" || cfg.MCP.Linear.TeamKey == "" {
 		return issue{}, errIssueProviderNotConfigured
@@ -301,6 +302,11 @@ func (p *linearIssueProvider) GetIssue(ctx context.Context, cfg projectConfig, c
 	if out.Issue.Comments != nil {
 		for _, c := range out.Issue.Comments.Nodes {
 			it.comments = append(it.comments, linearAPIToComment(c))
+		}
+	}
+	if out.Issue.Attachments != nil {
+		for _, a := range out.Issue.Attachments.Nodes {
+			it.attachments = append(it.attachments, linearAPIToAttachment(a))
 		}
 	}
 	return it, nil
@@ -1163,15 +1169,16 @@ type linearGraphQLError struct {
 // as float64 because Linear sometimes serialises ints as JSON
 // numbers via float; we cast to int in linearAPIToIssue.
 type linearAPIIssue struct {
-	ID          string                `json:"id"`
-	Identifier  string                `json:"identifier"`
-	Number      float64               `json:"number"`
-	Title       string                `json:"title"`
-	Description string                `json:"description"`
-	CreatedAt   time.Time             `json:"createdAt"`
-	State       *linearAPIState       `json:"state"`
-	Assignee    *linearAPIUser        `json:"assignee"`
-	Comments    *linearAPICommentList `json:"comments"`
+	ID          string                   `json:"id"`
+	Identifier  string                   `json:"identifier"`
+	Number      float64                  `json:"number"`
+	Title       string                   `json:"title"`
+	Description string                   `json:"description"`
+	CreatedAt   time.Time                `json:"createdAt"`
+	State       *linearAPIState          `json:"state"`
+	Assignee    *linearAPIUser           `json:"assignee"`
+	Comments    *linearAPICommentList    `json:"comments"`
+	Attachments *linearAPIAttachmentList `json:"attachments"`
 }
 
 type linearAPIState struct {
@@ -1197,9 +1204,48 @@ type linearAPICommentList struct {
 }
 
 type linearAPIComment struct {
-	CreatedAt time.Time      `json:"createdAt"`
-	Body      string         `json:"body"`
-	User      *linearAPIUser `json:"user"`
+	CreatedAt    time.Time              `json:"createdAt"`
+	Body         string                 `json:"body"`
+	URL          string                 `json:"url"`
+	User         *linearAPIUser         `json:"user"`
+	ExternalUser *linearAPIExternalUser `json:"externalUser"`
+	BotActor     *linearAPIActorBot     `json:"botActor"`
+}
+
+// linearAPIExternalUser is the trim of ExternalUser — a participant
+// without a Linear account (e.g. a Slack user in a synced thread).
+type linearAPIExternalUser struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+}
+
+// linearAPIActorBot is the trim of ActorBot — the integration that
+// authored a synced comment. Type is the integration ("slack",
+// "github", …); UserDisplayName is the external person the bot acted
+// on behalf of (the Slack author for a synced thread reply).
+type linearAPIActorBot struct {
+	Name            string `json:"name"`
+	Type            string `json:"type"`
+	UserDisplayName string `json:"userDisplayName"`
+}
+
+type linearAPIAttachmentList struct {
+	Nodes []linearAPIAttachment `json:"nodes"`
+}
+
+// linearAPIAttachment is the trim of the GraphQL Attachment type. A
+// linked Slack thread lives here (sourceType "slack") rather than in
+// comments unless the workspace syncs the thread. Metadata is the
+// integration-specific JSONObject, kept raw and compacted by the
+// converter.
+type linearAPIAttachment struct {
+	Title      string          `json:"title"`
+	Subtitle   string          `json:"subtitle"`
+	URL        string          `json:"url"`
+	SourceType string          `json:"sourceType"`
+	BodyData   string          `json:"bodyData"`
+	Metadata   json.RawMessage `json:"metadata"`
+	CreatedAt  time.Time       `json:"createdAt"`
 }
 
 // linearWorkflowState is the trim of WorkflowState — id + type are
@@ -1246,18 +1292,59 @@ func linearAPIToIssue(li linearAPIIssue) issue {
 
 func linearAPIToComment(c linearAPIComment) issueComment {
 	author := ""
-	if c.User != nil {
+	switch {
+	case c.User != nil && c.User.DisplayName != "":
+		author = c.User.DisplayName
+	case c.User != nil && c.User.Name != "":
+		author = c.User.Name
+	case c.ExternalUser != nil && c.ExternalUser.DisplayName != "":
+		author = c.ExternalUser.DisplayName
+	case c.ExternalUser != nil && c.ExternalUser.Name != "":
+		author = c.ExternalUser.Name
+	case c.BotActor != nil && c.BotActor.UserDisplayName != "":
+		author = c.BotActor.UserDisplayName
+	case c.BotActor != nil && c.BotActor.Name != "":
+		author = c.BotActor.Name
+	}
+	// A comment with no Linear user was synced from an integration;
+	// tag the channel ("slack", …) so the reader knows the author is
+	// external. botActor.type names the integration; fall back to a
+	// generic "external" when only an externalUser is present.
+	source := ""
+	if c.User == nil {
 		switch {
-		case c.User.DisplayName != "":
-			author = c.User.DisplayName
-		case c.User.Name != "":
-			author = c.User.Name
+		case c.BotActor != nil && c.BotActor.Type != "":
+			source = c.BotActor.Type
+		case c.ExternalUser != nil:
+			source = "external"
 		}
 	}
 	return issueComment{
 		author:    author,
 		createdAt: c.CreatedAt,
 		body:      linearUnescapeText(c.Body),
+		source:    source,
+		url:       c.URL,
+	}
+}
+
+// linearAPIToAttachment maps the GraphQL Attachment trim onto the
+// provider-neutral issueAttachment. Metadata is compacted; an empty
+// JSON object / null collapses to "" so the view doesn't show noise.
+func linearAPIToAttachment(a linearAPIAttachment) issueAttachment {
+	meta := strings.TrimSpace(string(a.Metadata))
+	switch meta {
+	case "", "{}", "null":
+		meta = ""
+	}
+	return issueAttachment{
+		title:      linearUnescapeText(a.Title),
+		subtitle:   linearUnescapeText(a.Subtitle),
+		url:        a.URL,
+		sourceType: a.SourceType,
+		body:       linearUnescapeText(a.BodyData),
+		metadata:   meta,
+		createdAt:  a.CreatedAt,
 	}
 }
 
@@ -1979,7 +2066,21 @@ query AskGetIssue($id: String!) {
       nodes {
         createdAt
         body
+        url
         user { name displayName }
+        externalUser { displayName name }
+        botActor { name type userDisplayName }
+      }
+    }
+    attachments(first: 50) {
+      nodes {
+        title
+        subtitle
+        url
+        sourceType
+        bodyData
+        metadata
+        createdAt
       }
     }
   }

--- a/issue_provider_linear_test.go
+++ b/issue_provider_linear_test.go
@@ -576,6 +576,138 @@ func TestLinearAPIToComment_AuthorFallback(t *testing.T) {
 	}
 }
 
+func TestLinearAPIToComment_ResolvesExternalAndBotAuthors(t *testing.T) {
+	// A Slack participant without a Linear account is carried via
+	// externalUser and tagged source=external.
+	ext := linearAPIToComment(linearAPIComment{
+		Body:         "from slack",
+		URL:          "https://slack.example/p1",
+		ExternalUser: &linearAPIExternalUser{DisplayName: "Dana"},
+	})
+	if ext.author != "Dana" || ext.source != "external" {
+		t.Errorf("externalUser comment=%+v", ext)
+	}
+	if ext.url != "https://slack.example/p1" {
+		t.Errorf("url=%q", ext.url)
+	}
+
+	// A synced Slack reply has no Linear user; botActor names the
+	// integration (source) and the person it acted for (author).
+	bot := linearAPIToComment(linearAPIComment{
+		Body:     "synced reply",
+		BotActor: &linearAPIActorBot{Type: "slack", UserDisplayName: "Erin"},
+	})
+	if bot.author != "Erin" || bot.source != "slack" {
+		t.Errorf("botActor comment=%+v", bot)
+	}
+
+	// A real Linear user wins and is never tagged with a source.
+	usr := linearAPIToComment(linearAPIComment{
+		Body:         "native",
+		User:         &linearAPIUser{DisplayName: "Antonio"},
+		ExternalUser: &linearAPIExternalUser{DisplayName: "ignored"},
+		BotActor:     &linearAPIActorBot{Type: "slack"},
+	})
+	if usr.author != "Antonio" || usr.source != "" {
+		t.Errorf("linear user should win untagged: author=%q source=%q", usr.author, usr.source)
+	}
+}
+
+func TestLinearAPIToAttachment_MapsFieldsAndCompactsMetadata(t *testing.T) {
+	a := linearAPIToAttachment(linearAPIAttachment{
+		Title:      "Slack thread in #eng",
+		Subtitle:   "12 replies",
+		URL:        "https://slack.example/archives/C/p123",
+		SourceType: "slack",
+		BodyData:   "first message &amp; more",
+		Metadata:   json.RawMessage(`{"channel":"eng"}`),
+	})
+	if a.title != "Slack thread in #eng" || a.sourceType != "slack" {
+		t.Errorf("attachment=%+v", a)
+	}
+	if a.body != "first message & more" {
+		t.Errorf("bodyData not unescaped: %q", a.body)
+	}
+	if a.metadata != `{"channel":"eng"}` {
+		t.Errorf("metadata=%q", a.metadata)
+	}
+	for _, raw := range []string{`{}`, `null`, ``} {
+		if got := linearAPIToAttachment(linearAPIAttachment{Metadata: json.RawMessage(raw)}); got.metadata != "" {
+			t.Errorf("metadata %q should collapse to empty, got %q", raw, got.metadata)
+		}
+	}
+}
+
+func TestLinearIssueQuery_RequestsAttachmentsAndSyncedAuthors(t *testing.T) {
+	for _, want := range []string{"attachments(", "bodyData", "sourceType", "botActor", "externalUser"} {
+		if !strings.Contains(linearIssueQuery, want) {
+			t.Errorf("linearIssueQuery missing %q", want)
+		}
+	}
+}
+
+func TestLinearProvider_GetIssue_SurfacesAttachmentsAndSyncedComments(t *testing.T) {
+	mock := newLinearMockServer(t)
+	mock.handlers["AskGetIssue"] = func(vars map[string]any) any {
+		return map[string]any{
+			"issue": map[string]any{
+				"number":      776,
+				"title":       "needs slack context",
+				"description": "see thread",
+				"state":       map[string]any{"type": "started"},
+				"createdAt":   "2026-01-20T00:00:00Z",
+				"comments": map[string]any{
+					"nodes": []any{
+						map[string]any{
+							"createdAt": "2026-02-01T10:00:00Z",
+							"body":      "synced from slack",
+							"url":       "https://slack.example/p9",
+							"botActor":  map[string]any{"type": "slack", "userDisplayName": "Dana"},
+						},
+					},
+				},
+				"attachments": map[string]any{
+					"nodes": []any{
+						map[string]any{
+							"title":      "Slack thread",
+							"subtitle":   "8 replies",
+							"url":        "https://slack.example/archives/C/p1",
+							"sourceType": "slack",
+							"bodyData":   "the discussion",
+							"metadata":   map[string]any{"channel": "eng"},
+							"createdAt":  "2026-01-21T00:00:00Z",
+						},
+					},
+				},
+			},
+		}
+	}
+	p := &linearIssueProvider{}
+	cfg := projectConfig{MCP: projectMCPConfig{Linear: linearMCPConfig{
+		Endpoint: mock.URL(), Token: "lin_api_x", TeamKey: "WAJ",
+	}}}
+	got, err := p.GetIssue(context.Background(), cfg, "/tmp", 776)
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if len(got.attachments) != 1 {
+		t.Fatalf("attachments=%+v", got.attachments)
+	}
+	a := got.attachments[0]
+	if a.sourceType != "slack" || a.url != "https://slack.example/archives/C/p1" || a.body != "the discussion" {
+		t.Errorf("attachment=%+v", a)
+	}
+	if a.metadata != `{"channel":"eng"}` {
+		t.Errorf("metadata=%q", a.metadata)
+	}
+	if len(got.comments) != 1 {
+		t.Fatalf("comments=%+v", got.comments)
+	}
+	if c := got.comments[0]; c.author != "Dana" || c.source != "slack" || c.url != "https://slack.example/p9" {
+		t.Errorf("synced comment=%+v", c)
+	}
+}
+
 func TestLinearGraphQLEndpointDefault_AppliesWhenBlank(t *testing.T) {
 	got := linearGraphQLEndpointOrDefault(linearMCPConfig{})
 	if got != linearGraphQLDefaultEndpoint {
@@ -1118,11 +1250,11 @@ func TestIsLinearUUID(t *testing.T) {
 		{"00000000-0000-0000-0000-000000000000", true},
 		{"", false},
 		{"abc", false},
-		{"abc12345-1234-4567-8901-abcdef12345", false}, // 35
+		{"abc12345-1234-4567-8901-abcdef12345", false},   // 35
 		{"abc12345-1234-4567-8901-abcdef123456X", false}, // 37
-		{"abc12345-12345-456-8901-abcdef123456", false}, // misplaced hyphens
-		{"abc12345_1234_4567_8901_abcdef123456", false}, // underscores not hyphens
-		{"abcg2345-1234-4567-8901-abcdef123456", false}, // non-hex 'g'
+		{"abc12345-12345-456-8901-abcdef123456", false},  // misplaced hyphens
+		{"abc12345_1234_4567_8901_abcdef123456", false},  // underscores not hyphens
+		{"abcg2345-1234-4567-8901-abcdef123456", false},  // non-hex 'g'
 	}
 	for _, c := range cases {
 		if got := isLinearUUID(c.in); got != c.want {

--- a/issues.go
+++ b/issues.go
@@ -104,6 +104,13 @@ type issue struct {
 	// belongs to the detail view, not the data, so we don't smear "the
 	// canonical thread order" across read sites.
 	comments []issueComment
+
+	// attachments are external resources linked to the issue (Slack
+	// threads, GitHub PRs, plain URLs, …). Linear surfaces a linked
+	// Slack thread here rather than as a comment unless the workspace
+	// syncs the thread, so the agent needs these to see the discussion
+	// at all.
+	attachments []issueAttachment
 }
 
 // issueComment is one comment in an issue's thread. Provider-neutral
@@ -113,6 +120,33 @@ type issueComment struct {
 	author    string
 	createdAt time.Time
 	body      string
+
+	// source tags the integration channel a synced comment came from
+	// (e.g. "slack") when it wasn't authored by a Linear user. Empty
+	// for native Linear comments.
+	source string
+
+	// url is a permalink to the comment's origin (e.g. the Slack
+	// message) when the provider exposes one. Empty otherwise.
+	url string
+}
+
+// issueAttachment is one external resource linked to an issue. For
+// Linear this is the GraphQL `Attachment` type — a Slack thread, a
+// GitHub PR, a Figma file, or a plain URL. title/subtitle/url are the
+// fields Linear renders in its attachment widget; sourceType is the
+// integration that created it ("slack", "github", …); body carries any
+// attachment bodyData (often the originating message text); metadata is
+// the integration-specific JSON, compacted, empty when Linear returned
+// an empty object.
+type issueAttachment struct {
+	title      string
+	subtitle   string
+	url        string
+	sourceType string
+	body       string
+	metadata   string
+	createdAt  time.Time
 }
 
 // issuesState is the per-tab state for the issues screen. Holds the
@@ -1632,29 +1666,76 @@ func (v *issueDetailView) renderBody(width int) string {
 	b.WriteString(strings.TrimRight(body, "\n"))
 	b.WriteString("\n")
 
-	if len(v.issue.comments) == 0 {
-		b.WriteString("\n")
-		b.WriteString(dimStyle.Render("(no comments)"))
-		return b.String()
-	}
-
 	// All chrome inside the body sits at column 0 and inherits the
 	// screen-level indent. The separator's width matches the body
 	// width so it spans the indented column up to the right edge.
 	sepW := max(8, width-2)
-	b.WriteString("\n")
-	b.WriteString(dimStyle.Render(strings.Repeat("─", sepW)))
-	b.WriteString("\n\n")
-	b.WriteString(promptStyle.Render(
-		fmt.Sprintf("Comments (%d)", len(v.issue.comments))))
-	b.WriteString("\n\n")
+	section := func(title string) {
+		b.WriteString("\n")
+		b.WriteString(dimStyle.Render(strings.Repeat("─", sepW)))
+		b.WriteString("\n\n")
+		b.WriteString(promptStyle.Render(title))
+		b.WriteString("\n\n")
+	}
 
+	// Attachments (Slack threads, linked PRs, …) come before comments —
+	// for a Linear issue a linked Slack discussion lives here, and it's
+	// usually the primary context the reader is after.
+	if len(v.issue.attachments) > 0 {
+		section(fmt.Sprintf("Attachments (%d)", len(v.issue.attachments)))
+		for i, a := range v.issue.attachments {
+			if i > 0 {
+				b.WriteString("\n")
+			}
+			label := strings.TrimSpace(a.title)
+			if label == "" {
+				label = "(attachment)"
+			}
+			if a.sourceType != "" {
+				label = fmt.Sprintf("%s (%s)", label, a.sourceType)
+			}
+			b.WriteString(promptStyle.Render(label))
+			b.WriteString("\n")
+			if sub := strings.TrimSpace(a.subtitle); sub != "" {
+				b.WriteString(dimStyle.Render(sub))
+				b.WriteString("\n")
+			}
+			if a.url != "" {
+				b.WriteString(dimStyle.Render(a.url))
+				b.WriteString("\n")
+			}
+			if bd := strings.TrimSpace(a.body); bd != "" {
+				rb, err := r.Render(bd)
+				if err != nil {
+					rb = bd
+				}
+				b.WriteString(strings.TrimRight(rb, "\n"))
+				b.WriteString("\n")
+			}
+		}
+	}
+
+	if len(v.issue.comments) == 0 {
+		if len(v.issue.attachments) == 0 {
+			b.WriteString("\n")
+			b.WriteString(dimStyle.Render("(no comments)"))
+		}
+		return b.String()
+	}
+
+	section(fmt.Sprintf("Comments (%d)", len(v.issue.comments)))
 	for i, c := range v.issue.comments {
 		if i > 0 {
 			b.WriteString("\n")
 		}
-		head := fmt.Sprintf("%s · %s",
-			c.author, c.createdAt.Format("2006-01-02"))
+		author := c.author
+		if author == "" {
+			author = "(unknown)"
+		}
+		head := fmt.Sprintf("%s · %s", author, c.createdAt.Format("2006-01-02"))
+		if c.source != "" {
+			head = fmt.Sprintf("%s (%s) · %s", author, c.source, c.createdAt.Format("2006-01-02"))
+		}
 		b.WriteString(dimStyle.Render(head))
 		b.WriteString("\n")
 		body, err := r.Render(strings.TrimSpace(c.body))

--- a/mcp_linear.go
+++ b/mcp_linear.go
@@ -54,19 +54,38 @@ type linearGetInput struct {
 
 type linearCommentView struct {
 	Author    string `json:"author"`
+	Source    string `json:"source,omitempty"`
 	CreatedAt string `json:"created_at"`
 	Body      string `json:"body"`
+	URL       string `json:"url,omitempty"`
+}
+
+// linearAttachmentView is an external resource linked to the issue —
+// most importantly a Slack thread (source_type "slack"). Surfaced to
+// the agent so it can read or follow discussions Linear stores as
+// attachments rather than comments. body is the attachment's bodyData
+// (often the originating message); metadata is the integration's raw
+// JSON when non-empty.
+type linearAttachmentView struct {
+	Title      string `json:"title,omitempty"`
+	Subtitle   string `json:"subtitle,omitempty"`
+	URL        string `json:"url"`
+	SourceType string `json:"source_type,omitempty"`
+	Body       string `json:"body,omitempty"`
+	Metadata   string `json:"metadata,omitempty"`
+	CreatedAt  string `json:"created_at"`
 }
 
 type linearIssueDetailView struct {
-	Number      int                 `json:"number"`
-	Identifier  string              `json:"identifier"`
-	Title       string              `json:"title"`
-	Status      string              `json:"status"`
-	Assignee    string              `json:"assignee"`
-	CreatedAt   string              `json:"created_at"`
-	Description string              `json:"description"`
-	Comments    []linearCommentView `json:"comments,omitempty"`
+	Number      int                    `json:"number"`
+	Identifier  string                 `json:"identifier"`
+	Title       string                 `json:"title"`
+	Status      string                 `json:"status"`
+	Assignee    string                 `json:"assignee"`
+	CreatedAt   string                 `json:"created_at"`
+	Description string                 `json:"description"`
+	Comments    []linearCommentView    `json:"comments,omitempty"`
+	Attachments []linearAttachmentView `json:"attachments,omitempty"`
 }
 
 type linearGetOutput struct {
@@ -283,7 +302,9 @@ Returns a page of issues (number, identifier, title, status, assignee, created_a
 
 Errors when Linear is not configured for the current project (missing API key or team key).`
 
-	linearGetToolDescription = `Get one Linear issue by number, including description and comments.
+	linearGetToolDescription = `Get one Linear issue by number, including description, comments, and attachments.
+
+Attachments are external resources linked to the issue — most importantly Slack threads (source_type "slack"), plus GitHub PRs, Figma files, and plain URLs. A Slack discussion linked to an issue lives in attachments, not comments, unless the workspace syncs the thread; follow the attachment url to read the full Slack thread. Comments synced from an integration carry a "source" (e.g. "slack") and the external author's name in place of a Linear user.
 
 The configured team is implicit; the caller passes only the integer number. Errors when the issue does not exist or Linear is not configured for the current project.`
 
@@ -306,7 +327,7 @@ Supported edits:
   • estimate — set point estimate, or pass a negative value to clear
   • parent — set parent (TEAM-N / bare number / UUID) for sub-issue, or pass empty string to orphan
 
-Returns the post-update issue snapshot (full detail view including description and comments). Errors when no field was supplied, a name fails to resolve, the issue does not exist, or Linear is not configured.`
+Returns the post-update issue snapshot (full detail view including description, comments, and attachments). Errors when no field was supplied, a name fails to resolve, the issue does not exist, or Linear is not configured.`
 
 	linearCreateCommentToolDescription = `Add a comment to a Linear issue.
 
@@ -724,8 +745,9 @@ func linearIssueViewOf(it issue, teamKey string) linearIssueView {
 }
 
 // linearIssueDetailViewOf is the get-tool counterpart to
-// linearIssueViewOf — adds description and comments to the wire
-// shape so the agent gets the full body in one round trip.
+// linearIssueViewOf — adds description, comments, and attachments to
+// the wire shape so the agent gets the full body (including linked
+// Slack threads) in one round trip.
 func linearIssueDetailViewOf(it issue, teamKey string) linearIssueDetailView {
 	out := linearIssueDetailView{
 		Number:      it.number,
@@ -741,8 +763,24 @@ func linearIssueDetailViewOf(it issue, teamKey string) linearIssueDetailView {
 		for _, c := range it.comments {
 			out.Comments = append(out.Comments, linearCommentView{
 				Author:    c.author,
+				Source:    c.source,
 				CreatedAt: c.createdAt.Format(time.RFC3339),
 				Body:      c.body,
+				URL:       c.url,
+			})
+		}
+	}
+	if len(it.attachments) > 0 {
+		out.Attachments = make([]linearAttachmentView, 0, len(it.attachments))
+		for _, a := range it.attachments {
+			out.Attachments = append(out.Attachments, linearAttachmentView{
+				Title:      a.title,
+				Subtitle:   a.subtitle,
+				URL:        a.url,
+				SourceType: a.sourceType,
+				Body:       a.body,
+				Metadata:   a.metadata,
+				CreatedAt:  a.createdAt.Format(time.RFC3339),
 			})
 		}
 	}

--- a/mcp_linear_test.go
+++ b/mcp_linear_test.go
@@ -157,6 +157,83 @@ func TestLinearIssueDetailViewOf_OmitsCommentsWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestLinearIssueDetailViewOf_IncludesAttachmentsAndCommentSource(t *testing.T) {
+	ct := time.Date(2026, 2, 1, 10, 0, 0, 0, time.UTC)
+	at := time.Date(2026, 1, 21, 0, 0, 0, 0, time.UTC)
+	detail := linearIssueDetailViewOf(issue{
+		number: 776,
+		title:  "needs slack context",
+		comments: []issueComment{
+			{author: "Dana", source: "slack", body: "synced", url: "https://slack.example/p9", createdAt: ct},
+		},
+		attachments: []issueAttachment{
+			{title: "Slack thread", subtitle: "8 replies", url: "https://slack.example/p1", sourceType: "slack", body: "discussion", metadata: `{"channel":"eng"}`, createdAt: at},
+		},
+	}, "WAJ")
+	if len(detail.Attachments) != 1 {
+		t.Fatalf("attachments=%+v", detail.Attachments)
+	}
+	a := detail.Attachments[0]
+	if a.SourceType != "slack" || a.URL != "https://slack.example/p1" || a.Body != "discussion" || a.Metadata != `{"channel":"eng"}` {
+		t.Errorf("attachment view=%+v", a)
+	}
+	if a.CreatedAt != "2026-01-21T00:00:00Z" {
+		t.Errorf("attachment createdAt=%q", a.CreatedAt)
+	}
+	if len(detail.Comments) != 1 || detail.Comments[0].Source != "slack" || detail.Comments[0].URL != "https://slack.example/p9" {
+		t.Errorf("comment view=%+v", detail.Comments)
+	}
+}
+
+func TestLinearIssueDetailViewOf_OmitsAttachmentsWhenEmpty(t *testing.T) {
+	detail := linearIssueDetailViewOf(issue{number: 1, title: "x"}, "ENG")
+	if detail.Attachments != nil {
+		t.Errorf("Attachments should be nil when none, got %+v", detail.Attachments)
+	}
+}
+
+func TestLinearGetTool_SurfacesAttachments(t *testing.T) {
+	mock := newLinearMockServer(t)
+	mock.handlers["AskGetIssue"] = func(vars map[string]any) any {
+		return map[string]any{
+			"issue": map[string]any{
+				"number":      776,
+				"title":       "ctx",
+				"description": "body",
+				"state":       map[string]any{"type": "started"},
+				"createdAt":   "2026-01-20T00:00:00Z",
+				"attachments": map[string]any{
+					"nodes": []any{
+						map[string]any{
+							"title":      "Slack thread",
+							"url":        "https://slack.example/p1",
+							"sourceType": "slack",
+							"bodyData":   "the discussion",
+							"metadata":   map[string]any{},
+							"createdAt":  "2026-01-21T00:00:00Z",
+						},
+					},
+				},
+			},
+		}
+	}
+	b, _ := configuredLinearBridge(t, mock.URL())
+	res, out, _ := b.linearGetTool(context.Background(), &mcp.CallToolRequest{}, linearGetInput{Number: 776})
+	if res.IsError {
+		t.Fatalf("get errored: %s", textContent(res))
+	}
+	if len(out.Issue.Attachments) != 1 {
+		t.Fatalf("attachments=%+v", out.Issue.Attachments)
+	}
+	a := out.Issue.Attachments[0]
+	if a.SourceType != "slack" || a.URL != "https://slack.example/p1" || a.Body != "the discussion" {
+		t.Errorf("attachment=%+v", a)
+	}
+	if a.Metadata != "" {
+		t.Errorf("empty metadata should collapse, got %q", a.Metadata)
+	}
+}
+
 // -----------------------------------------------------------------------
 // linearProjectConfig gate coverage
 // -----------------------------------------------------------------------


### PR DESCRIPTION
## Problem

ask's Linear integration (`linear_get_issue` and the kanban issue-detail view) fetched only an issue's `description` and `comments { body, user }`, so Slack discussions were invisible to agents and users:

- A **linked Slack thread** lives in Linear as an **`Attachment`**, which the query never requested — so it was completely invisible.
- A **synced Slack reply** lands as a `comment` with a null `user` and its author in `botActor` / `externalUser`, so it rendered author-less.

(Surfaced while triaging an issue whose only context was a linked Slack thread.)

## What changed

- **Query** (`issue_provider_linear.go`): `linearIssueQuery` now pulls `attachments { title, subtitle, url, sourceType, bodyData, metadata, createdAt }` and enriches comments with `botActor` / `externalUser` / `url`.
- **Structs + converters**: new `linearAPIAttachment` / `linearAPIActorBot` / `linearAPIExternalUser`; `linearAPIToAttachment`; `linearAPIToComment` now resolves author via `user -> externalUser -> botActor` and tags a `source` (e.g. `slack`). `GetIssue` hydrates `issue.attachments`.
- **Model** (`issues.go`): `issue.attachments`, `issueComment.source` / `url`, new `issueAttachment`.
- **Agent surface** (`mcp_linear.go`): `linear_get_issue` gains an `attachments[]` array plus comment `source` / `url`; the tool description tells the agent that Slack threads live in attachments and to follow the `url` for the full thread.
- **Human surface** (`issues.go` `renderBody`): the kanban detail view shows an Attachments section (Slack thread first) and a `(slack)` author tag on synced comments.

This fully solves *synced* threads; for *link-only* threads it surfaces the permalink plus whatever Linear stored (`bodyData` / `metadata`). All GraphQL fields were verified against Linear's published schema.

## Tests

Behavioral (non-rendering) tests in `issue_provider_linear_test.go` + `mcp_linear_test.go`: converter author-resolution (slack / external / native), attachment mapping + metadata compaction, a query-shape guard, and end-to-end `GetIssue` / `linear_get_issue` attachment surfacing. `go build ./...` and `go vet ./...` are clean, and the full Linear suite passes (`go test -run Linear ./.`).

Note: `main` currently carries a few pre-existing test failures unrelated to this change (`mcp_workflows`, `Ctrl+Z` suspend, usage-plugin script path), so a full-suite run on the base is red independently of this PR.

## Follow-up (not in this PR)

Layer 2 — fetching the full reply chain of *link-only* (unsynced) Slack threads — would require the Slack API (`conversations.replies`) plus a token; intentionally deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
