### PR TITLE
fix: bound startup VCS subprocesses so a wedged git can't hang launch

### DIFF
--- a/memory_root.go
+++ b/memory_root.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -63,9 +62,7 @@ func memoryProjectRoot(cwd string) string {
 // Empty when cwd is not in a git checkout, when git is not on PATH,
 // or when the path normalization fails.
 func gitMainRoot(cwd string) string {
-	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
-	cmd.Dir = cwd
-	out, err := cmd.Output()
+	out, err := vcsOutput(cwd, "git", "rev-parse", "--git-common-dir")
 	if err != nil {
 		return ""
 	}
@@ -95,9 +92,7 @@ func gitMainRoot(cwd string) string {
 // per-workspace memory partitioning in jj — fewer ask users hit this
 // today, and the symmetry with git can be revisited when it does.
 func jjRoot(cwd string) string {
-	cmd := exec.Command("jj", "root")
-	cmd.Dir = cwd
-	out, err := cmd.Output()
+	out, err := vcsOutput(cwd, "jj", "root")
 	if err != nil {
 		return ""
 	}

--- a/vcs.go
+++ b/vcs.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// vcsCommandTimeout bounds a single git/jj subprocess that runs on ask's
+// startup critical path — before the TUI is on screen (pruneWorktrees and
+// the memory-tenant root canonicalization in newTab → setCwd). Those
+// commands are cheap, read-mostly metadata queries (`git rev-parse
+// --git-common-dir`, `git worktree list`, `git worktree remove`, `jj root`,
+// …) that return in milliseconds on a healthy repo. The only way one runs
+// long is a wedged VCS — a hung fsmonitor/credential helper, an NFS or
+// Spotlight stall, a lock held by a crashed process. Unbounded, such a
+// stall hangs ask before it ever draws: a blank-at-launch freeze with no
+// recourse. (This is the concrete bug it guards: a second `ask` launched in
+// a busy checkout while the first was running never opened.) The ceiling is
+// generous enough never to trip on a healthy-but-slow machine, tight enough
+// that a wedge degrades to "launches a few seconds late, minus
+// prune/canonicalization" rather than "hangs forever."
+const vcsCommandTimeout = 5 * time.Second
+
+// vcsWaitDelay bounds how long, after the timeout fires and the VCS process
+// is killed, Output/CombinedOutput waits for the process's stdout/stderr
+// pipes to drain before forcibly closing them and returning. This is
+// essential, not cosmetic: exec.CommandContext kills only the direct child,
+// but a wedged git often leaves a grandchild holding the pipe open (an
+// fsmonitor daemon, a credential helper, a `sleep` in a hook). Without a
+// WaitDelay, Output() blocks reading that pipe until the grandchild exits —
+// so the command "times out" yet the call still hangs forever, defeating
+// the entire guard. WaitDelay makes Wait close the pipes and return. See
+// exec.Cmd.WaitDelay (Go 1.20+).
+const vcsWaitDelay = 2 * time.Second
+
+// vcsOutput runs `name args...` in dir and returns its stdout, bounded by
+// vcsCommandTimeout. Drop-in for exec.Cmd.Output on the startup path.
+func vcsOutput(dir, name string, args ...string) ([]byte, error) {
+	return runVCS(vcsCommandTimeout, vcsWaitDelay, dir, name, args, false)
+}
+
+// vcsCombined is vcsOutput but returns combined stdout+stderr, mirroring
+// exec.Cmd.CombinedOutput for callers that fold the tool's stderr into
+// their own error message.
+func vcsCombined(dir, name string, args ...string) ([]byte, error) {
+	return runVCS(vcsCommandTimeout, vcsWaitDelay, dir, name, args, true)
+}
+
+// vcsRunner runs a VCS command in dir and returns combined output. It has
+// two implementations that differ only in whether a hang is bounded, so a
+// shared helper (e.g. jjWorkspaceTargets) can be timeout-guarded on ask's
+// startup path yet patient on a foreground action:
+//   - vcsCombined          — timeout-bounded; for the startup/prune path,
+//     where a wedged VCS must never block the launch.
+//   - unboundedVCSCombined — no timeout; for foreground actions like
+//     /resume, where a legitimately slow `jj workspace` op must be waited
+//     out, not aborted at 5s. A hang there stalls one user-initiated action
+//     (Ctrl+C-able), not the whole UI coming up.
+type vcsRunner func(dir, name string, args ...string) ([]byte, error)
+
+// unboundedVCSCombined runs a VCS command with no timeout. Used only off the
+// startup critical path (see vcsRunner); the bounded vcsCombined is the
+// default everywhere prune/launch can reach.
+func unboundedVCSCombined(dir, name string, args ...string) ([]byte, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	return cmd.CombinedOutput()
+}
+
+// runVCS executes a VCS subprocess under a hard timeout. On expiry the
+// process is killed (exec.CommandContext sends SIGKILL) and a timeout error
+// is returned instead of blocking forever; waitDelay then bounds the pipe
+// drain so a grandchild holding the output pipe can't keep the call blocked
+// past the timeout. timeout and waitDelay are parameters so tests can
+// exercise the deadline path with sub-second values.
+func runVCS(timeout, waitDelay time.Duration, dir, name string, args []string, combined bool) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	// Run the child in its own process group so the timeout can SIGKILL the
+	// whole group, reaping helper grandchildren a wedged VCS spawns
+	// (credential helper, hook, fsmonitor) instead of orphaning them to run
+	// on. Setpgid alone is safe — the child is not a session leader, so it
+	// avoids the Setpgid+Setsid EPERM trap documented in shell.go.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		// Negative pid targets the group (== child pid, since Setpgid made
+		// the child its leader). Fall back to the lone process if the group
+		// signal fails.
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+			return cmd.Process.Kill()
+		}
+		return nil
+	}
+	// Backstop: WaitDelay guarantees Output/CombinedOutput returns even if a
+	// fully daemonized escapee (its own session) survives the group kill and
+	// keeps the output pipe open (see vcsWaitDelay).
+	cmd.WaitDelay = waitDelay
+	var (
+		out []byte
+		err error
+	)
+	if combined {
+		out, err = cmd.CombinedOutput()
+	} else {
+		out, err = cmd.Output()
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		return out, fmt.Errorf("%s %s: timed out after %s (vcs unresponsive)", name, strings.Join(args, " "), timeout)
+	}
+	return out, err
+}

--- a/vcs_test.go
+++ b/vcs_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// runVCS must (a) return at the deadline instead of blocking forever — the
+// guarantee that keeps a stalled git/jj from hanging ask's launch — and
+// (b) reap the wedged process's descendants rather than orphaning them.
+//
+// The command forks a `sleep` grandchild that inherits the stdout pipe and
+// records its PID. That models a real wedged git, which spawns helpers
+// (fsmonitor daemon, credential helper) that hold the pipe open: killing
+// only the direct child leaves Output() blocking AND leaks the helper. We
+// assert both that runVCS returns promptly and that the grandchild is dead
+// afterward (proving the process-group kill, not just WaitDelay, fired).
+// (`sh`/`sleep` are the lone non-git subprocesses in the suite — the only
+// portable stand-in for a never-returning process; the timings keep it fast.)
+func TestRunVCS_TimesOutAndReapsGrandchild(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "grandchild.pid")
+	script := fmt.Sprintf("sleep 30 & echo $! > %s; wait", pidFile)
+
+	start := time.Now()
+	out, err := runVCS(80*time.Millisecond, 1*time.Second, "", "sh", []string{"-c", script}, false)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("expected a timeout error, got nil (out=%q)", out)
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected a timeout error, got %v", err)
+	}
+	// timeout (80ms) + waitDelay (1s) + slack. A regression dropping the
+	// kill/WaitDelay would block here until the 30s sleep ends.
+	if elapsed > 3*time.Second {
+		t.Fatalf("runVCS did not return promptly despite a pipe-holding grandchild: took %s", elapsed)
+	}
+
+	pid := readPID(t, pidFile)
+	// The grandchild is orphaned to init after sh dies; a process-group kill
+	// reaps it within milliseconds. Poll briefly to avoid races; a regression
+	// that kills only the direct child leaves it alive for the full 30s.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if errors.Is(syscall.Kill(pid, 0), syscall.ESRCH) {
+			return // reaped — good
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("grandchild pid %d still alive: process group was not killed on timeout", pid)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func readPID(t *testing.T, path string) int {
+	t.Helper()
+	// The grandchild PID is written at sh start; give it a beat to land.
+	deadline := time.Now().Add(1 * time.Second)
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			if s := strings.TrimSpace(string(data)); s != "" {
+				pid, perr := strconv.Atoi(s)
+				if perr == nil {
+					return pid
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("grandchild never recorded its pid at %s", path)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// The happy path returns the command's stdout unchanged so the timeout
+// wrapper is transparent to healthy callers.
+func TestRunVCS_ReturnsOutputOnSuccess(t *testing.T) {
+	if !gitAvailable() {
+		t.Skip("git not installed")
+	}
+	dir := initGitRepo(t)
+	out, err := vcsOutput(dir, "git", "rev-parse", "--is-inside-work-tree")
+	if err != nil {
+		t.Fatalf("vcsOutput: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "true" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}

--- a/worktree.go
+++ b/worktree.go
@@ -236,9 +236,25 @@ func samePathOrResolved(a, b string) bool {
 // non-ask reason, and we never prune when ask itself is launched inside one of
 // those workspaces.
 func pruneWorktrees() {
-	cwd := getwdOrEmpty()
-	backend := worktreeBackendAt(cwd)
-	if backend == workspaceBackendNone {
+	pruneWorktreesAt(getwdOrEmpty())
+}
+
+// pruneWorktreesAt is pruneWorktrees with the repo root injected so tests
+// can drive it against a temp checkout.
+func pruneWorktreesAt(cwd string) {
+	pruneWorktreesWith(cwd, worktreeLocks)
+}
+
+// pruneWorktreesWith is the testable core. locksFn enumerates the lock
+// state of every ask-managed worktree. When it fails — a wedged or
+// timed-out `git worktree list`, or the transient porcelain race where a
+// concurrent ask removes a `locked` file mid-read — we ABORT the entire
+// prune rather than proceed with an incomplete map: treating a worktree as
+// unlocked when it is in fact held by a live ask would `git worktree
+// remove` it out from under that instance. Best-effort cleanup must never
+// risk live state, so an unreadable lock table means "prune nothing."
+func pruneWorktreesWith(cwd string, locksFn func(string) (map[string]string, error)) {
+	if worktreeBackendAt(cwd) == workspaceBackendNone {
 		return
 	}
 	if worktreeNameFromCwd(cwd) != "" {
@@ -251,7 +267,11 @@ func pruneWorktrees() {
 		}
 		return
 	}
-	locks := worktreeLocks(cwd)
+	locks, err := locksFn(cwd)
+	if err != nil {
+		debugLog("worktree prune: cannot read lock state, skipping prune: %v", err)
+		return
+	}
 	for _, e := range entries {
 		if !e.IsDir() {
 			continue
@@ -345,24 +365,22 @@ func worktreeLockReason(locks map[string]string, path string) (string, bool) {
 // Keys come from each backend's native listing — git canonicalizes
 // through symlinks; jj uses paths we constructed ourselves. Use
 // worktreeLockReason for lookups so callers don't have to know which.
-func worktreeLocks(cwd string) map[string]string {
+func worktreeLocks(cwd string) (map[string]string, error) {
 	switch worktreeBackendAt(cwd) {
 	case workspaceBackendGit:
 		return gitWorktreeLocks(cwd)
 	case workspaceBackendJJ:
 		return jjWorktreeLocks(cwd)
 	default:
-		return nil
+		return nil, nil
 	}
 }
 
-func gitWorktreeLocks(cwd string) map[string]string {
-	cmd := exec.Command("git", "worktree", "list", "--porcelain")
-	cmd.Dir = cwd
-	out, err := cmd.Output()
+func gitWorktreeLocks(cwd string) (map[string]string, error) {
+	out, err := vcsOutput(cwd, "git", "worktree", "list", "--porcelain")
 	if err != nil {
 		debugLog("worktree list: %v", err)
-		return nil
+		return nil, err
 	}
 	locks := map[string]string{}
 	var curPath, reason string
@@ -390,16 +408,17 @@ func gitWorktreeLocks(cwd string) map[string]string {
 		}
 	}
 	flush()
-	return locks
+	return locks, nil
 }
 
-func jjWorktreeLocks(cwd string) map[string]string {
+func jjWorktreeLocks(cwd string) (map[string]string, error) {
 	entries, err := os.ReadDir(filepath.Join(cwd, ".claude", "worktrees"))
 	if err != nil {
-		if !os.IsNotExist(err) {
-			debugLog("jj workspace lock readdir: %v", err)
+		if os.IsNotExist(err) {
+			return nil, nil
 		}
-		return nil
+		debugLog("jj workspace lock readdir: %v", err)
+		return nil, err
 	}
 	locks := map[string]string{}
 	for _, e := range entries {
@@ -416,15 +435,13 @@ func jjWorktreeLocks(cwd string) map[string]string {
 		}
 		locks[path] = strings.TrimSpace(string(data))
 	}
-	return locks
+	return locks, nil
 }
 
 func unlockWorktreeAt(cwd, path string) error {
 	switch worktreeBackendAt(cwd) {
 	case workspaceBackendGit:
-		cmd := exec.Command("git", "worktree", "unlock", path)
-		cmd.Dir = cwd
-		if out, err := cmd.CombinedOutput(); err != nil {
+		if out, err := vcsCombined(cwd, "git", "worktree", "unlock", path); err != nil {
 			return fmt.Errorf("git worktree unlock %s: %w (%s)", path, err, bytes.TrimSpace(out))
 		}
 	case workspaceBackendJJ:
@@ -439,22 +456,19 @@ func unlockWorktreeAt(cwd, path string) error {
 func removeWorktreeAt(cwd, name, path string) error {
 	switch worktreeBackendAt(cwd) {
 	case workspaceBackendGit:
-		rm := exec.Command("git", "worktree", "remove", path)
-		rm.Dir = cwd
-		if out, err := rm.CombinedOutput(); err != nil {
+		if out, err := vcsCombined(cwd, "git", "worktree", "remove", path); err != nil {
 			return fmt.Errorf("git worktree remove %s: %w (%s)", path, err, bytes.TrimSpace(out))
 		}
 		debugLog("worktree removed %s", path)
 		branch := "worktree-" + name
-		br := exec.Command("git", "branch", "-d", branch)
-		br.Dir = cwd
-		if out, err := br.CombinedOutput(); err != nil {
+		if out, err := vcsCombined(cwd, "git", "branch", "-d", branch); err != nil {
 			return fmt.Errorf("git branch -d %s: %w (%s)", branch, err, bytes.TrimSpace(out))
 		}
 		debugLog("branch deleted %s", branch)
 		return nil
 	case workspaceBackendJJ:
-		if err := jjWorkspaceUpdateStale(path); err != nil {
+		// Prune runs at startup — bound these so a wedged jj can't hang launch.
+		if err := jjWorkspaceUpdateStale(vcsCombined, path); err != nil {
 			return err
 		}
 		dirty, err := jjWorkspaceHasChanges(path)
@@ -464,14 +478,12 @@ func removeWorktreeAt(cwd, name, path string) error {
 		if dirty {
 			return fmt.Errorf("jj workspace %s has working-copy changes", name)
 		}
-		workspaces, err := jjWorkspaceTargets(cwd)
+		workspaces, err := jjWorkspaceTargets(vcsCombined, cwd)
 		if err != nil {
 			return err
 		}
 		if _, ok := workspaces[name]; ok {
-			cmd := exec.Command("jj", "--ignore-working-copy", "workspace", "forget", name)
-			cmd.Dir = cwd
-			if out, err := cmd.CombinedOutput(); err != nil {
+			if out, err := vcsCombined(cwd, "jj", "--ignore-working-copy", "workspace", "forget", name); err != nil {
 				return fmt.Errorf("jj workspace forget %s: %w\n%s", name, err, bytes.TrimSpace(out))
 			}
 			debugLog("jj workspace forgot %s", name)
@@ -486,10 +498,8 @@ func removeWorktreeAt(cwd, name, path string) error {
 	}
 }
 
-func jjWorkspaceTargets(cwd string) (map[string]string, error) {
-	cmd := exec.Command("jj", "--ignore-working-copy", "workspace", "list", "-T", "name ++ \"|\" ++ target.commit_id() ++ \"\\n\"")
-	cmd.Dir = cwd
-	out, err := cmd.CombinedOutput()
+func jjWorkspaceTargets(run vcsRunner, cwd string) (map[string]string, error) {
+	out, err := run(cwd, "jj", "--ignore-working-copy", "workspace", "list", "-T", "name ++ \"|\" ++ target.commit_id() ++ \"\\n\"")
 	if err != nil {
 		return nil, fmt.Errorf("jj workspace list: %w\n%s", err, bytes.TrimSpace(out))
 	}
@@ -509,19 +519,15 @@ func jjWorkspaceTargets(cwd string) (map[string]string, error) {
 }
 
 func jjWorkspaceHasChanges(path string) (bool, error) {
-	cmd := exec.Command("jj", "diff", "--summary", "--color=never", "--no-pager")
-	cmd.Dir = path
-	out, err := cmd.CombinedOutput()
+	out, err := vcsCombined(path, "jj", "diff", "--summary", "--color=never", "--no-pager")
 	if err != nil {
 		return false, fmt.Errorf("jj diff --summary %s: %w\n%s", path, err, bytes.TrimSpace(out))
 	}
 	return strings.TrimSpace(string(out)) != "", nil
 }
 
-func jjWorkspaceUpdateStale(path string) error {
-	cmd := exec.Command("jj", "workspace", "update-stale")
-	cmd.Dir = path
-	out, err := cmd.CombinedOutput()
+func jjWorkspaceUpdateStale(run vcsRunner, path string) error {
+	out, err := run(path, "jj", "workspace", "update-stale")
 	if err != nil {
 		return fmt.Errorf("jj workspace update-stale %s: %w\n%s", path, err, bytes.TrimSpace(out))
 	}
@@ -747,10 +753,13 @@ func ensureResumeWorktree(resumeCwd string) error {
 		return fmt.Errorf("git worktree add %s: %w\n%s\n%s",
 			resumeCwd, err2, bytes.TrimSpace(out), bytes.TrimSpace(out2))
 	case workspaceBackendJJ:
+		// Resume is a foreground action — leave these unbounded so a
+		// legitimately slow `jj workspace` op is waited out, not aborted at
+		// the startup timeout.
 		if _, err := os.Stat(resumeCwd); err == nil {
-			return jjWorkspaceUpdateStale(resumeCwd)
+			return jjWorkspaceUpdateStale(unboundedVCSCombined, resumeCwd)
 		}
-		workspaces, err := jjWorkspaceTargets(repoRoot)
+		workspaces, err := jjWorkspaceTargets(unboundedVCSCombined, repoRoot)
 		if err != nil {
 			return err
 		}

--- a/worktree_lifecycle_test.go
+++ b/worktree_lifecycle_test.go
@@ -286,7 +286,10 @@ func TestCreateWorktree_LocksItAsOurs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createWorktree: %v", err)
 	}
-	locks := worktreeLocks(dir)
+	locks, err := worktreeLocks(dir)
+	if err != nil {
+		t.Fatalf("worktreeLocks: %v", err)
+	}
 	reason, ok := worktreeLockReason(locks, path)
 	if !ok {
 		t.Fatalf("new worktree should be locked; got locks=%v", locks)

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -364,7 +365,10 @@ func TestCreateExternalWorktree_MakesSiblingAndBranch(t *testing.T) {
 		t.Errorf("expected branch worktree-%s, got:\n%s", name, branches)
 	}
 	// The lock reason should be ours.
-	locks := worktreeLocks(dir)
+	locks, err := worktreeLocks(dir)
+	if err != nil {
+		t.Fatalf("worktreeLocks: %v", err)
+	}
 	reason, ok := worktreeLockReason(locks, path)
 	if !ok {
 		t.Errorf("worktree should be locked after createExternalWorktree; locks=%v", locks)
@@ -530,7 +534,10 @@ func TestWorktreeLocks_ParsesPorcelain(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createExternalWorktree: %v", err)
 	}
-	locks := worktreeLocks(dir)
+	locks, err := worktreeLocks(dir)
+	if err != nil {
+		t.Fatalf("worktreeLocks: %v", err)
+	}
 	if _, ok := worktreeLockReason(locks, path); !ok {
 		t.Errorf("worktreeLocks missing %s; got %v", path, locks)
 	}
@@ -538,6 +545,56 @@ func TestWorktreeLocks_ParsesPorcelain(t *testing.T) {
 	runGit(t, dir, "worktree", "unlock", path)
 	runGit(t, dir, "worktree", "remove", "--force", path)
 	runGit(t, dir, "branch", "-D", "worktree-"+name)
+}
+
+// A wedged or racing `git worktree list` makes worktreeLocks fail; prune
+// must then ABORT rather than treat every worktree as unlocked and reap a
+// live instance's workspace. With a healthy lister the same unlocked
+// worktree is removed, so this isolates the abort-on-error guard.
+func TestPruneWorktrees_AbortsWhenLockListingFails(t *testing.T) {
+	if !gitAvailable() {
+		t.Skip("git not installed")
+	}
+	dir := initGitRepo(t)
+	t.Chdir(dir)
+	path, _, err := createWorktree()
+	if err != nil {
+		t.Fatalf("createWorktree: %v", err)
+	}
+	// Unlock so a healthy prune *would* remove it — the worktree is clean.
+	runGit(t, dir, "worktree", "unlock", path)
+
+	boom := func(string) (map[string]string, error) {
+		return nil, errors.New("git worktree list failed")
+	}
+	pruneWorktreesWith(dir, boom)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("worktree must survive prune when lock listing fails: %v", err)
+	}
+
+	// A working lister reaps the same unlocked worktree, proving the abort
+	// above was the lock-listing failure and not some unrelated skip.
+	pruneWorktreesWith(dir, worktreeLocks)
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("unlocked worktree should be pruned by a healthy prune: err=%v", err)
+	}
+}
+
+// worktreeLocks surfaces an error (rather than an empty map) when the git
+// query fails, so pruneWorktreesWith can distinguish "no locks" from
+// "couldn't read locks." A `.git` that isn't a real repo makes the
+// porcelain query fail.
+func TestWorktreeLocks_ErrorsOnBrokenRepo(t *testing.T) {
+	if !gitAvailable() {
+		t.Skip("git not installed")
+	}
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	if _, err := worktreeLocks(dir); err == nil {
+		t.Fatal("worktreeLocks should error when the git worktree query fails")
+	}
 }
 
 func TestWorktreeLockReason_DirectHit(t *testing.T) {


### PR DESCRIPTION
## Problem

Launching a second `ask` in a git checkout while another instance is running could hang **blank at launch** — the TUI never drew. `ask` runs `git` subprocesses on its startup path (before `tea.Program.Run`) with **no timeout**:

- `pruneWorktrees` → `git worktree list` / `remove`, `git branch -d`
- the memory-tenant canonicalization in `newTab → setCwd → gitMainRoot` → `git rev-parse --git-common-dir` (runs for *every* git checkout, even with worktree mode and memory both off)

If `git` stalls for any reason — a hung fsmonitor/credential helper, an NFS/Spotlight stall, a lock held by a crashed process — the whole launch blocks forever with no recourse. Reproduced with a wedged `git` on `PATH`: the process sat in `wait4` on `git rev-parse` and never rendered a frame.

## Fix

- **`vcs.go`** — run startup-path git/jj under a bounded helper (`exec.CommandContext` + `vcsCommandTimeout`). On timeout the child's whole **process group** is killed (`Setpgid` + `cmd.Cancel`), so helper grandchildren (credential helper, fsmonitor, hooks) are reaped instead of orphaned. `cmd.WaitDelay` is kept as a backstop: it forces `Output()`/`CombinedOutput()` to return even if a fully daemonized escapee keeps the stdout pipe open.
- Convert `gitMainRoot`/`jjRoot` and every prune-reachable git/jj call to the bounded helper. `git worktree add` / resume (foreground, legitimately slow checkouts) stay **unbounded** by design — the two `jj` helpers shared between prune and `ensureResumeWorktree` take a `vcsRunner`, so the prune path is bounded while the foreground resume path waits the op out (Ctrl-C-able) rather than aborting at the startup timeout.
- **Harden prune** against a transient `git worktree list` failure: it can exit non-zero when a concurrent `ask` removes a `locked` file mid-read. `worktreeLocks` now returns an error and `pruneWorktrees` **aborts** rather than proceeding with an empty lock map — which would treat live worktrees as unlocked and reap them out from under another instance.

## Result

Under a wedged `git`, the TUI now draws within a few seconds — degrading gracefully (prune skipped; memory tenants by the raw path) — instead of hanging forever, and leaves **no orphaned git processes** behind.

## Testing

- `vcs_test.go`: the timeout returns promptly **and** reaps the pipe-holding grandchild (process-group guarantee), plus the success passthrough.
- `worktree_test.go`: prune aborts when lock listing fails (vs. reaping the same worktree under a healthy lister); `worktreeLocks` surfaces an error on a broken repo.
- `go vet ./...` clean; full suite shows no new failures vs. base.
- Reviewed by Codex (GPT-5.5, xhigh); its two findings — process-group reaping and the unbounded-resume `vcsRunner` split — are incorporated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
