### PR TITLE
Add Kimi (Moonshot AI) provider

### DIFF
--- a/config.go
+++ b/config.go
@@ -49,6 +49,7 @@ type askConfig struct {
 	// currently anthropic.
 	Provider  string            `json:"provider,omitempty"`
 	DeepSeek  apiProviderConfig `json:"deepseek,omitempty"`
+	Moonshot  apiProviderConfig `json:"kimi,omitempty"`
 	Anthropic apiProviderConfig `json:"anthropic,omitempty"`
 	OpenAI    apiProviderConfig `json:"openai,omitempty"`
 	UI        uiConfig          `json:"ui,omitempty"`
@@ -572,11 +573,13 @@ type apiProviderConfig struct {
 // suffix is path-compatibility only (unrelated to model versions) and
 // is what the OpenAI-style SDK expects to prefix /chat/completions.
 const deepseekDefaultBaseURL = "https://api.deepseek.com/v1"
+const moonshotDefaultBaseURL = "https://api.moonshot.cn/v1"
 
 // Conventional environment fallbacks consulted when the config field
 // is empty.
 const (
 	deepseekEnvAPIKey  = "DEEPSEEK_API_KEY"
+	moonshotEnvAPIKey  = "MOONSHOT_API_KEY"
 	anthropicEnvAPIKey = "ANTHROPIC_API_KEY"
 	openaiEnvAPIKey    = "OPENAI_API_KEY"
 )
@@ -596,6 +599,10 @@ func resolveDeepSeekAPIKey(c apiProviderConfig) string {
 	return resolveAPIProviderKey(c, deepseekEnvAPIKey)
 }
 
+func resolveKimiAPIKey(c apiProviderConfig) string {
+	return resolveAPIProviderKey(c, moonshotEnvAPIKey)
+}
+
 func resolveAnthropicAPIKey(c apiProviderConfig) string {
 	return resolveAPIProviderKey(c, anthropicEnvAPIKey)
 }
@@ -611,6 +618,15 @@ func resolveDeepSeekBaseURL(c apiProviderConfig) string {
 		return c.BaseURL
 	}
 	return deepseekDefaultBaseURL
+}
+
+// resolveKimiBaseURL returns the configured base URL or the default
+// Moonshot API endpoint when unset.
+func resolveKimiBaseURL(c apiProviderConfig) string {
+	if c.BaseURL != "" {
+		return c.BaseURL
+	}
+	return moonshotDefaultBaseURL
 }
 
 // recentModelRef is one Ctrl+M picker "Recently used" entry.

--- a/kimi.go
+++ b/kimi.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+
+	"charm.land/fantasy"
+	"charm.land/fantasy/providers/openai"
+	"charm.land/fantasy/providers/openaicompat"
+)
+
+const (
+	kimiProviderID             = "kimi"
+	kimiDefaultModel           = "kimi-k2.5"
+	kimiContextWindow          = 128_000
+	kimiFallbackMaxOutputTokens = 32_000
+)
+
+var kimiModelOptions = []string{"kimi-k2.5", "kimi-k2-thinking"}
+
+var kimiEffortOptions = []string{"off", "high"}
+
+// kimiLanguageModel builds the fantasy LanguageModel for one session.
+// Swappable in tests so StartSession can run against a fake model with
+// zero network.
+var kimiLanguageModel = func(cfg apiProviderConfig, modelID string) (fantasy.LanguageModel, error) {
+	key := resolveKimiAPIKey(cfg)
+	if key == "" {
+		return nil, missingAPIKeyError(moonshotEnvAPIKey)
+	}
+	provider, err := openaicompat.New(
+		openaicompat.WithName(kimiProviderID),
+		openaicompat.WithBaseURL(resolveKimiBaseURL(cfg)),
+		openaicompat.WithAPIKey(key),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return provider.LanguageModel(context.Background(), modelID)
+}
+
+// kimiProviderOptions translates ask's effort picker onto the wire
+// controls. Kimi supports thinking on/off via the same openaicompat
+// pattern as DeepSeek: "off" disables thinking, "high" engages it.
+func kimiProviderOptions(effort string) (fantasy.ProviderOptions, *float64) {
+	opts := &openaicompat.ProviderOptions{}
+	var temperature *float64
+	switch effort {
+	case "off":
+		opts.ExtraBody = map[string]any{"thinking": map[string]any{"type": "disabled"}}
+		t := 0.0
+		temperature = &t
+	default: // "high" and unset both ride the default thinking mode
+		e := openai.ReasoningEffortHigh
+		opts.ReasoningEffort = &e
+	}
+	return fantasy.ProviderOptions{kimiProviderID: opts}, temperature
+}
+
+var kimiSpec = agentProviderSpec{
+	id:            kimiProviderID,
+	displayName:   "Kimi",
+	defaultModel:  kimiDefaultModel,
+	modelOptions:  kimiModelOptions,
+	effortOptions: kimiEffortOptions,
+	buildModel: func(cfg askConfig, modelID string) (fantasy.LanguageModel, error) {
+		return kimiLanguageModel(cfg.Moonshot, modelID)
+	},
+	callOptions: func(_, effort string) (fantasy.ProviderOptions, *float64) {
+		return kimiProviderOptions(effort)
+	},
+	// kimi-k2.5 supports vision; kimi-k2-thinking does not.
+	supportsImages: func(modelID string) bool { return modelID != "kimi-k2-thinking" },
+	contextWindow:  func(string) int64 { return kimiContextWindow },
+	maxOutputTokens: func(string) int64 {
+		return kimiFallbackMaxOutputTokens
+	},
+	loadSettings: func(cfg askConfig) ProviderSettings {
+		return ProviderSettings{
+			Model:         cfg.Moonshot.Model,
+			Effort:        cfg.Moonshot.Effort,
+			SlashCommands: cfg.Moonshot.SlashCommands,
+		}
+	},
+	saveSettings: func(cfg *askConfig, s ProviderSettings) {
+		cfg.Moonshot.Model = s.Model
+		cfg.Moonshot.Effort = s.Effort
+		cfg.Moonshot.SlashCommands = s.SlashCommands
+	},
+}
+
+func kimiAgentProvider() agentAPIProvider { return agentAPIProvider{spec: &kimiSpec} }
+
+func kimiStore() *agentSessionStore {
+	return &agentSessionStore{provider: kimiProviderID}
+}

--- a/kimi_test.go
+++ b/kimi_test.go
@@ -1,0 +1,338 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/fantasy"
+	"charm.land/fantasy/providers/openaicompat"
+)
+
+func swapKimiLM(t *testing.T, lm fantasy.LanguageModel) {
+	t.Helper()
+	prev := kimiLanguageModel
+	kimiLanguageModel = func(apiProviderConfig, string) (fantasy.LanguageModel, error) {
+		return lm, nil
+	}
+	t.Cleanup(func() { kimiLanguageModel = prev })
+}
+
+func TestKimiProvider_Metadata(t *testing.T) {
+	p := kimiAgentProvider()
+	if p.ID() != "kimi" || p.DisplayName() != "Kimi" {
+		t.Errorf("identity wrong: %q %q", p.ID(), p.DisplayName())
+	}
+	caps := p.Capabilities()
+	if !caps.Resume || !caps.ModelPicker || !caps.EffortPicker {
+		t.Errorf("capabilities wrong: %+v", caps)
+	}
+	if caps.AskUserQuestionMCP || caps.PermissionPromptMCP {
+		t.Errorf("MCP redirect capabilities must be off (native tools): %+v", caps)
+	}
+	picker := p.ModelPicker()
+	if len(picker.Options) != 2 || picker.Options[0] != "kimi-k2.5" || !picker.AllowCustom {
+		t.Errorf("model picker wrong: %+v", picker)
+	}
+	if efforts := p.EffortOptions(); len(efforts) != 2 || efforts[0] != "off" {
+		t.Errorf("effort options wrong: %v", efforts)
+	}
+	if id := p.PreMintSessionID(ProviderSessionArgs{}); id == "" {
+		t.Error("kimi must pre-mint session ids")
+	}
+
+	// Registered and addressable for workflow steps.
+	got, ok := providerByIDStrict("kimi")
+	if !ok || got.ID() != "kimi" {
+		t.Fatal("kimi must be in the provider registry")
+	}
+	if err := validateProviderID("kimi"); err != nil {
+		t.Errorf("workflow provider validation must accept kimi: %v", err)
+	}
+}
+
+func TestKimiProvider_SettingsRoundTrip(t *testing.T) {
+	isolateHome(t)
+	p := kimiAgentProvider()
+	if s := p.LoadSettings(); s.Model != "" || s.Effort != "" {
+		t.Errorf("fresh settings must be zero: %+v", s)
+	}
+	want := ProviderSettings{Model: "kimi-k2-thinking", Effort: "high",
+		SlashCommands: []providerSlashEntry{{Name: "x", Description: "y"}}}
+	if err := p.SaveSettings(want); err != nil {
+		t.Fatalf("SaveSettings: %v", err)
+	}
+	got := p.LoadSettings()
+	if got.Model != want.Model || got.Effort != want.Effort || len(got.SlashCommands) != 1 {
+		t.Errorf("settings lost: %+v", got)
+	}
+}
+
+func TestKimiProviderOptions(t *testing.T) {
+	opts, temp := kimiProviderOptions("off")
+	ds := opts["kimi"].(*openaicompat.ProviderOptions)
+	if ds.ExtraBody == nil || temp == nil || *temp != 0.0 {
+		t.Errorf("off must disable thinking and pin temperature 0: %+v temp=%v", ds, temp)
+	}
+	thinking, _ := ds.ExtraBody["thinking"].(map[string]any)
+	if thinking["type"] != "disabled" {
+		t.Errorf("thinking extra_body wrong: %+v", ds.ExtraBody)
+	}
+
+	opts, temp = kimiProviderOptions("high")
+	ds = opts["kimi"].(*openaicompat.ProviderOptions)
+	if ds.ReasoningEffort == nil || string(*ds.ReasoningEffort) != "high" || temp != nil {
+		t.Errorf("high mapping wrong: %+v temp=%v", ds, temp)
+	}
+
+	opts, temp = kimiProviderOptions("")
+	ds = opts["kimi"].(*openaicompat.ProviderOptions)
+	if ds.ReasoningEffort == nil || string(*ds.ReasoningEffort) != "high" || temp != nil {
+		t.Errorf("default effort must be high thinking: %+v", ds)
+	}
+}
+
+func TestKimiProvider_NoAPIKeyFailsFast(t *testing.T) {
+	isolateHome(t)
+	t.Setenv(moonshotEnvAPIKey, "")
+	p := kimiAgentProvider()
+	_, _, err := p.StartSession(ProviderSessionArgs{Cwd: t.TempDir(), NewSessionID: "s1"})
+	if err == nil {
+		t.Fatal("StartSession without a key must fail")
+	}
+	if !strings.Contains(err.Error(), "model picker") || !strings.Contains(err.Error(), moonshotEnvAPIKey) {
+		t.Errorf("error must point at both config and env: %v", err)
+	}
+}
+
+func TestKimiProvider_SessionLifecycle(t *testing.T) {
+	isolateHome(t)
+	stubGitStatus(t, "")
+	lm := &fakeLM{turns: [][]fantasy.StreamPart{
+		textTurn("answer one", fantasy.Usage{InputTokens: 10}),
+	}}
+	swapKimiLM(t, lm)
+
+	p := kimiAgentProvider()
+	cwd := t.TempDir()
+	args := ProviderSessionArgs{Cwd: cwd, TabID: 4, NewSessionID: "ses-lifecycle", SkipAllPermissions: true}
+	proc, ch, err := p.StartSession(args)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	if proc.cmd != nil {
+		t.Error("in-process provider must not carry an exec.Cmd")
+	}
+	if p.NativeSessionID(proc) != "" {
+		t.Error("pre-minting provider must return empty NativeSessionID")
+	}
+
+	if err := p.Send(proc, "question", nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	msgs := readSessionMsgs(t, ch, isTurnComplete)
+	var done providerDoneMsg
+	var usage *usageMsg
+	for _, m := range msgs {
+		switch v := m.(type) {
+		case providerDoneMsg:
+			done = v
+		case usageMsg:
+			u := v
+			usage = &u
+		}
+	}
+	if done.res.SessionID != "ses-lifecycle" || done.res.Result != "answer one" {
+		t.Errorf("done msg wrong: %+v", done.res)
+	}
+	// Kimi has no catalog pricing data, so usageMsg never has costKnown.
+	if usage == nil || usage.costKnown {
+		t.Errorf("usageMsg must exist and be cost-unknown: %+v", usage)
+	}
+
+	// The system prompt reached the wire as the first message.
+	calls := lm.streamCalls()
+	if len(calls) == 0 || calls[0].Prompt[0].Role != fantasy.MessageRoleSystem {
+		t.Fatal("first wire message must be the system prompt")
+	}
+	if sys := messageText(calls[0].Prompt[0]); !strings.Contains(sys, "<critical_rules>") ||
+		!strings.Contains(sys, "super human speeds") {
+		t.Error("system prompt must include coder rules and ask steering")
+	}
+	// Kimi always uses the fallback max output tokens.
+	if want := kimiSpec.maxOutputTokens("kimi-k2.5"); calls[0].MaxOutputTokens == nil ||
+		*calls[0].MaxOutputTokens != want {
+		t.Errorf("wire MaxOutputTokens = %v want %d", calls[0].MaxOutputTokens, want)
+	}
+
+	// Idle interrupt reports unhandled → killProc fallback path.
+	if handled, _ := p.Interrupt(proc); handled {
+		t.Error("idle interrupt must report handled=false")
+	}
+
+	// Session persisted → listable and resumable.
+	sessions, err := p.ListSessions(cwd)
+	if err != nil || len(sessions) != 1 || sessions[0].id != "ses-lifecycle" {
+		t.Fatalf("ListSessions: %v %+v", err, sessions)
+	}
+	if sessions[0].preview != "question" {
+		t.Errorf("preview %q", sessions[0].preview)
+	}
+	entries, err := p.LoadHistory("ses-lifecycle", HistoryOpts{ToolOutput: toolOutputFull})
+	if err != nil || len(entries) != 2 {
+		t.Fatalf("LoadHistory: %v %+v", err, entries)
+	}
+
+	// Teardown: kill → providerExitedMsg then channel close.
+	proc.kill()
+	sawExit := false
+	for m := range ch {
+		if _, ok := m.(providerExitedMsg); ok {
+			sawExit = true
+		}
+	}
+	if !sawExit {
+		t.Error("kill must produce providerExitedMsg")
+	}
+
+	// Resume restores the transcript into a fresh session.
+	lm2 := &fakeLM{turns: [][]fantasy.StreamPart{
+		textTurn("answer two", fantasy.Usage{}),
+	}}
+	swapKimiLM(t, lm2)
+	proc2, ch2, err := p.StartSession(ProviderSessionArgs{
+		Cwd: cwd, TabID: 4, SessionID: "ses-lifecycle", SkipAllPermissions: true,
+	})
+	if err != nil {
+		t.Fatalf("resume StartSession: %v", err)
+	}
+	defer func() { proc2.kill(); drainProviderStream(ch2) }()
+	if err := p.Send(proc2, "follow-up", nil); err != nil {
+		t.Fatal(err)
+	}
+	readSessionMsgs(t, ch2, isTurnComplete)
+	wire := lm2.streamCalls()[0].Prompt
+	var sawPriorTurn bool
+	for _, m := range wire {
+		if m.Role == fantasy.MessageRoleUser && strings.Contains(messageText(m), "question") {
+			sawPriorTurn = true
+		}
+	}
+	if !sawPriorTurn {
+		t.Error("resumed session must replay prior turns on the wire")
+	}
+}
+
+func TestKimiProvider_ResumeUnknownSessionErrors(t *testing.T) {
+	isolateHome(t)
+	swapKimiLM(t, &fakeLM{})
+	p := kimiAgentProvider()
+	if _, _, err := p.StartSession(ProviderSessionArgs{Cwd: t.TempDir(), SessionID: "missing"}); err == nil {
+		t.Fatal("resuming an unknown session must fail")
+	}
+}
+
+func TestKimiProvider_MaterializeRoundTrip(t *testing.T) {
+	isolateHome(t)
+	p := kimiAgentProvider()
+	workspace := t.TempDir()
+	id, cwd, err := p.Materialize(workspace, []NeutralTurn{
+		{Role: "user", Text: "ported question"},
+		{Role: "assistant", Text: "ported answer"},
+	})
+	if err != nil || id == "" || cwd != workspace {
+		t.Fatalf("Materialize: id=%q cwd=%q err=%v", id, cwd, err)
+	}
+	entries, err := p.LoadHistory(id, HistoryOpts{})
+	if err != nil || len(entries) != 2 {
+		t.Fatalf("materialized history: %v %+v", err, entries)
+	}
+	if entries[0].kind != histUser || entries[1].kind != histResponse {
+		t.Errorf("materialized entry kinds wrong: %+v", entries)
+	}
+}
+
+// Guard: the fake home isolation used above must keep agent sessions
+// out of the real home. (Defensive — isolateHome already pins $HOME.)
+func TestKimiStoreUsesHome(t *testing.T) {
+	home := isolateHome(t)
+	st := kimiStore()
+	root, err := st.root()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(root, home) {
+		t.Errorf("store root %q must live under isolated home %q", root, home)
+	}
+}
+
+func TestKimiMaxOutputTokens(t *testing.T) {
+	if got := kimiSpec.maxOutputTokens("kimi-k2.5"); got != kimiFallbackMaxOutputTokens {
+		t.Errorf("kimi-k2.5 budget = %d want %d", got, kimiFallbackMaxOutputTokens)
+	}
+	if got := kimiSpec.maxOutputTokens("kimi-k2-thinking"); got != kimiFallbackMaxOutputTokens {
+		t.Errorf("kimi-k2-thinking budget = %d want %d", got, kimiFallbackMaxOutputTokens)
+	}
+	if got := kimiSpec.maxOutputTokens("custom-model"); got != kimiFallbackMaxOutputTokens {
+		t.Errorf("unknown model must use the fallback budget: %d", got)
+	}
+}
+
+func TestKimiSupportsImages(t *testing.T) {
+	// kimi-k2.5 supports vision.
+	if !kimiSpec.supportsImages("kimi-k2.5") {
+		t.Error("kimi-k2.5 must support images")
+	}
+	// kimi-k2-thinking does not support vision.
+	if kimiSpec.supportsImages("kimi-k2-thinking") {
+		t.Error("kimi-k2-thinking must NOT support images")
+	}
+	// Unknown models fall back to true.
+	if !kimiSpec.supportsImages("unknown-model") {
+		t.Error("unknown model should default to image-capable")
+	}
+}
+
+func TestKimiProvider_K2ThinkingRejectsImages(t *testing.T) {
+	isolateHome(t)
+	stubGitStatus(t, "")
+	lm := &fakeLM{turns: [][]fantasy.StreamPart{
+		textTurn("answer", fantasy.Usage{}),
+	}}
+	swapKimiLM(t, lm)
+
+	p := kimiAgentProvider()
+	args := ProviderSessionArgs{
+		Cwd: t.TempDir(), NewSessionID: "ses-think", SkipAllPermissions: true,
+		Model: "kimi-k2-thinking",
+	}
+	proc, ch, err := p.StartSession(args)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	defer func() { proc.kill(); drainProviderStream(ch) }()
+
+	// kimi-k2-thinking must reject images.
+	if err := p.Send(proc, "look", []pendingAttachment{{mime: "image/png"}}); err == nil ||
+		!strings.Contains(err.Error(), "image") {
+		t.Errorf("kimi-k2-thinking must reject images: %v", err)
+	}
+}
+
+func TestModelContextLimit_Kimi(t *testing.T) {
+	if got := modelContextLimit("kimi-k2.5"); got != kimiContextWindow {
+		t.Errorf("kimi-k2.5 limit = %d want %d", got, kimiContextWindow)
+	}
+	if got := modelContextLimit("kimi-k2-thinking"); got != kimiContextWindow {
+		t.Errorf("kimi-k2-thinking limit = %d want %d", got, kimiContextWindow)
+	}
+	// Guard: other providers still resolve correctly.
+	if got := modelContextLimit("opus[1m]"); got != 1_000_000 {
+		t.Errorf("claude 1m tier broken by kimi case: %d", got)
+	}
+	if got := modelContextLimit("sonnet"); got != 200_000 {
+		t.Errorf("claude default tier broken: %d", got)
+	}
+	if got := modelContextLimit("deepseek-v4-pro"); got != deepseekContextWindow {
+		t.Errorf("deepseek limit broken: %d", got)
+	}
+}

--- a/model_picker.go
+++ b/model_picker.go
@@ -41,6 +41,8 @@ var providerKeySpecs = []providerKeySpec{
 		func(c *askConfig) *apiProviderConfig { return &c.OpenAI }},
 	{deepseekProviderID, "DeepSeek", deepseekEnvAPIKey,
 		func(c *askConfig) *apiProviderConfig { return &c.DeepSeek }},
+	{kimiProviderID, "Kimi (Moonshot)", moonshotEnvAPIKey,
+		func(c *askConfig) *apiProviderConfig { return &c.Moonshot }},
 }
 
 func providerKeySpecByID(id string) (providerKeySpec, bool) {

--- a/provider.go
+++ b/provider.go
@@ -353,6 +353,7 @@ func init() {
 	registerProvider(anthropicAgentProvider())
 	registerProvider(openaiAgentProvider())
 	registerProvider(deepseekAgentProvider())
+	registerProvider(kimiAgentProvider())
 }
 
 // providerByID returns the provider with the given ID, or the first

--- a/usage.go
+++ b/usage.go
@@ -17,6 +17,9 @@ func modelContextLimit(model string) int {
 	if strings.HasPrefix(lower, "deepseek") {
 		return deepseekContextWindow
 	}
+	if strings.HasPrefix(lower, "kimi") {
+		return kimiContextWindow
+	}
 	if m, ok := catalogModel(catwalk.InferenceProviderAnthropic, model); ok && m.ContextWindow > 0 {
 		return int(m.ContextWindow)
 	}


### PR DESCRIPTION
## Summary

Adds support for the **Kimi API** from **Moonshot AI** as a new in-process provider in ask. Kimi uses the OpenAI-compatible protocol — the same pattern as the existing DeepSeek provider.

## What was done

### New provider (`kimi.go`)
- **Provider ID**: `kimi`, display name `Kimi`
- **Default model**: `kimi-k2.5` (128K context, vision support, function calling)
- **Reasoning model**: `kimi-k2-thinking` (effort-aware reasoning, no vision)
- **Effort mapping**: `off` → thinking disabled, `high` → `reasoning_effort` high (default)
- **Base URL**: `https://api.moonshot.cn/v1` (configurable via `cfg.Moonshot.BaseURL`)
- **API key**: `MOONSHOT_API_KEY` environment variable or config field
- **Context window**: 128,000 tokens (hardcoded; Moonshot is not in the embedded catwalk catalog)
- **Cost metering**: Unpriced (`costKnown=false`) — no catalog pricing data for native Moonshot endpoint models
- **Friendly names**: Fall through to `humanizeModelID` producing "Kimi K2.5" / "Kimi K2 Thinking"

### Tests (`kimi_test.go`)
12 tests covering:
- Provider metadata, registration, and model-picker surface
- Settings round-trip persistence
- Effort→wire mapping (`off` sends `thinking: disabled` extra body; `high` sends `reasoning_effort: high`)
- No-API-key fast-fail with descriptive error
- Full session lifecycle against `fakeLM` (send, system prompt on wire, image handling, interrupt)
- Resume unknown session errors
- Materialize round-trip
- Store home-directory isolation
- Max output tokens (always 32K fallback)
- Per-model image support (k2.5: yes; k2-thinking: no)
- `modelContextLimit` prefix check + cross-provider guard

### Config (`config.go`)
- `Moonshot apiProviderConfig` field (JSON key `kimi`)
- `MOONSHOT_API_KEY` env var constant
- `https://api.moonshot.cn/v1` default base URL constant
- `resolveKimiAPIKey` / `resolveKimiBaseURL` resolver functions

### Registration (`provider.go`)
- `registerProvider(kimiAgentProvider())` in `init()`

### Model picker (`model_picker.go`)
- Kimi entry in `providerKeySpecs` so Ctrl+M shows "Kimi (Moonshot)" and prompts for the API key if missing

### Context limit (`usage.go`)
- `kimi` prefix in `modelContextLimit` returns 128K

## Why

Kimi is Moonshot AI's flagship LLM API with strong reasoning capabilities (kimi-k2.5 and kimi-k2-thinking). It's OpenAI-compatible, so the integration follows exactly the same pattern as DeepSeek — a single provider spec file, a test file matching the same coverage surface, and three small edits to registration/config/picker plumbing.

## Verification

```
go build ./...   → clean
go vet ./...     → clean  
go test ./...    → ok (all 12 Kimi tests pass, zero regressions)
```