### PR TITLE
fix: require ask/plans/start/ to be a directory with files

### DIFF
--- a/mcp_workflows.go
+++ b/mcp_workflows.go
@@ -232,9 +232,9 @@ CRITICAL — the workflow starts in a brand-new session with NO access to this c
 
 BEFORE calling workflow_run you MUST:
   1. Call clear_plans to remove any stale plan artifacts from previous runs.
-  2. Write the starting plan for this task into ask/plans/start/ (create at least one file there).
+  2. Create the directory ask/plans/start/ and write the starting plan into one or more FILES INSIDE that directory — for example ask/plans/start/plan.md.
 
-The workflow runner verifies that ask/plans/start/ exists and contains at least one file before step 1; if it is missing or empty, the run is rejected and you must create it and try again.
+CRITICAL: ask/plans/start/ must be a DIRECTORY, not a file. Do not write a single file named "start". The workflow runner verifies that ask/plans/start/ exists as a directory and contains at least one file before step 1. If it is missing, empty, or a file, the run is rejected and you must fix the directory and try again.
 
 append is REQUIRED. You MUST submit the FULL plan the workflow needs to carry the task through end to end on its own — the goal, the concrete steps to take, the relevant file paths, the constraints, and the acceptance criteria. Do NOT pass a bare one-line summary, and do NOT point back at "the conversation above" — the workflow cannot see it. Write append as if briefing someone who has never seen this chat.
 

--- a/workflow_plans.go
+++ b/workflow_plans.go
@@ -101,22 +101,26 @@ func sanitizeStepName(name string) string {
 	return stem
 }
 
-// ensureStartPlanExists verifies that ask/plans/start/ exists and
-// contains at least one non-directory entry before the workflow begins.
+const startPlanDirInstruction = "ask/plans/start/ must be a DIRECTORY (not a file) and must contain at least one file. Create the directory, then write one or more files inside it — for example ask/plans/start/plan.md. Do not write a single file named start."
+
+// ensureStartPlanExists verifies that ask/plans/start/ exists as a
+// directory and contains at least one non-directory entry before the
+// workflow begins. The error text is LLM-facing, so it repeats the
+// exact shape the path must have.
 func ensureStartPlanExists(cwd string) error {
 	dir := startPlanDir(cwd)
 	if dir == "" {
-		return errors.New("start plan is missing: create files in ask/plans/start/ before running the workflow")
+		return errors.New("start plan is missing: " + startPlanDirInstruction)
 	}
 	info, err := os.Stat(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return errors.New("start plan is missing: create files in ask/plans/start/ before running the workflow")
+			return errors.New("start plan is missing: " + startPlanDirInstruction)
 		}
 		return fmt.Errorf("cannot read start plan dir: %w", err)
 	}
 	if !info.IsDir() {
-		return errors.New("ask/plans/start/ exists but is not a directory")
+		return errors.New("ask/plans/start/ exists but is a FILE, not a directory. Remove it, " + startPlanDirInstruction)
 	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -130,7 +134,7 @@ func ensureStartPlanExists(cwd string) error {
 		}
 	}
 	if !hasFile {
-		return errors.New("start plan is empty: add at least one file to ask/plans/start/ before running the workflow")
+		return errors.New("start plan is empty: " + startPlanDirInstruction)
 	}
 	return nil
 }
@@ -182,6 +186,8 @@ func removeAllWorkflowPlans(cwd string) error {
 const clearPlansToolDescription = `Clear the workflow plans directory (ask/plans/).
 
 This removes all files and subdirectories under ask/plans/ but leaves the directory itself. Call this before submitting a new workflow_run to ensure no stale plan data from a previous run interferes with the next workflow.
+
+After clearing, create the directory ask/plans/start/ and write the starting plan into one or more files inside that directory (for example ask/plans/start/plan.md). ask/plans/start/ must be a directory, not a file.
 
 This tool is safe to call repeatedly; it is a no-op when ask/plans/ does not exist.`
 

--- a/workflows_run.go
+++ b/workflows_run.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -561,9 +562,11 @@ func buildWorkflowStepPrompt(step workflowStep, source workflowSource, prevOutpu
 			b.WriteString("\n- Previous step's notes directory: " + pc.prevNotesDir)
 		}
 		if pc.isStartStep {
-			b.WriteString("\n\nThis is the first step. Write your starting plan into your notes directory (")
+			b.WriteString("\n\nThis is the first step. Your notes directory (")
 			b.WriteString(pc.notesDir)
-			b.WriteString(") before doing any other work.")
+			b.WriteString(") MUST be a directory, not a file. Create it if it does not exist, then write one or more files inside it (for example ")
+			b.WriteString(filepath.Join(pc.notesDir, "plan.md"))
+			b.WriteString("). Do NOT write a single file named \"start\". The workflow runner verifies the directory exists and contains files before step 1; if it is missing, empty, or a file, the run will be rejected.")
 		}
 	}
 	var loop *loopPromptCtx

