### PR TITLE
fix: preserve session cost meter across cross-provider model swaps

### DIFF
--- a/cost_test.go
+++ b/cost_test.go
@@ -169,14 +169,14 @@ func TestProviderSwapCostMeter(t *testing.T) {
 	pB.id = "openai"
 	withRegisteredProviders(t, pA, pB)
 
-	// Cross-provider: the conversation resets, so the meter does too.
+	// Cross-provider swap now keeps the spend meter.
 	m := newTestModel(t, pA)
 	m.sessionCostUSD = 0.42
 	m.sessionCostKnown = true
 	next, _ := m.applyProviderModelSwitch(providerRegistry[1], "gpt-5.5")
 	mi := next.(model)
-	if mi.sessionCostUSD != 0 || mi.sessionCostKnown {
-		t.Errorf("cross-provider swap kept cost: %v known=%v", mi.sessionCostUSD, mi.sessionCostKnown)
+	if mi.sessionCostUSD != 0.42 || !mi.sessionCostKnown {
+		t.Errorf("cross-provider swap dropped cost: %v known=%v", mi.sessionCostUSD, mi.sessionCostKnown)
 	}
 
 	// Same-provider model swap keeps the session — and its spend.

--- a/model_picker.go
+++ b/model_picker.go
@@ -604,11 +604,10 @@ func (m model) applyProviderModelSwitch(newProv Provider, model string) (tea.Mod
 			debugLog("SaveSettings err: %v", err)
 		}
 	}
-	// Zero all usage telemetry so the chip never shows stale numbers
-	// from the previous provider. Both cross-provider and same-provider
-	// swaps clear — a model change for the same provider still drops
-	// session context, and the new session's first stream events will
-	// re-populate as needed.
+	// Clear token counts and context-model pointer so the chip
+	// starts fresh for the new session. The spend meter
+	// (sessionCostUSD / sessionCostKnown) follows the tab across
+	// provider swaps — the money is already billed.
 	m.lastUsageTokens = 0
 	m.modelForContext = ""
 	var historyCmd tea.Cmd
@@ -622,11 +621,9 @@ func (m model) applyProviderModelSwitch(newProv Provider, model string) (tea.Mod
 		m.sessionID = ""
 		m.sessionMinted = false
 		m.resumeCwd = ""
-		// The conversation resets, so the spend meter does too. A
-		// same-provider model swap keeps the session (and its
-		// accumulated spend — money already billed).
-		m.sessionCostUSD = 0
-		m.sessionCostKnown = false
+		// The spend meter follows the tab across provider swaps —
+		// the money is already billed and the session is being
+		// translated through the VS store, not discarded.
 		if m.virtualSessionID != "" {
 			historyCmd = m.applyVSProviderSwap(oldProvName, newProv)
 		}

--- a/types.go
+++ b/types.go
@@ -624,9 +624,9 @@ type model struct {
 	// call). Priced from the catwalk catalog — sessionCostKnown stays
 	// false until at least one priceable call lands, so the sidebar
 	// never shows a $0.00 that actually means "unpriceable model".
-	// Reset wherever the conversation resets (/new, /clear, /resume
-	// pick, cross-provider swap); a resumed session counts spend since
-	// resume only (historical spend is not persisted).
+	// Reset only on /new, /clear, and /resume pick — not on provider or
+	// model swaps. A resumed session counts spend since resume only
+	// (historical spend is not persisted).
 	sessionCostUSD   float64
 	sessionCostKnown bool
 


### PR DESCRIPTION
## Summary

When switching models with Ctrl+M and the new model is served by a different in-process provider (e.g. anthropic → openai), `applyProviderModelSwitch` was zeroing `m.sessionCostUSD` and `m.sessionCostKnown` in the cross-provider path. This dropped the accumulated spend from the sidebar session cost counter, making it look like no money had been spent on the tab.

This change removes the two reset lines from the cross-provider swap block so the spend meter follows the tab, matching the same-provider swap behavior that already preserved it.

## Motivation

The sidebar session cost counter is a user-facing accumulator of all API spend on a tab. Resetting it on cross-provider swaps was inconsistent:
- Same-provider swaps kept the meter ✓
- Workflow supplants kept the meter ✓  
- Cross-provider swaps zeroed it ✗ (the bug)

The money is already billed regardless of which provider served the next turn. The meter should persist across all model changes and only reset on explicit user actions (`/new`, `/clear`, `/resume` pick).

## Changes

- **`model_picker.go`**: Removed the two lines that reset `sessionCostUSD`/`sessionCostKnown` in the cross-provider swap block. Fixed a stale comment that incorrectly claimed "Zero all usage telemetry" applied to the spend meter.
- **`types.go`**: Updated doc comment on `sessionCostUSD`/`sessionCostKnown` to say reset only on `/new`, `/clear`, and `/resume` pick — not on provider or model swaps.
- **`cost_test.go`**: Updated `TestProviderSwapCostMeter` to assert cross-provider swap preserves cost=0.42 known=true.

## Testing

- `go build ./...` ✓
- `go vet ./...` ✓  
- `go test ./...` ✓ (all 1000+ tests pass)
- `TestProviderSwapCostMeter` specifically validates:
  - Cross-provider swap keeps `sessionCostUSD=0.42` and `sessionCostKnown=true`
  - Same-provider swap continues to keep the meter
- `/new`, `/clear`, and `/resume` pick continue to reset the meter (existing behavior, unchanged)