### PR TITLE
feat: structured plans/notes directory system for workflow pipelines

### DIFF
--- a/agent_tools_bridge.go
+++ b/agent_tools_bridge.go
@@ -147,10 +147,10 @@ func mcpResultText(res *mcp.CallToolResult) string {
 }
 
 // agentBridgeTools builds the full native tool set for one session:
-// the 12 linear_* tools and the 7 workflow_* tools (CRUD + copy +
-// run). ask_user_question and end_turn already have natives in
-// agent_tools_ask.go. Tool names match what the bridge exposes so
-// prompts and saved workflows keep working unchanged.
+// the 12 linear_* tools and the 8 workflow_* tools (CRUD + copy +
+// run + clear_plans). ask_user_question and end_turn already have
+// natives in agent_tools_ask.go. Tool names match what the bridge
+// exposes so prompts and saved workflows keep working unchanged.
 func agentBridgeTools(env *agentToolEnv) []fantasy.AgentTool {
 	cwd := func() string { return env.cwd }
 	return []fantasy.AgentTool{
@@ -230,6 +230,10 @@ func agentBridgeTools(env *agentToolEnv) []fantasy.AgentTool {
 		nativeBridgeTool("workflow_run", workflowRunToolDescription,
 			func(_ context.Context, in workflowRunInput) (*mcp.CallToolResult, workflowRunOutput, error) {
 				return workflowRunCore(cwd(), env.tabID, in)
+			}),
+		nativeBridgeTool("clear_plans", clearPlansToolDescription,
+			func(_ context.Context, in clearPlansInput) (*mcp.CallToolResult, clearPlansOutput, error) {
+				return clearPlansCore(cwd(), in)
 			}),
 	}
 }

--- a/agent_tools_bridge_test.go
+++ b/agent_tools_bridge_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -28,6 +30,7 @@ func TestAgentBridgeTools_CoversEveryBridgeTool(t *testing.T) {
 		"linear_list_states", "linear_list_projects", "linear_list_cycles",
 		"workflow_list", "workflow_get", "workflow_create",
 		"workflow_edit", "workflow_delete", "workflow_copy", "workflow_run",
+		"clear_plans",
 	}
 	got := map[string]bool{}
 	for _, tool := range agentBridgeTools(env) {
@@ -322,5 +325,67 @@ func TestWorkflowRun_AppendIsRequiredInSchema(t *testing.T) {
 	}
 	if !required["append"] {
 		t.Errorf("append must be required; got required=%v", run.Info().Required)
+	}
+}
+
+// TestClearPlans_BridgeToolIdempotent: the clear_plans registry tool is
+// wired, clears ask/plans/ children (leaving the dir itself), and is
+// idempotent over empty or missing directories.
+func TestClearPlans_BridgeToolIdempotent(t *testing.T) {
+	isolateHome(t)
+	env, _ := newTestToolEnv(t)
+
+	tool := bridgeToolByName(t, env, "clear_plans")
+	if tool == nil {
+		t.Fatal("clear_plans tool not found in agentBridgeTools")
+	}
+	info := tool.Info()
+	if info.Name != "clear_plans" {
+		t.Fatalf("name: %s", info.Name)
+	}
+	if !strings.Contains(info.Description, "Clear the workflow plans directory") {
+		t.Errorf("description missing expected text: %s", info.Description)
+	}
+
+	// Clear when ask/plans/ does not exist: succeeds (no-op).
+	resp, err := tool.Run(context.Background(), fantasy.ToolCall{
+		ID: "1", Name: "clear_plans", Input: `{}`,
+	})
+	if err != nil || resp.IsError {
+		t.Fatalf("clear_plans on absent dir: %v %+v", err, resp)
+	}
+	if !strings.Contains(resp.Content, "cleared") {
+		t.Errorf("response should confirm cleared; got %q", resp.Content)
+	}
+
+	// Create some plan files.
+	base := filepath.Join(env.cwd, "ask", "plans")
+	if err := os.MkdirAll(filepath.Join(base, "start"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(base, "start", "plan.md"), []byte("plan"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Clear: removes start/ but leaves ask/plans/.
+	resp, err = tool.Run(context.Background(), fantasy.ToolCall{
+		ID: "2", Name: "clear_plans", Input: `{}`,
+	})
+	if err != nil || resp.IsError {
+		t.Fatalf("clear_plans with contents: %v %+v", err, resp)
+	}
+	if _, e := os.Stat(filepath.Join(base, "start")); !os.IsNotExist(e) {
+		t.Error("start/ should be removed after clear")
+	}
+	if _, e := os.Stat(base); os.IsNotExist(e) {
+		t.Error("ask/plans/ itself should survive clear")
+	}
+
+	// Clear again on empty dir: still succeeds.
+	resp, err = tool.Run(context.Background(), fantasy.ToolCall{
+		ID: "3", Name: "clear_plans", Input: `{}`,
+	})
+	if err != nil || resp.IsError {
+		t.Fatalf("clear_plans second time: %v %+v", err, resp)
 	}
 }

--- a/mcp_workflows.go
+++ b/mcp_workflows.go
@@ -230,9 +230,15 @@ Fire-and-forget: returns immediately with the session key. The workflow runs in 
 
 CRITICAL — the workflow starts in a brand-new session with NO access to this conversation. Its message history, the files you have read, and your tool results DO NOT carry over. The append parameter is the ONLY channel of context into the run: its text is threaded into step 1's prompt as a "Reference:" block, and that is everything the workflow gets.
 
+BEFORE calling workflow_run you MUST:
+  1. Call clear_plans to remove any stale plan artifacts from previous runs.
+  2. Write the starting plan for this task into ask/plans/start/ (create at least one file there).
+
+The workflow runner verifies that ask/plans/start/ exists and contains at least one file before step 1; if it is missing or empty, the run is rejected and you must create it and try again.
+
 append is REQUIRED. You MUST submit the FULL plan the workflow needs to carry the task through end to end on its own — the goal, the concrete steps to take, the relevant file paths, the constraints, and the acceptance criteria. Do NOT pass a bare one-line summary, and do NOT point back at "the conversation above" — the workflow cannot see it. Write append as if briefing someone who has never seen this chat.
 
-Errors when the workflow doesn't exist, the name is ambiguous across scopes, when it has no steps, when append is empty, or when the UI isn't ready to spawn a tab.`
+Errors when the workflow doesn't exist, the name is ambiguous across scopes, when it has no steps, when append is empty, when ask/plans/start/ is missing or empty, or when the UI isn't ready to spawn a tab.`
 
 	endTurnToolDescription = `Report the end of your turn for the current workflow step. REQUIRED on every step.
 

--- a/types.go
+++ b/types.go
@@ -740,6 +740,16 @@ type workflowRunState struct {
 	// workflowRunStepDoneMsg.
 	currentStep strings.Builder
 
+	// currentNotesDir is the notes directory for the step currently
+	// in flight. Computed at dispatch and reused when advancing so the
+	// runner knows which directory the just-finished step wrote to.
+	currentNotesDir string
+
+	// prevNotesDir is the notes directory of the step whose output is
+	// being carried into the current dispatch. Empty for the workflow's
+	// first step.
+	prevNotesDir string
+
 	// done flips true once the final step exits cleanly. The banner
 	// shows "complete · ctrl+d to close" while the tab stays open.
 	done bool

--- a/workflow_plans.go
+++ b/workflow_plans.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// workflow_plans.go manages the persistent artifact tree that workflow
+// runs read from and write to. The runtime owns all paths; steps are
+// told their own notes directory and the previous step's notes directory
+// via prompt injection.
+
+// workflowPlansDirName is the project-root-relative base directory for
+// workflow plan artifacts.
+const workflowPlansDirName = "ask/plans"
+
+// workflowStartPlanDirName is the subdirectory that holds the starting
+// plan. It is also the notes directory for the workflow's first step.
+const workflowStartPlanDirName = "start"
+
+// workflowPlansDir returns the absolute base plans directory for cwd.
+// Empty when projectRoot cannot be determined.
+func workflowPlansDir(cwd string) string {
+	root := projectRoot(cwd)
+	if root == "" {
+		return ""
+	}
+	return filepath.Join(root, filepath.FromSlash(workflowPlansDirName))
+}
+
+// startPlanDir returns the absolute path to ask/plans/start/.
+func startPlanDir(cwd string) string {
+	base := workflowPlansDir(cwd)
+	if base == "" {
+		return ""
+	}
+	return filepath.Join(base, workflowStartPlanDirName)
+}
+
+// stepNotesDir returns the notes directory for a single dispatch.
+//
+//   - The first step of a workflow writes to ask/plans/start/.
+//   - Subsequent linear steps write to ask/plans/<step-name>/.
+//   - Steps inside a loop write to ask/plans/<loop-name>/<iteration>/.
+func stepNotesDir(cwd, stepName, loopName string, iteration int) string {
+	base := workflowPlansDir(cwd)
+	if base == "" {
+		return ""
+	}
+	if loopName != "" && iteration > 0 {
+		return filepath.Join(base, sanitizeStepName(loopName), fmt.Sprintf("%d", iteration))
+	}
+	return filepath.Join(base, sanitizeStepName(stepName))
+}
+
+// sanitizeStepName maps a workflow step name onto a filesystem-safe
+// path component. Runes outside [a-zA-Z0-9._-] become '-'; runs
+// collapse; empty results fall back to "step".
+func sanitizeStepName(name string) string {
+	var b strings.Builder
+	lastDash := false
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '.', r == '_', r == '-':
+			b.WriteRune(r)
+			lastDash = r == '-'
+		default:
+			if !lastDash {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	stem := strings.Trim(b.String(), "-.")
+	if stem == "" {
+		stem = "step"
+	}
+	return stem
+}
+
+// ensureStartPlanExists verifies that ask/plans/start/ exists and
+// contains at least one non-directory entry before the workflow begins.
+func ensureStartPlanExists(cwd string) error {
+	dir := startPlanDir(cwd)
+	if dir == "" {
+		return errors.New("start plan is missing: create files in ask/plans/start/ before running the workflow")
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return errors.New("start plan is missing: create files in ask/plans/start/ before running the workflow")
+		}
+		return fmt.Errorf("cannot read start plan dir: %w", err)
+	}
+	if !info.IsDir() {
+		return errors.New("ask/plans/start/ exists but is not a directory")
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("cannot list start plan dir: %w", err)
+	}
+	hasFile := false
+	for _, e := range entries {
+		if !e.IsDir() {
+			hasFile = true
+			break
+		}
+	}
+	if !hasFile {
+		return errors.New("start plan is empty: add at least one file to ask/plans/start/ before running the workflow")
+	}
+	return nil
+}
+
+// clearWorkflowPlans removes all children under ask/plans/ but leaves
+// the directory itself. It is safe to call repeatedly.
+func clearWorkflowPlans(cwd string) error {
+	dir := workflowPlansDir(cwd)
+	if dir == "" {
+		return errors.New("no project root to locate ask/plans/")
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("cannot read plans dir: %w", err)
+	}
+	if !info.IsDir() {
+		return errors.New("ask/plans exists but is not a directory")
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("cannot list plans dir: %w", err)
+	}
+	for _, e := range entries {
+		if err := os.RemoveAll(filepath.Join(dir, e.Name())); err != nil {
+			return fmt.Errorf("cannot remove %s: %w", e.Name(), err)
+		}
+	}
+	return nil
+}
+
+// removeAllWorkflowPlans removes the entire ask/plans/ tree. Used by
+// the runner after the final step succeeds.
+func removeAllWorkflowPlans(cwd string) error {
+	dir := workflowPlansDir(cwd)
+	if dir == "" {
+		return nil
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("cannot remove plans dir: %w", err)
+	}
+	return nil
+}
+
+// ----- clear_plans tool -----
+
+const clearPlansToolDescription = `Clear the workflow plans directory (ask/plans/).
+
+This removes all files and subdirectories under ask/plans/ but leaves the directory itself. Call this before submitting a new workflow_run to ensure no stale plan data from a previous run interferes with the next workflow.
+
+This tool is safe to call repeatedly; it is a no-op when ask/plans/ does not exist.`
+
+type clearPlansInput struct{}
+
+type clearPlansOutput struct {
+	Cleared bool `json:"cleared" jsonschema:"true on success"`
+}
+
+func clearPlansCore(cwd string, in clearPlansInput) (*mcp.CallToolResult, clearPlansOutput, error) {
+	if errRes := requireWorkflowCwd(cwd); errRes != nil {
+		return errRes, clearPlansOutput{}, nil
+	}
+	if err := clearWorkflowPlans(cwd); err != nil {
+		return errResult(err.Error()), clearPlansOutput{}, nil
+	}
+	return okResult("ask/plans/ cleared"), clearPlansOutput{Cleared: true}, nil
+}

--- a/workflows_run.go
+++ b/workflows_run.go
@@ -113,6 +113,14 @@ func (m model) startWorkflowStep() (tea.Model, tea.Cmd) {
 	}
 	top := r.Workflow.Steps[r.StepIdx]
 
+	// Gate: the workflow must not start until the LLM has written a
+	// starting plan into ask/plans/start/.
+	if r.StepIdx == 0 && r.loop == nil {
+		if err := ensureStartPlanExists(m.cwd); err != nil {
+			return m.workflowFinalize(false, err.Error())
+		}
+	}
+
 	// Enter a loop step the first time the cursor lands on it.
 	if top.isLoop() && r.loop == nil {
 		if len(top.Steps) == 0 {
@@ -133,9 +141,31 @@ func (m model) startWorkflowStep() (tea.Model, tea.Cmd) {
 	// set by advanceWorkflowStep when the prior turn skipped end_turn (or
 	// a loop tail omitted its decision) so the re-prompt explains itself.
 	step := top
-	pc := &stepPromptCtx{remind: r.remind}
 	if r.loop != nil {
 		step = top.Steps[r.loop.innerIdx]
+	}
+	isStartStep := r.StepIdx == 0 && r.loop == nil
+	// When the first step is a loop, the first inner step of
+	// iteration 1 acts as the start step — it writes to
+	// ask/plans/start/ instead of ask/plans/<loop>/<iter>/.
+	isLoopStartStep := r.StepIdx == 0 && r.loop != nil && r.loop.iteration == 1 && r.loop.innerIdx == 0
+	var notesDir string
+	switch {
+	case isStartStep, isLoopStartStep:
+		notesDir = startPlanDir(m.cwd)
+	case r.loop != nil:
+		notesDir = stepNotesDir(m.cwd, step.Name, top.Name, r.loop.iteration)
+	default:
+		notesDir = stepNotesDir(m.cwd, step.Name, "", 0)
+	}
+	r.currentNotesDir = notesDir
+	pc := &stepPromptCtx{
+		remind:       r.remind,
+		notesDir:     notesDir,
+		prevNotesDir: r.prevNotesDir,
+		isStartStep:  isStartStep || isLoopStartStep,
+	}
+	if r.loop != nil {
 		pc.loop = &loopPromptCtx{
 			name:          top.Name,
 			iteration:     r.loop.iteration,
@@ -200,6 +230,9 @@ func (m model) workflowFinalize(ok bool, reason string) (tea.Model, tea.Cmd) {
 		r.done = true
 		workflowTracker().markFinal(m.cwd, r.Source.Key(), r.Workflow.Name, workflowStatusDone, r.StepIdx)
 		m.appendHistory(outputStyle.Render(promptStyle.Render("✓ workflow complete: " + r.Workflow.Name)))
+		if err := removeAllWorkflowPlans(m.cwd); err != nil {
+			debugLog("workflow cleanup: %v", err)
+		}
 	} else {
 		r.failed = true
 		r.failedReason = reason
@@ -263,6 +296,7 @@ func (m model) advanceWorkflowStep(stepErr error) (tea.Model, tea.Cmd) {
 		}
 		// Got the summary: render the step's line, record output, advance.
 		m.appendHistory(stepSummaryLine(step.Name, step.Provider, step.Model, sig.summary, m.width))
+		r.prevNotesDir = r.currentNotesDir
 		if txt != "" {
 			r.stepLog = append(r.stepLog, txt)
 		}
@@ -295,6 +329,7 @@ func (m model) advanceWorkflowStep(stepErr error) (tea.Model, tea.Cmd) {
 	// Break from any inner step exits the loop immediately, skipping the
 	// rest of the iteration.
 	if sig.decision == workflowLoopBreak {
+		r.prevNotesDir = r.currentNotesDir
 		if txt != "" {
 			r.loop.iterationLog = append(r.loop.iterationLog, txt)
 		}
@@ -307,6 +342,7 @@ func (m model) advanceWorkflowStep(stepErr error) (tea.Model, tea.Cmd) {
 	// same iteration. (A "continue" and an omitted decision are equivalent
 	// here — only the tail's continue advances the iteration.)
 	if !isTail {
+		r.prevNotesDir = r.currentNotesDir
 		if txt != "" {
 			r.loop.iterationLog = append(r.loop.iterationLog, txt)
 		}
@@ -329,6 +365,7 @@ func (m model) advanceWorkflowStep(stepErr error) (tea.Model, tea.Cmd) {
 
 	// Tail registered continue: record output, then start the next
 	// iteration or soft-exit if the iteration cap is reached.
+	r.prevNotesDir = r.currentNotesDir
 	if txt != "" {
 		r.loop.iterationLog = append(r.loop.iterationLog, txt)
 	}
@@ -457,11 +494,15 @@ const (
 )
 
 // stepPromptCtx carries the per-dispatch facts buildWorkflowStepPrompt
-// needs beyond the step itself: the loop framing (nil outside a loop) and
-// why this dispatch is a re-prompt (remindNone on a normal first dispatch).
+// needs beyond the step itself: the loop framing (nil outside a loop),
+// why this dispatch is a re-prompt (remindNone on a normal first dispatch),
+// and the current/previous notes directories.
 type stepPromptCtx struct {
-	loop   *loopPromptCtx
-	remind remindKind
+	loop         *loopPromptCtx
+	remind       remindKind
+	notesDir     string
+	prevNotesDir string
+	isStartStep  bool
 }
 
 // loopPromptCtx carries the per-dispatch loop facts injected into an
@@ -510,6 +551,19 @@ func buildWorkflowStepPrompt(step workflowStep, source workflowSource, prevOutpu
 				b.WriteString("\n---\n")
 			}
 			b.WriteString(strings.TrimSpace(entry))
+		}
+	}
+	if pc != nil && pc.notesDir != "" {
+		b.WriteString("\n\n")
+		b.WriteString("Workflow notes directories:\n")
+		b.WriteString("- Your notes directory: " + pc.notesDir)
+		if pc.prevNotesDir != "" {
+			b.WriteString("\n- Previous step's notes directory: " + pc.prevNotesDir)
+		}
+		if pc.isStartStep {
+			b.WriteString("\n\nThis is the first step. Write your starting plan into your notes directory (")
+			b.WriteString(pc.notesDir)
+			b.WriteString(") before doing any other work.")
 		}
 	}
 	var loop *loopPromptCtx

--- a/workflows_run_test.go
+++ b/workflows_run_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -248,6 +250,15 @@ func TestStartWorkflowStep_UnknownProviderFails(t *testing.T) {
 		Source: issueWorkflowSource(issue),
 	}
 	workflowTracker().markWorking(cwd, issue.Key(), "wf", m.id)
+	// The start-plan gate fires for StepIdx 0; populate ask/plans/start/
+	// so the gate passes and we reach the provider check under test.
+	startDir := filepath.Join(cwd, "ask", "plans", "start")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(startDir, "plan.md"), []byte("plan"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	newM, _ := m.startWorkflowStep()
 	mm := newM.(model)
 	if !mm.workflowRun.failed {
@@ -531,6 +542,15 @@ func TestStartWorkflowStep_EntersLoop(t *testing.T) {
 		Source: issueWorkflowSource(issueRef{Provider: "github", Project: "ow/r", Number: 1}),
 	}
 	workflowTracker().markWorking(cwd, m.workflowRun.Source.Key(), "wf", m.id)
+	// The start-plan gate fires for StepIdx 0; create ask/plans/start/ so
+	// the gate passes and we reach the loop-entry logic under test.
+	startDir := filepath.Join(cwd, "ask", "plans", "start")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(startDir, "plan.md"), []byte("plan"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	newM, _ := m.startWorkflowStep()
 	r := newM.(model).workflowRun
@@ -681,5 +701,235 @@ func TestHandleEndTurnSignal_NoEffectWhenNoRun(t *testing.T) {
 	}
 	if resp := <-reply; resp.registered {
 		t.Errorf("reply should be not-registered on a finished run; got %+v", resp)
+	}
+}
+
+// ----- plans-directory system tests -----
+
+// startPlanWorkspace creates the start-plan directory fixture and returns
+// the cwd so callers can write individual files into it.
+func startPlanWorkspace(t *testing.T) (cwd string) {
+	t.Helper()
+	cwd = isolateHome(t)
+	dir := filepath.Join(cwd, "ask", "plans", "start")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return cwd
+}
+
+// TestStartWorkflowStep_RejectsMissingStartPlan: StepIdx 0 without
+// ask/plans/start/ must finalise as failed with the gate message.
+func TestStartWorkflowStep_RejectsMissingStartPlan(t *testing.T) {
+	cwd := isolateHome(t)
+	resetWorkflowTrackerForTest()
+	m := newTestModel(t, newFakeProvider())
+	m.cwd = cwd
+	m.workflowRun = &workflowRunState{
+		Workflow: workflowDef{
+			Name:  "wf",
+			Steps: []workflowStep{{Name: "first"}},
+		},
+		Source: issueWorkflowSource(issueRef{Provider: "github", Project: "ow/r", Number: 1}),
+	}
+	workflowTracker().markWorking(cwd, m.workflowRun.Source.Key(), "wf", m.id)
+	newM, _ := m.startWorkflowStep()
+	mm := newM.(model)
+	if !mm.workflowRun.failed {
+		t.Fatal("expected failed when start plan is missing")
+	}
+	if !strings.Contains(mm.workflowRun.failedReason, "start plan is missing") {
+		t.Errorf("failure reason must mention missing start plan; got %q", mm.workflowRun.failedReason)
+	}
+}
+
+// TestStartWorkflowStep_RejectsEmptyStartPlan: ask/plans/start/ exists
+// but contains no files — the gate must still reject.
+func TestStartWorkflowStep_RejectsEmptyStartPlan(t *testing.T) {
+	cwd := startPlanWorkspace(t)
+	resetWorkflowTrackerForTest()
+	withRegisteredProviders(t, newFakeProvider())
+	m := newTestModel(t, newFakeProvider())
+	m.cwd = cwd
+	m.workflowRun = &workflowRunState{
+		Workflow: workflowDef{
+			Name:  "wf",
+			Steps: []workflowStep{{Name: "first", Provider: "fake"}},
+		},
+		Source: issueWorkflowSource(issueRef{Provider: "github", Project: "ow/r", Number: 1}),
+	}
+	workflowTracker().markWorking(cwd, m.workflowRun.Source.Key(), "wf", m.id)
+	newM, _ := m.startWorkflowStep()
+	mm := newM.(model)
+	if !mm.workflowRun.failed {
+		t.Fatal("expected failed when start plan is empty")
+	}
+	if !strings.Contains(mm.workflowRun.failedReason, "start plan is empty") {
+		t.Errorf("failure reason must mention empty start plan; got %q", mm.workflowRun.failedReason)
+	}
+}
+
+// TestBuildWorkflowStepPrompt_PlansDirs: the prompt carries the notes
+// directories the step should read/write, the previous step's notes dir
+// when applicable, and the "write your starting plan" instruction for step 1.
+func TestBuildWorkflowStepPrompt_PlansDirs(t *testing.T) {
+	step := workflowStep{Prompt: "Do the work."}
+	src := issueWorkflowSource(issueRef{Provider: "github", Project: "ow/r", Number: 1})
+
+	// First step: sees its own notes dir + the "write your starting plan" nudge.
+	pc := &stepPromptCtx{notesDir: "/proj/ask/plans/start", isStartStep: true}
+	got := buildWorkflowStepPrompt(step, src, nil, pc)
+	for _, want := range []string{
+		"Workflow notes directories:",
+		"- Your notes directory: /proj/ask/plans/start",
+		"Write your starting plan into your notes directory (/proj/ask/plans/start)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("start-step prompt missing %q; got:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "Previous step's notes directory") {
+		t.Error("first step must not mention a previous notes directory")
+	}
+
+	// Subsequent step: sees its own notes dir + the previous one.
+	pc2 := &stepPromptCtx{notesDir: "/proj/ask/plans/review", prevNotesDir: "/proj/ask/plans/start"}
+	got = buildWorkflowStepPrompt(step, src, nil, pc2)
+	if !strings.Contains(got, "- Your notes directory: /proj/ask/plans/review") {
+		t.Errorf("subsequent-step prompt missing own notes dir; got:\n%s", got)
+	}
+	if !strings.Contains(got, "- Previous step's notes directory: /proj/ask/plans/start") {
+		t.Errorf("subsequent-step prompt missing previous notes dir; got:\n%s", got)
+	}
+	if strings.Contains(got, "Write your starting plan") {
+		t.Error("only the first step gets the starting-plan instruction")
+	}
+}
+
+// TestWorkflowFinalize_RemovesPlansOnSuccess: a successful finalise deletes
+// the entire ask/plans/ tree.
+func TestWorkflowFinalize_RemovesPlansOnSuccess(t *testing.T) {
+	cwd := isolateHome(t)
+	resetWorkflowTrackerForTest()
+
+	// Create back ask/plans/start/ + an extra step note.
+	startDir := filepath.Join(cwd, "ask", "plans", "start")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(startDir, "plan.md"), []byte("plan"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stepDir := filepath.Join(cwd, "ask", "plans", "step-two")
+	if err := os.MkdirAll(stepDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newTestModel(t, newFakeProvider())
+	m.cwd = cwd
+	issue := issueRef{Provider: "github", Project: "ow/r", Number: 99}
+	m.workflowRun = &workflowRunState{
+		Workflow: workflowDef{Name: "wf", Steps: []workflowStep{{Name: "only"}}},
+		Source:   issueWorkflowSource(issue),
+	}
+	workflowTracker().markWorking(cwd, issue.Key(), "wf", m.id)
+
+	mm, _ := m.workflowFinalize(true, "")
+	if !mm.(model).workflowRun.done {
+		t.Fatal("finalize should mark done")
+	}
+	if _, err := os.Stat(filepath.Join(cwd, "ask", "plans")); !os.IsNotExist(err) {
+		t.Error("ask/plans/ must be removed after successful finalise")
+	}
+}
+
+// TestStepNotesDir_PathLayout: stepNotesDir produces the expected paths
+// for linear steps, start step, and loop iterations.
+func TestStepNotesDir_PathLayout(t *testing.T) {
+	cwd := startPlanWorkspace(t)
+
+	// Linear non-start-step; the function doesn't know about "firstness" — the
+	// caller decides.  A normal linear step gets ask/plans/<sanitized>/.
+	got := stepNotesDir(cwd, "code review", "", 0)
+	wantSuffix := filepath.Join("ask", "plans", "code-review")
+	if !strings.HasSuffix(got, wantSuffix) {
+		t.Errorf("linear step: got %q, want suffix %q", got, wantSuffix)
+	}
+
+	// Loop step.
+	got = stepNotesDir(cwd, "inner", "refinement loop", 3)
+	wantSuffix = filepath.Join("ask", "plans", "refinement-loop", "3")
+	if !strings.HasSuffix(got, wantSuffix) {
+		t.Errorf("loop step: got %q, want suffix %q", got, wantSuffix)
+	}
+
+	// Zero iteration or empty loop name falls back to linear.
+	got = stepNotesDir(cwd, "code review", "unused-loop", 0)
+	wantSuffix = filepath.Join("ask", "plans", "code-review")
+	if !strings.HasSuffix(got, wantSuffix) {
+		t.Errorf("zero-iteration step: got %q, want suffix %q", got, wantSuffix)
+	}
+}
+
+// TestSanitizeStepName: step names become safe path components.
+func TestSanitizeStepName(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"code review", "code-review"},
+		{"ship:validate & test", "ship-validate-test"},
+		{"---", "step"},
+		{"", "step"},
+		{"..", "step"},
+		{"hello.world_v2-beta", "hello.world_v2-beta"},
+		{"  leading/trailing  ", "leading-trailing"},
+		{"a b", "a-b"},
+		{"a--b", "a--b"},
+	}
+	for _, tc := range cases {
+		got := sanitizeStepName(tc.in)
+		if got != tc.want {
+			t.Errorf("sanitizeStepName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestClearWorkflowPlans_Idempotent: clearing an empty dir, a missing dir,
+// and a dir with contents all succeed and are repeatable.
+func TestClearWorkflowPlans_Idempotent(t *testing.T) {
+	cwd := isolateHome(t)
+
+	// Missing dir: no-op.
+	if err := clearWorkflowPlans(cwd); err != nil {
+		t.Fatalf("clear absent: %v", err)
+	}
+
+	// Create ask/plans/ with subdirs.
+	base := filepath.Join(cwd, "ask", "plans")
+	if err := os.MkdirAll(filepath.Join(base, "start"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(base, "step-two"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(base, "start", "plan.md"), []byte("plan"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// First clear removes children.
+	if err := clearWorkflowPlans(cwd); err != nil {
+		t.Fatalf("first clear: %v", err)
+	}
+	for _, sub := range []string{"start", "step-two"} {
+		if _, err := os.Stat(filepath.Join(base, sub)); !os.IsNotExist(err) {
+			t.Errorf("%s should be removed after clear", sub)
+		}
+	}
+	// ask/plans/ itself still exists.
+	if _, err := os.Stat(base); os.IsNotExist(err) {
+		t.Error("ask/plans/ dir itself should survive clear")
+	}
+
+	// Second clear on the now-empty dir is a no-op.
+	if err := clearWorkflowPlans(cwd); err != nil {
+		t.Fatalf("second clear: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Add a persistent artifact tree under `ask/plans/` that workflow steps read from and write to. The runtime manages directory paths, injects them into step prompts, gates on a start plan before step 1, and cleans up after successful completion.

### New file — `workflow_plans.go`
- **Directory layout**: `ask/plans/start/` for the starting plan, `ask/plans/<step>/` for subsequent steps, `ask/plans/<loop>/<iter>/` for loop iterations.
- **`sanitizeStepName`**: maps step names to filesystem-safe path components (alphanumerics + `._-`, run collapse, empty → `"step"`).
- **`ensureStartPlanExists`**: gates workflow start by verifying `ask/plans/start/` exists and contains at least one non-directory file. Returns a clear error message if missing or empty.
- **`clearWorkflowPlans`**: removes all children under `ask/plans/` but preserves the directory itself. Idempotent — safe to call repeatedly, no-op when the dir is absent.
- **`removeAllWorkflowPlans`**: deletes the entire `ask/plans/` tree (used on successful finalization).
- **`clearPlansCore`**: wired as a native registry tool so the LLM can clear stale plan data before submitting `workflow_run`.

### Changes — `workflows_run.go`
- **Start-plan gate** at `StepIdx == 0`: rejects the run with a descriptive message if `ask/plans/start/` is missing or empty.
- **Notes directory injection** into every step prompt via `buildWorkflowStepPrompt`: each step sees its own notes path and the previous step notes path.
- **Loop-as-first-step edge case**: when the first top-level step is a loop, the first inner step of iteration 1 writes to `ask/plans/start/` and receives the "write your starting plan" instruction.
- **Cleanup**: `removeAllWorkflowPlans` is called after successful finalization (failures leave the tree for inspection).

### Changes — `agent_tools_bridge.go` / `mcp_workflows.go`
- `clear_plans` registered as a native deferred-registry tool (not on the core wire tool list).
- `workflowRunToolDescription` updated to instruct the LLM to call `clear_plans` and pre-write a start plan into `ask/plans/start/` before submitting `workflow_run`.

### Schema decision
- `previousStepNotesPath` is **runtime-computed only** — no field is added to `workflowStep` or the JSON-schema view types. This keeps persistence byte-identical and avoids migration. Two new runtime tracking fields (`currentNotesDir`, `prevNotesDir`) live on `workflowRunState`.

## Motivation

Workflow pipelines currently have no persistent artifact surface. Steps can only pass output through the "previous step output" text block threaded into prompts. This forces the LLM to carry all context in its limited prompt window and makes it impossible to produce structured artifacts (files, diagrams, reports) that survive between steps. The `ask/plans/` directory gives each step a dedicated workspace, enables multi-file plans, and enforces a consistent start-plan discipline.

## Testing

- `go build ./...` ✓
- `go vet ./...` ✓
- `go test -count=1 ./...` ✓ (all 219+ tests pass)

### New tests in `workflows_run_test.go`:
- `TestStartWorkflowStep_RejectsMissingStartPlan` — gate rejects absent `ask/plans/start/`
- `TestStartWorkflowStep_RejectsEmptyStartPlan` — gate rejects empty `ask/plans/start/`
- `TestBuildWorkflowStepPrompt_PlansDirs` — start step gets notes dir + "write plan" nudge; subsequent steps get own + previous dir; step 1 has no spurious "previous"
- `TestWorkflowFinalize_RemovesPlansOnSuccess` — successful finalization deletes entire `ask/plans/` tree
- `TestStepNotesDir_PathLayout` — linear, start, and loop iteration paths
- `TestSanitizeStepName` — safe path component mapping
- `TestClearWorkflowPlans_Idempotent` — clearing empty, populated, and already-cleared dirs

### New test in `agent_tools_bridge_test.go`:
- `TestClearPlans_BridgeToolIdempotent` — `clear_plans` is wired, clears children, preserves the dir itself, no-ops on absent dir

### Updated existing tests:
- `TestStartWorkflowStep_UnknownProviderFails` and `TestStartWorkflowStep_EntersLoop` now create the required `ask/plans/start/` fixture to pass the start-plan gate.