--- a/workflows_run_test.go
+++ b/workflows_run_test.go
@@ -743,6 +743,42 @@ func TestStartWorkflowStep_RejectsMissingStartPlan(t *testing.T) {
 	}
 }
 
+// TestStartWorkflowStep_RejectsStartPlanAsFile: the LLM wrote
+// ask/plans/start as a regular file instead of a directory with files
+// inside it — the gate must reject with a clear, actionable message.
+func TestStartWorkflowStep_RejectsStartPlanAsFile(t *testing.T) {
+	cwd := isolateHome(t)
+	resetWorkflowTrackerForTest()
+	path := filepath.Join(cwd, "ask", "plans", "start")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("oops"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := newTestModel(t, newFakeProvider())
+	m.cwd = cwd
+	m.workflowRun = &workflowRunState{
+		Workflow: workflowDef{
+			Name:  "wf",
+			Steps: []workflowStep{{Name: "first"}},
+		},
+		Source: issueWorkflowSource(issueRef{Provider: "github", Project: "ow/r", Number: 1}),
+	}
+	workflowTracker().markWorking(cwd, m.workflowRun.Source.Key(), "wf", m.id)
+	newM, _ := m.startWorkflowStep()
+	mm := newM.(model)
+	if !mm.workflowRun.failed {
+		t.Fatal("expected failed when start plan is a file")
+	}
+	if !strings.Contains(mm.workflowRun.failedReason, "FILE") {
+		t.Errorf("failure reason must say start is a file; got %q", mm.workflowRun.failedReason)
+	}
+	if !strings.Contains(mm.workflowRun.failedReason, "directory") {
+		t.Errorf("failure reason must direct the LLM to use a directory; got %q", mm.workflowRun.failedReason)
+	}
+}
+
 // TestStartWorkflowStep_RejectsEmptyStartPlan: ask/plans/start/ exists
 // but contains no files — the gate must still reject.
 func TestStartWorkflowStep_RejectsEmptyStartPlan(t *testing.T) {
@@ -782,7 +818,9 @@ func TestBuildWorkflowStepPrompt_PlansDirs(t *testing.T) {
 	for _, want := range []string{
 		"Workflow notes directories:",
 		"- Your notes directory: /proj/ask/plans/start",
-		"Write your starting plan into your notes directory (/proj/ask/plans/start)",
+		"MUST be a directory, not a file",
+		"/proj/ask/plans/start/plan.md",
+		"Do NOT write a single file named \"start\"",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("start-step prompt missing %q; got:\n%s", want, got)


### PR DESCRIPTION
## Summary

The LLM was writing `ask/plans/start` as a single file instead of creating the `ask/plans/start/` directory and placing files inside it. This change strengthens both the instructions and the runner validation so the bad shape is caught and corrected.

## Changes

- `workflow_plans.go`: added a shared `startPlanDirInstruction` string and rewrote `ensureStartPlanExists` errors to explicitly say `ask/plans/start/` must be a directory containing files. Added a dedicated rejection when the path is a regular file.
- `workflows_run.go`: the first step's prompt now clearly states the notes directory must be a directory, gives an example file (`ask/plans/start/plan.md`), and warns against writing a file named `start`.
- `mcp_workflows.go`: updated `workflow_run` tool description with the same directory-with-files requirement.
- `workflow_plans.go`: updated `clear_plans` tool description to remind the model to create the directory and put files inside it.
- `workflows_run_test.go`: added `TestStartWorkflowStep_RejectsStartPlanAsFile` and updated `TestBuildWorkflowStepPrompt_PlansDirs` expectations.

## Motivation

The runner already required `ask/plans/start/` to exist and contain a file, but the error text was not explicit enough about the directory-vs-file distinction. Model behavior showed it was treating the path as a file, so the runner now kicks back with a precise correction and the prompts/tool docs reinforce the correct shape up front.

## Testing

- `go build ./...` passes
- `go vet ./...` passes
- `go test ./...` passes (~8.5s, 219+ tests)
- New test covers the case where `ask/plans/start` is a regular file.