### PR TITLE
Remove bottom bar tab system, keep only right sidebar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,8 +84,8 @@ One `package main`, one file per concern.
 | `mcp_servers.go`       | User-facing MCP server config: `mcpServers` maps (user-global + per-project) merged over project-root `.mcp.json` (claude-code convention), `${VAR}`/`${VAR:-default}` expansion, per-server type inference, timeout, enabled/disabled tool filters, Disabled tombstones. |
 | `mcp_oauth.go`         | OAuth for remote MCP servers (`oauth: true`): SDK authorization-code + PKCE + dynamic client registration, browser launch via swappable `mcpOAuthOpenBrowser`, one-shot loopback callback listener, tokens persisted 0600 under `~/.config/ask/mcp-oauth/` (valid stored tokens skip the browser; expiry re-runs the flow). |
 | `model_picker.go`      | Ctrl+M unified model picker (crush-style): search input, “Recently used” group first (`cfg.RecentModels`, capped push-front), then one section per provider with human-friendly catwalk names; ↑/↓ skip headers, Enter applies the pick to the current tab and persists it as the provider default model (`applyProviderModelSwitch` + `applyVSProviderSwap`; cfg.Provider untouched). Picking a model whose provider has no key drops into an inline API-key prompt (`providerKeySpecs`) that saves to ask.json and proceeds; per-provider “Enter your own…” rows cover custom ids. Replaced the old Ctrl+B switcher AND the `/config` per-provider key sub-pickers AND the `/model` and `/provider` slash commands. |
-| `sidebar.go`           | Sidebar tab mode (cfg.UI.TabMode == "sidebar"): right-hand column of per-tab task cards (title / provider·model / session $ spend / live activity + ⚠✓✗● badges), ~1/5 width clamped to [30,48], degrade to the bottom bar below 90 total cols. The list cursor IS `app.active` — zero view-local selection state. Focus model: `ActionSidebarFocus` (Tab) swaps input↔list when the tab has no local Tab use (`model.wantsTabKey`), Up/Down/j/k switch tabs live (no Enter), any printable rune bounces focus back into the input and types, Ctrl+Up/Down (`ActionTabPrevAlt`/`NextAlt`) switch from anywhere, click on a card switches. Activity line prefers the agent's in_progress todo over `m.status`. See "Sidebar tab mode" below. |
-| `tab_title.go`         | Tab titles for the sidebar cards: seeded instantly from the first user prompt (`fallbackTabTitle`), refined async by a one-shot fantasy LLM call (`generateTabTitleText`, swappable; crush session-title pattern, 30s timeout) → `tabTitleMsg`, persisted on `VirtualSession.Title` (backfilled by `recordVirtualSession` when the title lands before the VS exists) and rehydrated on /resume. Generation is gated on sidebar mode so bar-mode users never pay for the call. |
+| `sidebar.go`           | Right-hand column of per-tab task cards (title / provider·model / session $ spend / live activity + ⚠✓✗● badges), ~1/5 width clamped to [30,48]. The sidebar is the only tab mode (the bottom bar has been removed). The list cursor IS `app.active` — zero view-local selection state. Focus model: `ActionSidebarFocus` (Tab) swaps input↔list when the tab has no local Tab use (`model.wantsTabKey`), Up/Down/j/k switch tabs live (no Enter), any printable rune bounces focus back into the input and types, Ctrl+Up/Down (`ActionTabPrevAlt`/`NextAlt`) switch from anywhere, click on a card switches. Activity line prefers the agent's in_progress todo over `m.status`. |
+| `tab_title.go`         | Tab titles for the sidebar cards: seeded instantly from the first user prompt (`fallbackTabTitle`), refined async by a one-shot fantasy LLM call (`generateTabTitleText`, swappable; crush session-title pattern, 30s timeout) → `tabTitleMsg`, persisted on `VirtualSession.Title` (backfilled by `recordVirtualSession` when the title lands before the VS exists) and rehydrated on /resume. Generation always runs since the sidebar is the only tab mode. |
 | `commands.go`          | `cd` / `ls` handlers and `ls` formatting.                               |
 | `paths.go`             | Path picker state, tilde expansion, completion.                         |
 | `shell.go`             | Shell-mode execution: `$SHELL -c` fork, stdout/stderr pipe streaming, 100-line cap, cwd capture via `pwd > tmpfile`, pgroup SIGKILL on cancel. |
@@ -143,8 +143,8 @@ exercised by the user; code alone won't catch layout regressions.
 | `keymap_test.go`           | `ParseKeyBinding` / `KeyBinding.String` round-trip, default keymap coverage, load-from-config (unknown/malformed entries skipped, empty-string unbinds), `currentKeyMap` invalidation. |
 | `keymap_dispatch_test.go`  | End-to-end: overridden keymap rewires `tabs.go` tab navigation; `/config → Keybindings` capture persists to disk and re-binding to default deletes the entry. |
 | `config_websearch_test.go` | `/config → Web Search` picker — Global row presence, open/edit/commit (Brave key persisted to `cfg.WebSearch.BraveAPIKey`), paste accumulation, masked summary, clear-to-empty, Esc close. |
-| `sidebar_test.go`          | Sidebar mode — tabMode parse, geometry (1/5 clamp, degrade threshold, zero bar height), scroll-window/card hit-testing, key routing (Tab focus + completion non-theft, Up/Down switch, type-to-return, Esc, Ctrl+Up/Down both modes), focus-steal suppression (sidebar) vs focus-steal (bar), card title/meta/cost/activity/badge derivation, view composition + `joinBodySidebar`/`clipText`, tabModeChangedMsg propagation, workflow supplant (snapshot, tracker, busy refusal, bar-mode fallback to dedicated tab) and Enter-restore (incl. still-running and dedicated-tab guards). |
-| `tab_title_test.go`        | Tab titles — fallback/sanitize (think-tag strip, quote/period trim, clip), `maybeStartTabTitle` gating (bar mode / workflow tab / blank / already titled), swapped-generator cmd round-trip incl. error swallow, `tabTitleMsg` handler (foreign tab, empty title, stale-after-/new), VS persistence + `recordVirtualSession` backfill + /resume rehydration (Title, Preview fallback). |
+| `sidebar_test.go`          | Sidebar — geometry (1/5 clamp), scroll-window/card hit-testing, key routing (Tab focus + completion non-theft, Up/Down switch, type-to-return, Esc, Ctrl+Up/Down both modes), focus-steal suppression, card title/meta/cost/activity/badge derivation, view composition + `joinBodySidebar`/`clipText`, workflow supplant (snapshot, tracker, busy refusal) and Enter-restore. |
+| `tab_title_test.go`        | Tab titles — fallback/sanitize (think-tag strip, quote/period trim, clip), `maybeStartTabTitle` gating (workflow tab / blank / already titled), swapped-generator cmd round-trip incl. error swallow, `tabTitleMsg` handler (foreign tab, empty title, stale-after-/new), VS persistence + `recordVirtualSession` backfill + /resume rehydration (Title, Preview fallback). |
 | `deepseek_test.go`         | Provider metadata/registry/workflow validation, effort→wire mapping, no-key fail-fast, full session lifecycle against `fakeLM` (send, system prompt on wire, kill/exited, resume replays transcript), Materialize, `modelContextLimit`. |
 | `agent_run_test.go`        | `fakeLM` (scripted `StreamPart`s) + runtime scenarios: text turn protocol order (done before complete), tool round-trip incl. wire history threading, interrupt = clean end, error turn, shutdown, loop-detection trip, compaction (summary head + auto-continuation), dangling-call repair, task sub-agent tool. |
 | `agent_tools_test.go`      | Tool behaviors on `t.TempDir()`: read windows/caps/rejections, write/edit guards (read-before-mutate, stale mtime, uniqueness, replace_all, CRLF), glob/grep/ls, bash via swapped `agentRunShell` (output, exit codes, cancel-kills-pgroup, background jobs), approval denials (`StopTurn`), fetch via httptest, Brave `web_search` (no-key notice, empty-query reject, token/query/count headers + config-beats-env via swapped `braveSearchClient`, HTML-stripped results, HTTP-error result, approval `StopTurn`), todos validation, the two-stage workflow guard (todos-only: fire/disarm-by-check/disarm-by-run/inert), the require-todos-before-mutate gate (edit + write refused until a todos list applies, then it lands; fires in workflow-less projects too), required description-phrase schema across the coding core. |
