### PR TITLE
fix: bypass require-todos gate for ask/plans paths

### DIFF
--- a/agent_tools_file.go
+++ b/agent_tools_file.go
@@ -121,17 +121,25 @@ func agentWriteTool(env *agentToolEnv) fantasy.AgentTool {
 		"write",
 		agentWriteToolDescription,
 		func(ctx context.Context, p agentWriteParams, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
-			// When gateTodosBeforeMutate is on, no mutation before a task
-			// list exists: writing is code-change intent, and the todos call
-			// is the mandatory chokepoint where workflows are checked.
-			// Refuse until todos has applied.
-			if notice := env.requireTodosNotice(); notice != "" {
-				return fantasy.NewTextResponse(notice), nil
-			}
 			if strings.TrimSpace(p.FilePath) == "" {
 				return fantasy.NewTextErrorResponse("file_path is required"), nil
 			}
 			path := env.absPath(p.FilePath)
+			// When gateTodosBeforeMutate is on, no mutation before a task
+			// list exists: writing is code-change intent, and the todos call
+			// is the mandatory chokepoint where workflows are checked.
+			// Refuse until todos has applied.
+			//
+			// Workflow plan files live under ask/plans/ and must be writable
+			// before a workflow_run can be submitted (the runner gates on the
+			// start plan existing). Allowing them through here breaks the
+			// circular dependency between "write the plan" and "create a task
+			// list / run a workflow".
+			if !isPathUnderWorkflowPlans(env.cwd, path) {
+				if notice := env.requireTodosNotice(); notice != "" {
+					return fantasy.NewTextResponse(notice), nil
+				}
+			}
 			oldContent := ""
 			mode := os.FileMode(0o644)
 			if info, err := os.Stat(path); err == nil {
@@ -191,13 +199,6 @@ func agentEditTool(env *agentToolEnv) fantasy.AgentTool {
 		"edit",
 		agentEditToolDescription,
 		func(ctx context.Context, p agentEditParams, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
-			// When gateTodosBeforeMutate is on, no mutation before a task
-			// list exists: editing is code-change intent, and the todos call
-			// is the mandatory chokepoint where workflows are checked.
-			// Refuse until todos has applied.
-			if notice := env.requireTodosNotice(); notice != "" {
-				return fantasy.NewTextResponse(notice), nil
-			}
 			if strings.TrimSpace(p.FilePath) == "" {
 				return fantasy.NewTextErrorResponse("file_path is required"), nil
 			}
@@ -205,6 +206,20 @@ func agentEditTool(env *agentToolEnv) fantasy.AgentTool {
 				return fantasy.NewTextErrorResponse("old_string and new_string are identical — nothing to do"), nil
 			}
 			path := env.absPath(p.FilePath)
+			// When gateTodosBeforeMutate is on, no mutation before a task
+			// list exists: editing is code-change intent, and the todos call
+			// is the mandatory chokepoint where workflows are checked.
+			// Refuse until todos has applied.
+			//
+			// Workflow plan files live under ask/plans/ and must be writable
+			// before a workflow_run can be submitted. Allowing them through
+			// here breaks the circular dependency between "edit the plan" and
+			// "create a task list / run a workflow".
+			if !isPathUnderWorkflowPlans(env.cwd, path) {
+				if notice := env.requireTodosNotice(); notice != "" {
+					return fantasy.NewTextResponse(notice), nil
+				}
+			}
 
 			if p.OldString == "" {
 				if _, err := os.Stat(path); err == nil {

--- a/agent_tools_test.go
+++ b/agent_tools_test.go
@@ -1105,6 +1105,57 @@ func TestRequireTodos_AppliesInAllProjects(t *testing.T) {
 	}
 }
 
+// TestRequireTodos_BypassedForWorkflowPlans_Write verifies that writes
+// under ask/plans/ bypass the require-todos gate. This is required so
+// the model can pre-create the workflow start plan before calling
+// workflow_run, breaking the circular dependency where the gate blocked
+// the very writes the workflow runner demands.
+func TestRequireTodos_BypassedForWorkflowPlans_Write(t *testing.T) {
+	env, _ := newTestToolEnv(t)
+	path := filepath.Join(env.cwd, "ask", "plans", "start", "plan.md")
+	write := agentWriteTool(env)
+
+	resp := runTool(t, write, agentWriteParams{FilePath: path, Content: "# start plan\n"})
+	if resp.IsError || strings.Contains(resp.Content, "todos tool") {
+		t.Fatalf("write under ask/plans should bypass require-todos gate; got %q", resp.Content)
+	}
+	if b, _ := os.ReadFile(path); string(b) != "# start plan\n" {
+		t.Fatalf("plan file should be written; got %q", string(b))
+	}
+}
+
+// TestRequireTodos_BypassedForWorkflowPlans_Edit verifies that edits
+// inside ask/plans/ bypass the require-todos gate.
+func TestRequireTodos_BypassedForWorkflowPlans_Edit(t *testing.T) {
+	env, _ := newTestToolEnv(t)
+	path := writeTestFile(t, env.cwd, filepath.Join("ask", "plans", "start", "plan.md"), "# old\n")
+	env.files.recordRead(path)
+	edit := agentEditTool(env)
+
+	resp := runTool(t, edit, agentEditParams{FilePath: path, OldString: "# old", NewString: "# new"})
+	if resp.IsError || strings.Contains(resp.Content, "todos tool") {
+		t.Fatalf("edit under ask/plans should bypass require-todos gate; got %q", resp.Content)
+	}
+	if b, _ := os.ReadFile(path); string(b) != "# new\n" {
+		t.Fatalf("plan file should be edited; got %q", string(b))
+	}
+}
+
+// TestRequireTodos_StillBlocksPathsOutsideWorkflowPlans confirms that
+// the bypass is narrowly scoped to the ask/plans/ tree; ordinary paths
+// are still gated.
+func TestRequireTodos_StillBlocksPathsOutsideWorkflowPlans(t *testing.T) {
+	env, _ := newTestToolEnv(t)
+	path := filepath.Join(env.cwd, "regular.txt")
+	resp := runTool(t, agentWriteTool(env), agentWriteParams{FilePath: path, Content: "x"})
+	if !strings.Contains(resp.Content, "todos tool") {
+		t.Fatalf("non-plans write should still be gated; got %q", resp.Content)
+	}
+	if _, err := os.Stat(path); err == nil {
+		t.Fatal("non-plans write must not create the file before todos is applied")
+	}
+}
+
 func TestHTMLToText(t *testing.T) {
 	out := htmlToText("<ul><li>one</li><li>two</li></ul><pre>code  here</pre>")
 	if !strings.Contains(out, "one") || !strings.Contains(out, "two") || !strings.Contains(out, "code  here") {

--- a/workflow_plans.go
+++ b/workflow_plans.go
@@ -58,6 +58,24 @@ func stepNotesDir(cwd, stepName, loopName string, iteration int) string {
 	return filepath.Join(base, sanitizeStepName(stepName))
 }
 
+// isPathUnderWorkflowPlans reports whether path is inside the
+// ask/plans/ tree for cwd's project root. It returns false when cwd has
+// no project root or when path is the plans directory itself.
+func isPathUnderWorkflowPlans(cwd, path string) bool {
+	plansDir := workflowPlansDir(cwd)
+	if plansDir == "" {
+		return false
+	}
+	rel, err := filepath.Rel(plansDir, path)
+	if err != nil {
+		return false
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
+}
+
 // sanitizeStepName maps a workflow step name onto a filesystem-safe
 // path component. Runes outside [a-zA-Z0-9._-] become '-'; runs
 // collapse; empty results fall back to "step".


### PR DESCRIPTION
## Summary

Workflow runs require the LLM to pre-create a starting plan under `ask/plans/start/` before invoking `workflow_run`. When the opt-in **Gate Todos Before Mutate** flag is enabled, the `write` and `edit` tools refuse to mutate any file until a `todos` list has been applied. This created a circular dependency: the model could not write the plan the runner demanded because the gate blocked all writes before `workflow_run`.

This change allows `read`/`write`/`edit` operations under the `ask/plans/` tree to bypass the require-todos gate. All other safety checks—read-before-edit, stale-mtime detection, and approval—remain in place for plan files.

## Changes

- Added `isPathUnderWorkflowPlans` helper in `workflow_plans.go` to test whether a path lives inside the `ask/plans/` tree for the current project root.
- Updated `agentWriteTool` and `agentEditTool` in `agent_tools_file.go` to skip `requireTodosNotice` when the target path is under `ask/plans/`.
- Added three behavior-only tests in `agent_tools_test.go`:
  - `write` under `ask/plans/start/` succeeds before any `todos` call.
  - `edit` inside `ask/plans/start/` succeeds before any `todos` call.
  - Ordinary paths outside `ask/plans/` are still gated.

## Motivation

Without this bypass, enabling the todos gate makes workflow pipelines unusable: the runner rejects a workflow start unless `ask/plans/start/` already contains files, but the gate prevents the model from creating those files. The fix keeps the workflow gating intent intact for normal code changes while carving out the small plan-artifact surface the workflow runner itself manages.

## Testing

- `go build ./...` passes
- `go vet ./...` passes
- `go test ./...` passes (~9s, 219+ tests)
- New tests specifically assert the bypass and the continuing gate for non-plans paths.