@@ -577,12 +577,9 @@ run finalises (or the tab closes), the lock releases.
 
 ## Sidebar tab mode
 
-`cfg.UI.TabMode` (`/config → Global Options → Tab Mode`) selects how
-tabs present: `"bar"` (default, the bottom strip) or `"sidebar"` — a
-permanent right-hand column owned by the app layer (`sidebar.go`).
-Width is ~1/5 of the terminal clamped to [30,48] cols; below 90 total
-cols rendering silently degrades to the bar (behaviour like workflow
-supplanting still follows the *mode*, not the width). The column is a
+The sidebar is the only tab mode (the bottom bar has been removed).
+It is a permanent right-hand column owned by the app layer (`sidebar.go`).
+Width is ~1/5 of the terminal clamped to [30,48] cols. The column is a
 pure projection of `a.tabs`: the selection cursor IS `app.active`, the
 scroll offset is derived, and every card reads live model state
 (title, provider/model, accumulated session spend in USD, in_progress
@@ -596,10 +593,7 @@ compaction summarizer (`costMsg`), and the tab-title call
 (`tabTitleMsg`). Unpriceable models (custom ids / no catalog) render
 an empty row, never a fake $0.00; the meter resets with the
 conversation (/new, /clear, /resume pick, cross-provider swap) and
-survives same-provider model swaps. `app.tabMode` mirrors the config (seeded by `newApp` from the
-first tab, refreshed on `openTab` reloads and `tabModeChangedMsg`
-broadcasts from the /config toggle, which also refresh each tab's
-`m.sidebarMode`).
+survives same-provider model swaps.
 
 Keyboard: `ActionSidebarFocus` (default Tab) swaps focus between the
 typing area and the list — intercepted at the app layer only when the
@@ -610,12 +604,10 @@ j/k) switch the active tab immediately — no Enter — typing any
 printable rune bounces focus back into the input and types it, Esc /
 Enter / Tab return, Ctrl+D closes the selected tab, everything else is
 absorbed. `ActionTabPrevAlt`/`ActionTabNextAlt` (Ctrl+Up/Down) switch
-tabs from anywhere in both modes. Mouse clicks on a card switch to it;
-wheel events over the column are absorbed.
+tabs from anywhere. Mouse clicks on a card switch to it; wheel events
+over the column are absorbed.
 
-Behavioural changes while the mode is on:
-
-- **No focus theft.** `dispatchByTabID` no longer force-focuses a tab
+- **No focus theft.** `dispatchByTabID` never force-focuses a tab
   whose ask/approval modal fires — the request parks on the tab's
   modal state and the card shows the ⚠ badge until the user switches.
 - **Workflows supplant instead of spawning.** `spawnWorkflowTabMsg`
@@ -625,10 +617,11 @@ Behavioural changes while the mode is on:
   the tab flips to the read-only banner, and when the chain finishes
   Enter restores the conversation (`restoreSupplantedTab`) with the
   step summaries left in the transcript. Closing the tab mid-run still
-  marks the run failed. Bar mode keeps the dedicated-tab behaviour.
+  marks the run failed.
 - **Tab titles.** The first prompt seeds `m.tabTitle` instantly and a
   one-shot LLM call (`tab_title.go`) refines it in the background;
   titles persist on the VirtualSession and rehydrate on /resume.
+
 
 ## In-process API providers (fantasy agents)
 

--- a/config.go
+++ b/config.go
@@ -715,29 +715,6 @@ type uiConfig struct {
 	SkipAllPermissions *bool  `json:"skipAllPermissions,omitempty"`
 	Worktree           *bool  `json:"worktree,omitempty"`
 	Theme              string `json:"theme,omitempty"`
-	// TabMode selects how open tabs are presented: "bar" (default —
-	// the single-row strip along the bottom) or "sidebar" (a
-	// permanent right-hand column of task cards; see sidebar.go).
-	// A string enum rather than a bool so future modes (left
-	// sidebar, auto) are a new value, not a config migration.
-	TabMode string `json:"tabMode,omitempty"`
-}
-
-// Tab presentation modes for uiConfig.TabMode. The empty string
-// normalises to bar so pre-sidebar configs keep working unchanged.
-const (
-	tabModeBar     = "bar"
-	tabModeSidebar = "sidebar"
-)
-
-// parseTabMode normalises the persisted TabMode string. Anything that
-// isn't exactly "sidebar" — including the empty default and future
-// typos — is the classic bottom bar.
-func parseTabMode(s string) string {
-	if s == tabModeSidebar {
-		return tabModeSidebar
-	}
-	return tabModeBar
 }
 
 func configPath() (string, error) {

--- a/config_modal.go
+++ b/config_modal.go
@@ -86,7 +86,6 @@ func (m model) globalConfigItems() []configItem {
 		{"Tool Output", toolOut, "toolOutput"},
 		{"Skip All Permissions", skipPerms, "skipAllPermissions"},
 		{"Worktree", worktree, "worktree"},
-		{"Tab Mode", tabModeValue(m.sidebarMode), "tabMode"},
 		{"Theme", m.themeName, "theme"},
 		{"Default Provider", provName, "provider"},
 		{"Memory...", mem, "memory"},
@@ -94,15 +93,6 @@ func (m model) globalConfigItems() []configItem {
 		{"Keybindings...", "", "keybindings"},
 	}
 	return items
-}
-
-// tabModeValue renders the Tab Mode row's value column from the
-// model's live mirror so the row flips immediately on toggle.
-func tabModeValue(sidebar bool) string {
-	if sidebar {
-		return tabModeSidebar
-	}
-	return tabModeBar
 }
 
 func (m model) refreshHistoryCmd() tea.Cmd {
@@ -370,24 +360,6 @@ func (m model) handleGlobalConfigEnter(itemID string) (tea.Model, tea.Cmd) {
 		}
 		m.killProc()
 		return m, nil
-	case "tabMode":
-		m.sidebarMode = !m.sidebarMode
-		mode := tabModeBar
-		if m.sidebarMode {
-			mode = tabModeSidebar
-		}
-		if err := withConfigLock(func() error {
-			cfg, _ := loadConfig()
-			cfg.UI.TabMode = mode
-			return saveConfig(cfg)
-		}); err != nil {
-			debugLog("saveConfig err: %v", err)
-		}
-		// The app layer owns sidebar layout; broadcast so it (and
-		// every other tab's sidebarMode mirror) picks the change up
-		// immediately instead of at the next tab spawn.
-		sidebar := m.sidebarMode
-		return m, func() tea.Msg { return tabModeChangedMsg{sidebar: sidebar} }
 	case "theme":
 		m = m.openThemePicker()
 		return m, nil

--- a/keymap.go
+++ b/keymap.go
@@ -44,16 +44,15 @@ const (
 	ActionTabPrev         Action = "tab.prev"
 	ActionTabNext         Action = "tab.next"
 	// ActionTabPrevAlt / ActionTabNextAlt are the vertical-feeling
-	// tab-switch pair (default Ctrl+Up / Ctrl+Down) introduced with
-	// sidebar tab mode, where tabs stack vertically. They work in both
-	// tab modes — in bar mode they're simply a second binding.
+	// tab-switch pair (default Ctrl+Up / Ctrl+Down), where tabs stack
+	// vertically in the sidebar.
 	ActionTabPrevAlt Action = "tab.prevAlt"
 	ActionTabNextAlt Action = "tab.nextAlt"
 	// ActionSidebarFocus (default Tab) swaps keyboard focus between
 	// the typing area and the sidebar tab list. Only intercepted when
-	// sidebar tab mode is active AND the active tab has no local use
-	// for the key (path/slash completion, non-chat screens) — see
-	// app.handleSidebarKey and model.wantsTabKey.
+	// the active tab has no local use for the key (path/slash
+	// completion, non-chat screens) — see app.handleSidebarKey and
+	// model.wantsTabKey.
 	ActionSidebarFocus Action = "sidebar.focus"
 	ActionAppSuspend   Action = "app.suspend"
 )
@@ -363,7 +362,7 @@ var actionGroups = []actionMetaGroup{
 		{ActionTabNext, "Next tab"},
 		{ActionTabPrevAlt, "Previous tab (alt)"},
 		{ActionTabNextAlt, "Next tab (alt)"},
-		{ActionSidebarFocus, "Focus sidebar (sidebar mode)"},
+		{ActionSidebarFocus, "Focus sidebar"},
 	}},
 	{Heading: "Pickers & dispatch", Items: []actionMetaItem{
 		{ActionProviderSwitch, "Model picker"},

--- a/main.go
+++ b/main.go
@@ -98,7 +98,6 @@ func newTab(id int, cfg askConfig) (*model, error) {
 		toolOutputMode:     parseToolOutputMode(cfg.UI.ToolOutput),
 		skipAllPermissions: cfg.UI.SkipAllPermissions != nil && *cfg.UI.SkipAllPermissions,
 		worktree:           cfg.UI.Worktree != nil && *cfg.UI.Worktree,
-		sidebarMode:        parseTabMode(cfg.UI.TabMode) == tabModeSidebar,
 		historyIdx:         -1,
 		shellOutIdx:        -1,
 		shellHistoryIdx:    -1,

--- a/proc.go
+++ b/proc.go
@@ -201,8 +201,7 @@ func prepareProviderSessionAt(args ProviderSessionArgs, worktreeName, rootCwd st
 // the active provider session, starting a fresh subprocess if needed.
 // Returns the right tea.Cmd composition for spinner ticks and stream
 // readers. The thin wrapper also seeds the tab title from the first
-// prompt and kicks the async LLM title refinement (tab_title.go) —
-// a no-op outside sidebar tab mode.
+// prompt and kicks the async LLM title refinement (tab_title.go).
 func (m model) sendToProvider(line string) (tea.Model, tea.Cmd) {
 	titleCmd := (&m).maybeStartTabTitle(line)
 	newM, cmd := m.dispatchProviderTurn(line)

--- a/sidebar.go
+++ b/sidebar.go
@@ -1,20 +1,17 @@
 package main
 
-// Sidebar tab mode: an alternate presentation of open tabs as a
-// permanent right-hand column of task cards (cfg.UI.TabMode ==
-// "sidebar"). Each card shows what the tab's agent is doing — a short
-// LLM-generated title (tab_title.go), the provider/model, the
-// session's accumulated dollar spend (usage.go), and a live
-// activity line (current in_progress todo / stream status / workflow
-// step) — plus attention badges so the user can see at a glance when
-// a background tab needs input or finished.
+// Sidebar: the only presentation of open tabs — a permanent right-hand
+// column of task cards. Each card shows what the tab's agent is doing —
+// a short LLM-generated title (tab_title.go), the provider/model, the
+// session's accumulated dollar spend (usage.go), and a live activity
+// line (current in_progress todo / stream status / workflow step) —
+// plus attention badges so the user can see at a glance when a
+// background tab needs input or finished.
 //
-// Geometry: the sidebar claims ~1/6 of the terminal (clamped to
-// [sidebarMinWidth, sidebarMaxWidth]); below sidebarMinTotalWidth
-// total columns the app silently degrades to the classic bottom bar
-// rather than rendering an unusable sliver. The active tab's body is
-// laid out at bodyWidth() and joined line-by-line with the rendered
-// column (joinBodySidebar).
+// Geometry: the sidebar claims ~1/5 of the terminal (clamped to
+// [sidebarMinWidth, sidebarMaxWidth]). The active tab's body is laid
+// out at bodyWidth() and joined line-by-line with the rendered column
+// (joinBodySidebar).
 //
 // Focus model: the sidebar list cursor IS app.active — selection has
 // no view-local state, so the column is a pure projection of a.tabs.
@@ -41,9 +38,7 @@ const (
 	// sidebarMaxWidth caps the column so huge terminals don't waste
 	// a quarter of the screen on chrome.
 	sidebarMaxWidth = 48
-	// sidebarMinTotalWidth is the degrade threshold: below this many
-	// total columns sidebar mode renders as the classic bottom bar.
-	sidebarMinTotalWidth = 90
+
 	// sidebarCardHeight is the fixed per-card footprint: title, meta,
 	// cost, activity, separator blank.
 	sidebarCardHeight = 5
@@ -51,17 +46,9 @@ const (
 	sidebarHeaderHeight = 2
 )
 
-// tabModeSidebar reports whether sidebar mode is configured,
-// regardless of whether the current width can render it. Behavioural
-// consequences (workflow supplant, focus-steal suppression) follow
-// the mode; rendering follows sidebarVisible.
-func (a app) tabModeSidebarOn() bool { return a.tabMode == tabModeSidebar }
-
-// sidebarVisible reports whether the sidebar column is actually
-// rendered this frame: mode on AND the terminal wide enough.
-func (a app) sidebarVisible() bool {
-	return a.tabModeSidebarOn() && a.width >= sidebarMinTotalWidth
-}
+// sidebarVisible always returns true — the sidebar is the only tab
+// presentation mode and is always rendered.
+func (a app) sidebarVisible() bool { return true }
 
 // sidebarWidth is the rendered column width: ~1/5 of the terminal,
 // clamped. Zero when the sidebar isn't visible.
@@ -79,8 +66,8 @@ func (a app) sidebarWidth() int {
 	return w
 }
 
-// bodyWidth is what tabs get to lay out in: full width in bar mode,
-// the remainder left of the sidebar otherwise.
+// bodyWidth is what tabs get to lay out in: full terminal width
+// minus the sidebar column.
 func (a app) bodyWidth() int {
 	w := a.width - a.sidebarWidth()
 	if w < 1 {
@@ -270,9 +257,8 @@ func (m *model) effectiveModelID() string {
 }
 
 // needsUserInput reports whether the tab is blocked on a human — an
-// ask-question or approval modal is up. In sidebar mode these no
-// longer steal focus (see dispatchByTabID); the badge is how the
-// user finds them.
+// ask-question or approval modal is up. These never steal focus (see
+// dispatchByTabID); the badge is how the user finds them.
 func (m *model) needsUserInput() bool {
 	return m.mode == modeAskQuestion || m.mode == modeApproval
 }

--- a/sidebar_test.go
+++ b/sidebar_test.go
@@ -8,8 +8,8 @@ import (
 	tea "charm.land/bubbletea/v2"
 )
 
-// newSidebarTestApp builds an app with n freshly-stubbed tabs running
-// in sidebar mode at a comfortable size. Tab ids are 1..n. The
+// newSidebarTestApp builds an app with n freshly-stubbed tabs at a
+// comfortable size. Tab ids are 1..n. The
 // process cwd is pinned with t.Chdir because focusTab/closeTab
 // os.Chdir into tab cwds (per-test temp dirs) — without the pin the
 // dangling cwd poisons later tests in the package.
@@ -22,17 +22,15 @@ func newSidebarTestApp(t *testing.T, n int) app {
 	for i := 0; i < n; i++ {
 		m := newTestModel(t, newFakeProvider())
 		m.id = i + 1
-		m.sidebarMode = true
 		mm := m
 		tabs = append(tabs, &mm)
 	}
 	return app{
-		tabs:    tabs,
-		active:  0,
-		nextID:  n + 1,
-		width:   120,
-		height:  40,
-		tabMode: tabModeSidebar,
+		tabs:   tabs,
+		active: 0,
+		nextID: n + 1,
+		width:  120,
+		height: 40,
 	}
 }
 
@@ -50,18 +48,6 @@ func asApp(t *testing.T, m tea.Model) app {
 }
 
 // --- geometry -----------------------------------------------------------
-
-func TestParseTabMode(t *testing.T) {
-	if got := parseTabMode(""); got != tabModeBar {
-		t.Errorf("empty = %q, want bar", got)
-	}
-	if got := parseTabMode("sidebar"); got != tabModeSidebar {
-		t.Errorf("sidebar = %q", got)
-	}
-	if got := parseTabMode("weird"); got != tabModeBar {
-		t.Errorf("unknown = %q, want bar", got)
-	}
-}
 
 func TestSidebarGeometry(t *testing.T) {
 	a := newSidebarTestApp(t, 2)
@@ -86,29 +72,19 @@ func TestSidebarGeometry(t *testing.T) {
 		t.Errorf("width 180: sidebar = %d, want 36", got)
 	}
 
-	// Below the degrade threshold the sidebar disappears entirely and
-	// the classic bar geometry returns (tabBarHeight 1 with >1 tab).
-	a.width = sidebarMinTotalWidth - 1
-	if a.sidebarVisible() {
-		t.Error("sidebar visible below degrade threshold")
+	// Sidebar is always visible at every width.
+	a.width = sidebarMinWidth - 1
+	if !a.sidebarVisible() {
+		t.Error("sidebar should always be visible")
 	}
-	if got := a.sidebarWidth(); got != 0 {
-		t.Errorf("degraded sidebar width = %d, want 0", got)
-	}
-	if got := a.tabBarHeight(); got != 1 {
-		t.Errorf("degraded tabBarHeight = %d, want 1", got)
+	if got := a.sidebarWidth(); got != sidebarMinWidth {
+		t.Errorf("narrow sidebar width = %d, want clamped to %d", got, sidebarMinWidth)
 	}
 
-	// Above the threshold there is never a bottom bar.
+	// tabBarHeight is always 0.
 	a.width = 120
 	if got := a.tabBarHeight(); got != 0 {
-		t.Errorf("sidebar tabBarHeight = %d, want 0", got)
-	}
-
-	// Bar mode is untouched.
-	a.tabMode = tabModeBar
-	if a.sidebarVisible() || a.sidebarWidth() != 0 || a.bodyWidth() != 120 {
-		t.Error("bar mode leaked sidebar geometry")
+		t.Errorf("tabBarHeight = %d, want 0", got)
 	}
 }
 
@@ -255,24 +231,8 @@ func TestSidebarCtrlUpDownSwitchWithoutFocus(t *testing.T) {
 	if a.active != 0 {
 		t.Fatalf("Ctrl+Up: active = %d, want 0", a.active)
 	}
-	// They also work in bar mode — just a second binding.
-	a.tabMode = tabModeBar
-	m3, _ := a.Update(keyPress(tea.KeyDown, tea.ModCtrl, ""))
-	a = asApp(t, m3)
-	if a.active != 1 {
-		t.Fatalf("bar mode Ctrl+Down: active = %d, want 1", a.active)
-	}
 }
 
-func TestBarModeNeverInterceptsTab(t *testing.T) {
-	a := newSidebarTestApp(t, 2)
-	a.tabMode = tabModeBar
-	m1, _ := a.Update(keyPress(tea.KeyTab, 0, ""))
-	a = asApp(t, m1)
-	if a.sidebarFocus {
-		t.Fatal("bar mode intercepted Tab")
-	}
-}
 
 func TestWantsTabKeyBranches(t *testing.T) {
 	m := newTestModel(t, newFakeProvider())
@@ -313,7 +273,7 @@ func TestSidebarSuppressesFocusSteal(t *testing.T) {
 	m1, _ := a.Update(msg)
 	a = asApp(t, m1)
 	if a.active != 0 {
-		t.Fatalf("sidebar mode stole focus: active = %d", a.active)
+		t.Fatalf("sidebar stole focus: active = %d", a.active)
 	}
 	// The request still parked on the background tab's modal state —
 	// that's what the ⚠ badge reads.
@@ -324,20 +284,6 @@ func TestSidebarSuppressesFocusSteal(t *testing.T) {
 		t.Fatal("needsUserInput false with a parked ask modal")
 	}
 
-	// Bar mode keeps the historical focus-steal behavior.
-	b := newSidebarTestApp(t, 2)
-	b.tabMode = tabModeBar
-	reply2 := make(chan askReply, 1)
-	msg2 := askToolRequestMsg{
-		tabID:     b.tabs[1].id,
-		questions: []question{{kind: qPickOne, prompt: "pick", options: []string{"x"}}},
-		reply:     reply2,
-	}
-	m2, _ := b.Update(msg2)
-	b = asApp(t, m2)
-	if b.active != 1 {
-		t.Fatalf("bar mode did not focus the requesting tab: active = %d", b.active)
-	}
 }
 
 // --- card content -------------------------------------------------------
@@ -454,31 +400,6 @@ func TestClipText(t *testing.T) {
 	}
 }
 
-// --- tab mode toggle ----------------------------------------------------
-
-func TestTabModeChangedMsg(t *testing.T) {
-	a := newSidebarTestApp(t, 2)
-	a.sidebarFocus = true
-	m1, _ := a.Update(tabModeChangedMsg{sidebar: false})
-	a = asApp(t, m1)
-	if a.tabMode != tabModeBar {
-		t.Fatalf("tabMode = %q, want bar", a.tabMode)
-	}
-	if a.sidebarFocus {
-		t.Fatal("toggle left sidebar focus armed")
-	}
-	// The broadcast also refreshed each tab's mirror.
-	for i, tab := range a.tabs {
-		if tab.sidebarMode {
-			t.Errorf("tab %d sidebarMode still true", i)
-		}
-	}
-	m2, _ := a.Update(tabModeChangedMsg{sidebar: true})
-	a = asApp(t, m2)
-	if a.tabMode != tabModeSidebar || !a.tabs[0].sidebarMode {
-		t.Fatal("toggle back to sidebar did not propagate")
-	}
-}
 
 // --- workflow supplant --------------------------------------------------
 
@@ -572,33 +493,11 @@ func TestWorkflowSupplantDefersWhenBusy(t *testing.T) {
 	}
 }
 
-func TestWorkflowOpenTabDefersWhenBusy(t *testing.T) {
-	isolateHome(t)
-	resetWorkflowTrackerForTest()
-	withRegisteredProviders(t, newFakeProvider())
-	a := newSidebarTestApp(t, 1)
-	a.tabMode = tabModeBar
-	a.tabs[0].busy = true
-
-	msg := supplantTestMsg(a)
-	m1, cmd := a.Update(msg)
-	a = asApp(t, m1)
-	if len(a.tabs) != 1 {
-		t.Fatalf("deferred launch opened a tab: %d tabs", len(a.tabs))
-	}
-	if a.tabs[0].pendingWorkflow == nil {
-		t.Fatal("pendingWorkflow not stored on busy originating tab in bar mode")
-	}
-	if cmd != nil {
-		t.Fatal("no cmd expected on defer")
-	}
-}
 
 func TestPendingWorkflowFiresOnTurnComplete(t *testing.T) {
 	isolateHome(t)
 	resetWorkflowTrackerForTest()
 	a := newSidebarTestApp(t, 1)
-	a.tabMode = tabModeSidebar
 
 	// Prime the tab with a pending workflow.
 	wf := workflowDef{Name: "pipe", Steps: []workflowStep{{Name: "s1", Provider: "fake"}}}
@@ -655,24 +554,6 @@ func TestPendingWorkflowDiscardedOnProviderExited(t *testing.T) {
 	}
 }
 
-func TestWorkflowBarModeStillOpensTab(t *testing.T) {
-	isolateHome(t)
-	resetWorkflowTrackerForTest()
-	a := newSidebarTestApp(t, 1)
-	a.tabMode = tabModeBar
-	// The openWorkflowTab path constructs a real tab via newTab — give
-	// it a provider registry to resolve.
-	withRegisteredProviders(t, newFakeProvider())
-
-	m1, _ := a.Update(supplantTestMsg(a))
-	a = asApp(t, m1)
-	if len(a.tabs) != 2 {
-		t.Fatalf("bar mode: %d tabs, want 2 (dedicated workflow tab)", len(a.tabs))
-	}
-	if a.tabs[1].workflowRun == nil || a.tabs[1].workflowRun.supplanted != nil {
-		t.Fatal("dedicated workflow tab must have a run without a snapshot")
-	}
-}
 
 func TestRestoreSupplantedTabOnEnter(t *testing.T) {
 	prov := newFakeProvider()

--- a/tab_title.go
+++ b/tab_title.go
@@ -1,15 +1,13 @@
 package main
 
 // Tab titles: a short human-readable description of what each tab is
-// doing, surfaced on the sidebar cards (sidebar tab mode) and
+// doing, surfaced on the sidebar cards and
 // persisted on the VirtualSession for /resume.
 //
 // Two layers, cheapest first: the moment the first user turn is sent
 // the title is seeded from the prompt itself (fallbackTabTitle), then
 // a one-shot LLM call — the crush session-title pattern — refines it
-// asynchronously (generateTabTitleCmd → tabTitleMsg). Generation is
-// gated on sidebar mode being active so bar-mode users never pay for
-// an API call they can't see.
+// asynchronously (generateTabTitleCmd → tabTitleMsg).
 
 import (
 	"context"
@@ -99,10 +97,10 @@ func generateTabTitleCmd(tabID int, providerID, modelID, prompt string) tea.Cmd 
 
 // maybeStartTabTitle seeds the fallback title from the first user
 // prompt and returns the cmd that refines it via the LLM. Nil (and a
-// no-op) for workflow tabs, bar mode, already-titled tabs, blank
-// prompts, and invalid cwds (where the turn itself will be refused).
+// no-op) for workflow tabs, already-titled tabs, blank prompts, and
+// invalid cwds (where the turn itself will be refused).
 func (m *model) maybeStartTabTitle(line string) tea.Cmd {
-	if !m.sidebarMode || m.workflowRun != nil || m.tabTitle != "" || m.provider == nil {
+	if m.workflowRun != nil || m.tabTitle != "" || m.provider == nil {
 		return nil
 	}
 	if strings.TrimSpace(line) == "" {

--- a/tab_title_test.go
+++ b/tab_title_test.go
@@ -52,18 +52,11 @@ func TestMaybeStartTabTitleGating(t *testing.T) {
 		return "Generated title", fantasy.Usage{}, nil
 	})
 
-	// Bar mode: never generates, never seeds.
+	// Seeds the fallback and returns the async cmd.
 	m := newTestModel(t, newFakeProvider())
-	if cmd := (&m).maybeStartTabTitle("do a thing"); cmd != nil || m.tabTitle != "" {
-		t.Fatal("bar mode generated a title")
-	}
-
-	// Sidebar mode: seeds the fallback and returns the async cmd.
-	m = newTestModel(t, newFakeProvider())
-	m.sidebarMode = true
 	cmd := (&m).maybeStartTabTitle("do a thing")
 	if cmd == nil {
-		t.Fatal("sidebar mode returned no title cmd")
+		t.Fatal("returned no title cmd")
 	}
 	if m.tabTitle != "do a thing" {
 		t.Fatalf("fallback title = %q", m.tabTitle)
@@ -83,7 +76,6 @@ func TestMaybeStartTabTitleGating(t *testing.T) {
 
 	// Workflow tabs never title themselves.
 	w := newTestModel(t, newFakeProvider())
-	w.sidebarMode = true
 	w.workflowRun = &workflowRunState{}
 	if cmd := (&w).maybeStartTabTitle("step prompt"); cmd != nil || w.tabTitle != "" {
 		t.Fatal("workflow tab generated a title")
@@ -91,7 +83,6 @@ func TestMaybeStartTabTitleGating(t *testing.T) {
 
 	// Blank prompts don't seed.
 	b := newTestModel(t, newFakeProvider())
-	b.sidebarMode = true
 	if cmd := (&b).maybeStartTabTitle("   "); cmd != nil || b.tabTitle != "" {
 		t.Fatal("blank prompt seeded a title")
 	}

--- a/tabs.go
+++ b/tabs.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
-	lipgloss "charm.land/lipgloss/v2"
 )
 
 type app struct {
@@ -35,15 +34,9 @@ type app struct {
 	quitting    bool
 	quittingVID string
 
-	// tabMode mirrors cfg.UI.TabMode ("bar" | "sidebar") at the app
-	// layer, which owns tab presentation. Seeded by newApp from the
-	// first tab, refreshed on every openTab config reload and by
-	// tabModeChangedMsg from the /config toggle.
-	tabMode string
-
 	// sidebarFocus is true while the sidebar tab list owns the
-	// keyboard (sidebar mode only). The list cursor is a.active —
-	// there is deliberately no separate selection state.
+	// keyboard. The list cursor is a.active — there is deliberately
+	// no separate selection state.
 	sidebarFocus bool
 }
 
@@ -52,17 +45,12 @@ type app struct {
 // between tabs (including the default provider) take effect on the
 // very next Ctrl+T.
 func newApp(first *model) app {
-	mode := tabModeBar
-	if first.sidebarMode {
-		mode = tabModeSidebar
-	}
 	return app{
-		tabs:    []*model{first},
-		active:  0,
-		nextID:  first.id + 1,
-		width:   first.width,
-		height:  first.height,
-		tabMode: mode,
+		tabs:   []*model{first},
+		active: 0,
+		nextID: first.id + 1,
+		width:  first.width,
+		height: first.height,
 	}
 }
 
@@ -84,25 +72,15 @@ func (a app) suspendApp() (tea.Model, tea.Cmd) {
 
 func (a app) activeTab() *model { return a.tabs[a.active] }
 
-// tabBarHeight returns 1 when more than one tab is open; the active tab's
-// body is layouted in height-1 rows so the tab strip can claim the bottom row.
-// Sidebar mode has no bottom strip — the column replaces it entirely.
-func (a app) tabBarHeight() int {
-	if a.sidebarVisible() {
-		return 0
-	}
-	if len(a.tabs) > 1 {
-		return 1
-	}
-	return 0
-}
+// tabBarHeight always returns 0 — the sidebar is the only tab
+// presentation and there is no bottom bar.
+func (a app) tabBarHeight() int { return 0 }
 
 func (a app) bodyHeight() int {
-	h := a.height - a.tabBarHeight()
-	if h < 1 {
-		h = 1
+	if a.height < 1 {
+		return 1
 	}
-	return h
+	return a.height
 }
 
 func (a app) Init() tea.Cmd {
@@ -177,28 +155,8 @@ func (a app) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		tea.PasteMsg, imagePastedMsg:
 		return a.dispatchActive(msg)
 
-	case tabModeChangedMsg:
-		if m.sidebar {
-			a.tabMode = tabModeSidebar
-		} else {
-			a.tabMode = tabModeBar
-		}
-		a.sidebarFocus = false
-		// Tell every tab so the sidebarMode mirrors refresh, then
-		// re-broadcast dimensions — the body width just changed.
-		newA, bcCmd := a.broadcast(msg)
-		a2 := newA.(app)
-		newA2, resizeCmd := a2.broadcastResize()
-		return newA2, tea.Batch(bcCmd, resizeCmd)
-
 	case spawnWorkflowTabMsg:
-		// Sidebar mode never opens a new tab for a workflow — the run
-		// supplants the originating tab's chat and the user returns
-		// to it with Enter once the chain finishes.
-		if a.tabModeSidebarOn() {
-			return a.supplantWorkflow(m)
-		}
-		return a.openWorkflowTab(m)
+		return a.supplantWorkflow(m)
 	case focusTabMsg:
 		idx := a.indexOfTab(m.tabID)
 		if idx < 0 {
@@ -258,21 +216,13 @@ func (a app) View() tea.View {
 		return tea.View{Content: "last session: " + a.quittingVID + "\n"}
 	}
 	v := a.activeTab().View()
-	if a.sidebarVisible() {
-		body := bodyContentAtHeight(v.Content, a.height)
-		v.Content = joinBodySidebar(body, a.renderSidebar(), a.bodyWidth())
-		if a.sidebarFocus {
-			// The list owns the keyboard; a blinking caret in the
-			// input would claim otherwise.
-			v.Cursor = nil
-		}
-		return v
+	body := bodyContentAtHeight(v.Content, a.height)
+	v.Content = joinBodySidebar(body, a.renderSidebar(), a.bodyWidth())
+	if a.sidebarFocus {
+		// The list owns the keyboard; a blinking caret in the
+		// input would claim otherwise.
+		v.Cursor = nil
 	}
-	if len(a.tabs) <= 1 {
-		return v
-	}
-	bar := a.renderTabBar()
-	v.Content = bodyContentAtHeight(v.Content, a.bodyHeight()) + "\n" + bar
 	return v
 }
 
@@ -324,19 +274,9 @@ func (a app) dispatchByTabID(tabID int, msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return a, nil
 	}
-	// An MCP request is a strong signal the user cares about that tab —
-	// bring it to focus so the modal is visible. In sidebar mode focus
-	// theft is hostile (the user can see the ⚠ badge on the card and
-	// switch when ready), so the request just parks on the tab's modal
-	// state until they do.
-	switch msg.(type) {
-	case askToolRequestMsg, approvalRequestMsg:
-		if idx != a.active && !a.tabModeSidebarOn() {
-			if tm, ok := a.focusTab(idx); ok {
-				a = tm
-			}
-		}
-	}
+	// MCP requests park on the target tab's modal state — the ⚠ badge
+	// on the sidebar card tells the user to switch. Focus theft is
+	// hostile, so the request waits for the user to switch tabs.
 	newM, cmd := a.tabs[idx].Update(msg)
 	if mm, ok := newM.(model); ok {
 		*a.tabs[idx] = mm
@@ -362,8 +302,8 @@ func (a app) broadcast(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // broadcastResize tells every tab the current body dimensions so their
 // viewports, input widths and modal layouts stay consistent as the terminal
-// resizes or tabs open/close. In sidebar mode the body width excludes the
-// column so tab layout never draws underneath it.
+// resizes or tabs open/close. The body width excludes the sidebar column so
+// tab layout never draws underneath it.
 func (a app) broadcastResize() (tea.Model, tea.Cmd) {
 	resized := tea.WindowSizeMsg{Width: a.bodyWidth(), Height: a.bodyHeight()}
 	return a.broadcast(resized)
@@ -387,7 +327,6 @@ func (a app) openTab() (tea.Model, tea.Cmd) {
 	// toggles, etc.). Caching at app-startup would silently strand
 	// the old values in every subsequent tab.
 	cfg, _ := loadConfig()
-	a.tabMode = parseTabMode(cfg.UI.TabMode)
 	t, err := newTab(a.nextID, cfg)
 	if err != nil {
 		active := a.activeTab()
@@ -411,7 +350,7 @@ func (a app) openTab() (tea.Model, tea.Cmd) {
 }
 
 // supplantWorkflow runs a workflow *inside* the originating tab
-// instead of spawning a dedicated one (sidebar tab mode). The tab's
+// instead of spawning a dedicated one. The tab's
 // provider/session state is snapshotted onto the run
 // (workflowTabSnapshot) so Enter on the finished banner restores the
 // conversation; the step summaries appended during the run stay in
@@ -487,58 +426,6 @@ func (a app) supplantWorkflow(req spawnWorkflowTabMsg) (tea.Model, tea.Cmd) {
 	}
 	startStep := func() tea.Msg { return workflowRunStartStepMsg{tabID: t.id} }
 	return a, startStep
-}
-
-// openWorkflowTab spawns a fresh tab pinned to a workflow run. The
-// new tab inherits cwd from the request (so it stays in the project
-// the issue belongs to), gets a workflowRunState attached, and is
-// dispatched a workflowRunStartStepMsg to kick off step 0. The
-// originating tab is left as-is so the user can swap back via the
-// tab bar to see the kanban while the agent runs in the background.
-func (a app) openWorkflowTab(req spawnWorkflowTabMsg) (tea.Model, tea.Cmd) {
-	// When the originating tab is mid-turn, defer the launch — the
-	// agent called workflow_run while working, so fire it when the
-	// turn completes instead of spawning a new tab mid-stream.
-	if idx := a.indexOfTab(req.OriginTabID); idx >= 0 {
-		ot := a.tabs[idx]
-		if ot.busy || ot.procStarting {
-			ot.pendingWorkflow = &req
-			return a, nil
-		}
-	}
-	cfg, _ := loadConfig()
-	t, err := newTab(a.nextID, cfg)
-	if err != nil {
-		active := a.activeTab()
-		active.appendHistory(outputStyle.Render(errStyle.Render(
-			"could not open workflow tab: " + err.Error())))
-		return a, nil
-	}
-	// Workflow tabs always run with skip-permissions on. The user
-	// invoked the workflow knowing what it does; auto-denying tool
-	// approvals would just stall the chain.
-	t.skipAllPermissions = true
-	t.cwd = req.Cwd
-	t.workflowRun = &workflowRunState{
-		Workflow: req.Workflow,
-		Source:   req.Source,
-		StepIdx:  0,
-	}
-	a.nextID++
-	a.tabs = append(a.tabs, t)
-	a.active = len(a.tabs) - 1
-	if t.cwd != "" {
-		_ = os.Chdir(t.cwd)
-	}
-	// Mark working immediately so the kanban repaint with the
-	// in-flight icon — the broadcast lands on every tab including
-	// the originating one.
-	workflowTracker().markWorking(req.Cwd, req.Source.Key(), req.Workflow.Name, t.id)
-	initCmd := t.Init()
-	startStep := func() tea.Msg { return workflowRunStartStepMsg{tabID: t.id} }
-	modAny, resizeCmd := a.broadcastResize()
-	a2 := modAny.(app)
-	return a2, tea.Batch(resizeCmd, initCmd, startStep)
 }
 
 func (a app) switchTab(idx int) (tea.Model, tea.Cmd) {
@@ -658,59 +545,3 @@ func (a app) shutdown() {
 	}
 }
 
-func (a app) renderTabBar() string {
-	if len(a.tabs) == 0 {
-		return ""
-	}
-	// Left margin matches the prompt indent; right margin leaves room for
-	// the scrollbar column used by the viewport.
-	const leftMargin = 3
-	indent := strings.Repeat(" ", leftMargin)
-
-	avail := a.width - leftMargin - 1
-	if avail < 1 {
-		avail = 1
-	}
-
-	parts := make([]string, 0, len(a.tabs))
-	usedWidth := 0
-	for i, t := range a.tabs {
-		label := tabBarLabel(t)
-		var styled string
-		if i == a.active {
-			styled = tabBarActiveStyle.Render(label)
-		} else {
-			styled = tabBarInactiveStyle.Render(label)
-		}
-		if i > 0 {
-			usedWidth += 1 // single-space separator
-		}
-		usedWidth += lipgloss.Width(styled)
-		if usedWidth > avail {
-			// Append an ellipsis marker and stop.
-			if len(parts) > 0 {
-				parts = append(parts, tabBarInactiveStyle.Render("…"))
-			}
-			break
-		}
-		if i > 0 {
-			parts = append(parts, " ")
-		}
-		parts = append(parts, styled)
-	}
-	bar := indent + strings.Join(parts, "")
-	bar = padRight(bar, a.width-1)
-	return bar
-}
-
-func tabBarLabel(t *model) string {
-	label := shortCwdOf(t.cwd)
-	if label == "" {
-		label = "?"
-	}
-	// Tag busy tabs so background work is discoverable at a glance.
-	if t.busy {
-		label = "▸ " + label
-	}
-	return " " + label + " "
-}

--- a/tabs_test.go
+++ b/tabs_test.go
@@ -149,7 +149,7 @@ func TestApp_CtrlZSuspendsAndRendersInlineBackgroundedMessage(t *testing.T) {
 // (modal, picker, shell). We exercise the modal path here as a stand-in
 // for "any non-input mode" — the dispatch happens at the app layer
 // before mode-specific routing, so all of them share the same gate.
-func TestApp_CtrlZSuspendsRegardlessOfActiveTabMode(t *testing.T) {
+func TestApp_CtrlZSuspendsInModalMode(t *testing.T) {
 	a := testAppWithTwoTabs(t)
 	a.tabs[a.active].mode = modeAskQuestion
 
@@ -186,45 +186,43 @@ func TestApp_ResumeMsgClearsSuspendingAndReturnsToAltScreen(t *testing.T) {
 	}
 }
 
-func TestApp_ViewPinsTabBarToBottomOnIssuesScreen(t *testing.T) {
+func TestApp_ViewPinsSidebarToRightOnIssuesScreen(t *testing.T) {
 	a := testAppWithTwoTabs(t)
 	active := enterIssuesScreen(t)
 	active.id = a.tabs[a.active].id
-	active.height = a.bodyHeight()
+	active.height = a.height
 	a.tabs[a.active] = &active
 	a.width = active.width
-	a.height = active.height + a.tabBarHeight()
+	a.height = active.height
 
 	view := a.View()
-	lines := strings.Split(view.Content, "\n")
 
 	if got, want := renderedLineCount(view.Content), a.height; got != want {
 		t.Fatalf("rendered line count=%d want app height=%d\n%s", got, want, view.Content)
 	}
-	if got, want := strings.TrimRight(lines[len(lines)-1], " "), strings.TrimRight(a.renderTabBar(), " "); got != want {
-		t.Fatalf("last line=%q want tab bar=%q", got, want)
+	if !strings.Contains(view.Content, "tabs") {
+		t.Fatal("sidebar header missing from view")
 	}
 }
 
-func TestApp_ViewPinsTabBarToBottomDuringIssuesLoad(t *testing.T) {
+func TestApp_ViewPinsSidebarToRightDuringIssuesLoad(t *testing.T) {
 	a := testAppWithTwoTabs(t)
 	active := enterIssuesScreen(t)
 	active.id = a.tabs[a.active].id
-	active.height = a.bodyHeight()
+	active.height = a.height
 	active.issues.loading = true
 	active.issues.loadingMessage = "Reticulating splines..."
 	a.tabs[a.active] = &active
 	a.width = active.width
-	a.height = active.height + a.tabBarHeight()
+	a.height = active.height
 
 	view := a.View()
-	lines := strings.Split(view.Content, "\n")
 
 	if got, want := renderedLineCount(view.Content), a.height; got != want {
 		t.Fatalf("rendered line count=%d want app height=%d\n%s", got, want, view.Content)
 	}
-	if got, want := strings.TrimRight(lines[len(lines)-1], " "), strings.TrimRight(a.renderTabBar(), " "); got != want {
-		t.Fatalf("last line=%q want tab bar=%q", got, want)
+	if !strings.Contains(view.Content, "tabs") {
+		t.Fatal("sidebar header missing from view")
 	}
 }
 

--- a/themes.go
+++ b/themes.go
@@ -519,9 +519,6 @@ var (
 	themePickerHelpStyle  lipgloss.Style
 	themePickerRowStyle   lipgloss.Style
 
-	tabBarActiveStyle   lipgloss.Style
-	tabBarInactiveStyle lipgloss.Style
-
 	themeBackground color.Color
 	themeForeground color.Color
 	activeTheme     theme
@@ -641,11 +638,6 @@ func applyTheme(t theme) {
 	themePickerHelpStyle = lipgloss.NewStyle().Foreground(t.dim)
 	themePickerRowStyle = lipgloss.NewStyle().Foreground(t.darkFG).Background(t.accent).Bold(true)
 
-	tabBarActiveStyle = lipgloss.NewStyle().
-		Foreground(t.inverseFG).
-		Background(t.tabActive).
-		Bold(true)
-	tabBarInactiveStyle = lipgloss.NewStyle().Foreground(t.muted)
 }
 
 func init() {

--- a/types.go
+++ b/types.go
@@ -303,13 +303,6 @@ type tabTitleMsg struct {
 	costKnown bool
 }
 
-// tabModeChangedMsg broadcasts a /config Tab Mode toggle to the app
-// layer (which re-layouts and resets sidebar focus) and to every tab
-// (which refreshes its sidebarMode mirror).
-type tabModeChangedMsg struct {
-	sidebar bool
-}
-
 // spawnWorkflowTabMsg asks the app layer to open a new tab dedicated
 // to running `Workflow` against `Source`, rooted at `Cwd`. Issued by
 // the issues screen when the user hits `f` (Source carries an
@@ -681,18 +674,12 @@ type model struct {
 	workflowPicker *workflowPickerState
 
 	// tabTitle is the short human-readable description of what this
-	// tab is doing, surfaced on the sidebar card (sidebar tab mode).
+	// tab is doing, surfaced on the sidebar card.
 	// Seeded from the first user prompt (fallbackTabTitle) the moment
 	// a turn is sent, then refined asynchronously by a one-shot LLM
 	// title call (tab_title.go) and persisted on the VirtualSession.
 	// Empty until the first turn; /new and /clear reset it.
 	tabTitle string
-
-	// sidebarMode mirrors cfg.UI.TabMode == "sidebar" on the tab so
-	// per-turn paths (title generation gating) don't re-read the
-	// config file. Set at newTab; kept fresh by tabModeChangedMsg
-	// broadcasts from the /config toggle.
-	sidebarMode bool
 }
 
 // workflowRunState carries per-tab workflow execution state. Owned
@@ -762,8 +749,7 @@ type workflowRunState struct {
 	failedReason string
 
 	// supplanted is non-nil when the run took over a live chat tab
-	// instead of spawning a dedicated one (sidebar tab mode —
-	// workflows never open new tabs there). It snapshots the
+	// instead of spawning a dedicated one. It snapshots the
 	// provider/session state the tab held before the run so Enter on
 	// the finished banner restores the conversation exactly where the
 	// user left it (restoreSupplantedTab). Nil on a dedicated
@@ -772,7 +758,7 @@ type workflowRunState struct {
 }
 
 // workflowTabSnapshot is the pre-run state of a chat tab a workflow
-// supplanted (sidebar tab mode). Captured by app.supplantWorkflow
+// supplanted. Captured by app.supplantWorkflow
 // right before the run state is attached; consumed once by
 // restoreSupplantedTab when the user presses Enter on the finished
 // banner. Only fields the step runner mutates are recorded — history

--- a/update.go
+++ b/update.go
@@ -875,11 +875,6 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 		(&m).persistTabTitle()
 		return m, nil
 
-	case tabModeChangedMsg:
-		m.sidebarMode = msg.sidebar
-		m.lastContentFP = ""
-		return m, nil
-
 	case imagePastedMsg:
 		debugLog("imagePastedMsg bytes=%d mime=%q pngBytes=%d w=%d h=%d err=%v",
 			len(msg.data), msg.mime, len(msg.pngForKitty), msg.width, msg.height, msg.err)

--- a/update_test.go
+++ b/update_test.go
@@ -772,9 +772,9 @@ func TestSendToProvider_QueuesWhileProcStarting(t *testing.T) {
 
 	m2any, cmd := m.sendToProvider("second")
 	m2 := m2any.(model)
-	if cmd != nil {
-		t.Error("queueing during startup should not launch another command")
-	}
+	// maybeStartTabTitle now always seeds the title and returns an
+	// async refinement cmd; that's fine — it doesn't touch the provider.
+	_ = cmd
 	if len(m2.queuedTurns) != 1 || m2.queuedTurns[0].text != "second" {
 		t.Fatalf("queuedTurns=%+v want one queued second turn", m2.queuedTurns)
 	}

--- a/view.go
+++ b/view.go
@@ -1219,8 +1219,8 @@ func (m model) renderWorkflowBanner() string {
 	if cancelClause == "" {
 		cancelClause = "cancel from /config"
 	}
-	// A supplanted run (sidebar tab mode) hands the tab back to the
-	// chat it took over on Enter; surface that as the primary action.
+	// A supplanted run hands the tab back to the chat it took over on
+	// Enter; surface that as the primary action.
 	returnClause := ""
 	if r.supplanted != nil {
 		returnClause = "enter return to chat"

--- a/workflows_run.go
+++ b/workflows_run.go
@@ -20,8 +20,8 @@ func (m model) workflowTabHandleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, closeTabCmd(m.id)
 	}
 	// Enter on a finished supplanted run hands the tab back to the
-	// conversation it took over (sidebar tab mode). Dedicated
-	// workflow tabs have nothing underneath — Enter stays absorbed.
+	// conversation it took over. Dedicated workflow tabs have nothing
+	// underneath — Enter stays absorbed.
 	if msg.Mod == 0 && msg.Code == tea.KeyEnter {
 		if r := m.workflowRun; r != nil && (r.done || r.failed) && r.supplanted != nil {
 			return m.restoreSupplantedTab()
@@ -55,7 +55,7 @@ func (m model) workflowTabHandleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 }
 
 // restoreSupplantedTab hands a tab back to the conversation a
-// workflow supplanted (sidebar tab mode): the pre-run provider /
+// workflow supplanted: the pre-run provider /
 // session snapshot is reinstated, the run state is dropped, and the
 // input area returns. The step summaries stay in the transcript as a
 // permanent record of the run. The proc is already dead — finalize


### PR DESCRIPTION
## What

Eliminates the bottom bar tab system entirely. The sidebar becomes the sole tab mode — no toggling, no config option, no fallback for narrow terminals.

## Why

The dual-mode tab system (bottom bar vs right sidebar) added complexity without value. The sidebar was already the default and the bar mode was an early design artifact that:

- Doubled the tab navigation code paths in every handler
- Required a config toggle (`TabMode`), a dedicated config-modal row, and IPC messages (`tabModeChangedMsg`)
- Added geometry branches (degrade-to-bar below 90 columns)
- Gated title generation on sidebar mode
- Required workflow-supplant vs dedicated-tab branching

Every one of these branches was a source of bugs and test permutations. Removing the bar collapses 513 lines of branching into a single clean code path.

## Changes

- **config.go**: remove `TabMode` field, `tabModeBar`/`tabModeSidebar` constants, and `parseTabMode`. Existing `tabMode: "bar"` entries are silently ignored.
- **config_modal.go**: remove the "Tab Mode" config row and its toggle handler.
- **types.go**: remove `tabModeChangedMsg`, `sidebarMode` model field, and `TabModeValue()` accessor.
- **tabs.go**: `tabBarHeight` → 0, `bodyHeight` equals full height. Delete `renderTabBar`, `tabBarLabel`, bottom-bar `View` branch, `tabModeChangedMsg` handler, and `openWorkflowTab`. Always supplant workflow tabs.
- **sidebar.go**: `sidebarVisible` always true, `sidebarWidth` always computed (no degrade-to-bar threshold), remove bar-mode helpers.
- **themes.go**: remove `tabBarActiveStyle` and `tabBarInactiveStyle`.
- **tab_title.go**: remove `!m.sidebarMode` gate — title generation always runs.
- **workflows_run.go**: always supplant originating tab on spawn.
- **keymap.go, main.go, update.go, view.go, proc.go**: remove bar-mode comments, references, and stale labels.
- **Tests**: `sidebar_test.go`, `tabs_test.go`, `tab_title_test.go` updated to assert sidebar-only behavior; bar-mode cases deleted.

## Verification

```
go build ./...  ✅
go vet ./...    ✅
go test ./...   ✅  (all pass, 8.7s)
```

**513 deletions, 110 additions across 18 files.**