### PR TITLE
fix: kick back workflow plan-directory shape errors to the LLM

### DIFF
--- a/mcp_workflows.go
+++ b/mcp_workflows.go
@@ -234,11 +234,13 @@ BEFORE calling workflow_run you MUST:
   1. Call clear_plans to remove any stale plan artifacts from previous runs.
   2. Create the directory ask/plans/start/ and write the starting plan into one or more FILES INSIDE that directory — for example ask/plans/start/plan.md.
 
-CRITICAL: ask/plans/start/ must be a DIRECTORY, not a file. Do not write a single file named "start". The workflow runner verifies that ask/plans/start/ exists as a directory and contains at least one file before step 1. If it is missing, empty, or a file, the run is rejected and you must fix the directory and try again.
+CRITICAL: ask/plans/start/ must be a DIRECTORY, not a file. Do not write a single file named "start". The workflow runner verifies the shape before step 1. If it is missing, empty, or a file, step 1 is re-prompted to fix the directory before any work is done — the run itself is not aborted.
+
+After step 1, each step writes its notes to ask/plans/<step-name>/. Missing directories are created automatically, but if the path exists as a file the step is re-prompted to fix it.
 
 append is REQUIRED. You MUST submit the FULL plan the workflow needs to carry the task through end to end on its own — the goal, the concrete steps to take, the relevant file paths, the constraints, and the acceptance criteria. Do NOT pass a bare one-line summary, and do NOT point back at "the conversation above" — the workflow cannot see it. Write append as if briefing someone who has never seen this chat.
 
-Errors when the workflow doesn't exist, the name is ambiguous across scopes, when it has no steps, when append is empty, when ask/plans/start/ is missing or empty, or when the UI isn't ready to spawn a tab.`
+Errors when the workflow doesn't exist, the name is ambiguous across scopes, when it has no steps, when append is empty, or when the UI isn't ready to spawn a tab.`
 
 	endTurnToolDescription = `Report the end of your turn for the current workflow step. REQUIRED on every step.
 

--- a/types.go
+++ b/types.go
@@ -723,10 +723,14 @@ type workflowRunState struct {
 	linearText  string
 
 	// remind records why the current dispatch is a re-prompt (a missing
-	// end_turn call, or a loop tail that omitted its decision) so
-	// buildWorkflowStepPrompt can append the matching reminder. remindNone
-	// on a normal first dispatch.
+	// end_turn call, a loop tail that omitted its decision, or a plan
+	// directory that is not usable) so buildWorkflowStepPrompt can append
+	// the matching reminder. remindNone on a normal first dispatch.
 	remind remindKind
+
+	// remindDetail carries dynamic text for remindFixPlanDir so the LLM
+	// knows exactly which path is the wrong shape and what to do about it.
+	remindDetail string
 
 	// stepLog accumulates the assistant non-tool text emitted by each
 	// completed top-level step so the next step's prompt can include a

--- a/workflow_plans.go
+++ b/workflow_plans.go
@@ -103,6 +103,30 @@ func sanitizeStepName(name string) string {
 
 const startPlanDirInstruction = "ask/plans/start/ must be a DIRECTORY (not a file) and must contain at least one file. Create the directory, then write one or more files inside it — for example ask/plans/start/plan.md. Do not write a single file named start."
 
+// ensureStepNotesDir verifies that a non-start step's notes directory
+// exists as a directory. A missing directory is created automatically;
+// an existing regular file is an error so the runner can kick the
+// problem back to the LLM. The error text is LLM-facing.
+func ensureStepNotesDir(dir string) error {
+	if dir == "" {
+		return errors.New("notes directory path is empty")
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if mkerr := os.MkdirAll(dir, 0o755); mkerr != nil {
+				return fmt.Errorf("cannot create notes directory %s: %w", dir, mkerr)
+			}
+			return nil
+		}
+		return fmt.Errorf("cannot read notes directory %s: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s exists but is a FILE, not a directory. Remove it, then create it as a directory and write your notes files inside it", dir)
+	}
+	return nil
+}
+
 // ensureStartPlanExists verifies that ask/plans/start/ exists as a
 // directory and contains at least one non-directory entry before the
 // workflow begins. The error text is LLM-facing, so it repeats the

--- a/workflows_run.go
+++ b/workflows_run.go
@@ -609,7 +609,7 @@ func buildWorkflowStepPrompt(step workflowStep, source workflowSource, prevOutpu
 			b.WriteString(pc.notesDir)
 			b.WriteString(") MUST be a directory, not a file. Create it if it does not exist, then write one or more files inside it (for example ")
 			b.WriteString(filepath.Join(pc.notesDir, "plan.md"))
-			b.WriteString("). Do NOT write a single file named \"start\". The workflow runner verifies the directory exists and contains files before step 1; if it is missing, empty, or a file, the run will be rejected.")
+			b.WriteString("). Do NOT write a single file named \"start\". The workflow runner verifies the directory exists and contains files before step 1; if it is missing, empty, or a file, this step will be re-prompted to fix the directory before any work is done.")
 		}
 	}
 	var loop *loopPromptCtx

--- a/workflows_run.go
+++ b/workflows_run.go
@@ -114,14 +114,6 @@ func (m model) startWorkflowStep() (tea.Model, tea.Cmd) {
 	}
 	top := r.Workflow.Steps[r.StepIdx]
 
-	// Gate: the workflow must not start until the LLM has written a
-	// starting plan into ask/plans/start/.
-	if r.StepIdx == 0 && r.loop == nil {
-		if err := ensureStartPlanExists(m.cwd); err != nil {
-			return m.workflowFinalize(false, err.Error())
-		}
-	}
-
 	// Enter a loop step the first time the cursor lands on it.
 	if top.isLoop() && r.loop == nil {
 		if len(top.Steps) == 0 {
@@ -162,6 +154,7 @@ func (m model) startWorkflowStep() (tea.Model, tea.Cmd) {
 	r.currentNotesDir = notesDir
 	pc := &stepPromptCtx{
 		remind:       r.remind,
+		remindDetail: r.remindDetail,
 		notesDir:     notesDir,
 		prevNotesDir: r.prevNotesDir,
 		isStartStep:  isStartStep || isLoopStartStep,
@@ -174,6 +167,23 @@ func (m model) startWorkflowStep() (tea.Model, tea.Cmd) {
 			exitCondition: top.ExitCondition,
 			isTail:        r.loop.innerIdx == len(top.Steps)-1,
 		}
+	}
+
+	// Validate the notes directory shape. The start directory must already
+	// exist as a directory with at least one file; all other step notes
+	// directories are auto-created when missing. If any directory exists as
+	// a regular file, kick the problem back to the current step instead of
+	// failing the run.
+	if pc.isStartStep {
+		if err := ensureStartPlanExists(m.cwd); err != nil {
+			r.remind = remindFixPlanDir
+			r.remindDetail = err.Error()
+			return m.sendToProvider(buildWorkflowStepPrompt(step, r.Source, r.contextForDispatch(), pc))
+		}
+	} else if err := ensureStepNotesDir(notesDir); err != nil {
+		r.remind = remindFixPlanDir
+		r.remindDetail = err.Error()
+		return m.sendToProvider(buildWorkflowStepPrompt(step, r.Source, r.contextForDispatch(), pc))
 	}
 
 	prov := providerByID(step.Provider)
@@ -281,6 +291,7 @@ func (m model) advanceWorkflowStep(stepErr error) (tea.Model, tea.Cmd) {
 	sig := r.pendingEndTurn
 	r.pendingEndTurn = nil
 	r.remind = remindNone
+	r.remindDetail = ""
 
 	// Linear (non-loop) step.
 	if r.loop == nil {
@@ -297,6 +308,11 @@ func (m model) advanceWorkflowStep(stepErr error) (tea.Model, tea.Cmd) {
 		}
 		// Got the summary: render the step's line, record output, advance.
 		m.appendHistory(stepSummaryLine(step.Name, step.Provider, step.Model, sig.summary, m.width))
+		if err := revalidateWorkflowNotesDir(m.cwd, r); err != nil {
+			r.remind = remindFixPlanDir
+			r.remindDetail = err.Error()
+			return m.dispatchOrFinalize()
+		}
 		r.prevNotesDir = r.currentNotesDir
 		if txt != "" {
 			r.stepLog = append(r.stepLog, txt)
@@ -343,6 +359,11 @@ func (m model) advanceWorkflowStep(stepErr error) (tea.Model, tea.Cmd) {
 	// same iteration. (A "continue" and an omitted decision are equivalent
 	// here — only the tail's continue advances the iteration.)
 	if !isTail {
+		if err := revalidateWorkflowNotesDir(m.cwd, r); err != nil {
+			r.remind = remindFixPlanDir
+			r.remindDetail = err.Error()
+			return m.dispatchOrFinalize()
+		}
 		r.prevNotesDir = r.currentNotesDir
 		if txt != "" {
 			r.loop.iterationLog = append(r.loop.iterationLog, txt)
@@ -366,6 +387,11 @@ func (m model) advanceWorkflowStep(stepErr error) (tea.Model, tea.Cmd) {
 
 	// Tail registered continue: record output, then start the next
 	// iteration or soft-exit if the iteration cap is reached.
+	if err := revalidateWorkflowNotesDir(m.cwd, r); err != nil {
+		r.remind = remindFixPlanDir
+		r.remindDetail = err.Error()
+		return m.dispatchOrFinalize()
+	}
 	r.prevNotesDir = r.currentNotesDir
 	if txt != "" {
 		r.loop.iterationLog = append(r.loop.iterationLog, txt)
@@ -385,6 +411,21 @@ func (m model) advanceWorkflowStep(stepErr error) (tea.Model, tea.Cmd) {
 	r.loop.retry = 0
 	r.loop.retryText = ""
 	return m.dispatchOrFinalize()
+}
+
+// revalidateWorkflowNotesDir re-checks the current step's notes
+// directory. It is called at turn end before advancing the cursor so a
+// step that was fixing its directory gets another chance if the shape
+// is still wrong. The start directory must contain files; other
+// directories are auto-created when missing.
+func revalidateWorkflowNotesDir(cwd string, r *workflowRunState) error {
+	if r.currentNotesDir == "" {
+		return nil
+	}
+	if r.currentNotesDir == startPlanDir(cwd) {
+		return ensureStartPlanExists(cwd)
+	}
+	return ensureStepNotesDir(r.currentNotesDir)
 }
 
 // dispatchOrFinalize is the shared tail of advanceWorkflowStep: when
@@ -492,6 +533,7 @@ const (
 	remindNone       remindKind = iota
 	remindNoSummary             // the prior turn ended without calling end_turn
 	remindNoDecision            // a loop tail called end_turn but omitted its decision
+	remindFixPlanDir            // a workflow notes directory is missing or is a file
 )
 
 // stepPromptCtx carries the per-dispatch facts buildWorkflowStepPrompt
@@ -501,6 +543,7 @@ const (
 type stepPromptCtx struct {
 	loop         *loopPromptCtx
 	remind       remindKind
+	remindDetail string
 	notesDir     string
 	prevNotesDir string
 	isStartStep  bool
@@ -579,7 +622,7 @@ func buildWorkflowStepPrompt(step workflowStep, source workflowSource, prevOutpu
 	b.WriteString(endTurnInstructionBlock(loop))
 	if remind != remindNone {
 		b.WriteString("\n\n")
-		b.WriteString(endTurnReminder(remind))
+		b.WriteString(endTurnReminder(remind, pc.remindDetail))
 	}
 	return strings.TrimSpace(b.String())
 }
@@ -618,12 +661,19 @@ func endTurnInstructionBlock(loop *loopPromptCtx) string {
 
 // endTurnReminder is appended to a re-prompted step's prompt, explaining
 // why it's being asked again without making it redo the work shown above.
-func endTurnReminder(k remindKind) string {
+func endTurnReminder(k remindKind, detail string) string {
 	switch k {
 	case remindNoDecision:
 		return "REMINDER: you called end_turn without a `decision`, which is required for the final step of a " +
 			"loop iteration. You have already done the work shown above — do NOT repeat it. Call end_turn again now " +
 			"with decision=\"continue\" or decision=\"break\"."
+	case remindFixPlanDir:
+		msg := "REMINDER: the workflow notes directory is not usable"
+		if detail != "" {
+			msg += ": " + detail
+		}
+		msg += ". You must make it a directory containing files, then call end_turn."
+		return msg
 	default: // remindNoSummary
 		return "REMINDER: your previous turn ended without calling end_turn. You have already done the work shown " +
 			"above — do NOT repeat it. Call the end_turn tool now (see the instructions above for what to include)."

--- a/workflows_run_test.go
+++ b/workflows_run_test.go
@@ -638,6 +638,17 @@ func TestBuildWorkflowStepPrompt_EndTurnInstructions(t *testing.T) {
 	if got := buildWorkflowStepPrompt(step, src, nil, &stepPromptCtx{remind: remindNoSummary}); !strings.Contains(got, "REMINDER") {
 		t.Error("no-summary remind prompt should include the reminder")
 	}
+
+	// Plan-directory reminder carries the dynamic detail.
+	fix := buildWorkflowStepPrompt(step, src, nil, &stepPromptCtx{
+		remind:       remindFixPlanDir,
+		remindDetail: "ask/plans/start/ exists but is a FILE",
+	})
+	for _, want := range []string{"REMINDER", "ask/plans/start/ exists but is a FILE", "directory containing files"} {
+		if !strings.Contains(fix, want) {
+			t.Errorf("fix-plan-dir reminder missing %q; got:\n%s", want, fix)
+		}
+	}
 }
 
 // TestStepSummaryLine renders the per-step log entry: name, provider/model
@@ -718,74 +729,14 @@ func startPlanWorkspace(t *testing.T) (cwd string) {
 	return cwd
 }
 
-// TestStartWorkflowStep_RejectsMissingStartPlan: StepIdx 0 without
-// ask/plans/start/ must finalise as failed with the gate message.
-func TestStartWorkflowStep_RejectsMissingStartPlan(t *testing.T) {
+// TestStartWorkflowStep_RePromptsMissingStartPlan: StepIdx 0 without
+// ask/plans/start/ kicks back to the LLM instead of finalising the run.
+func TestStartWorkflowStep_RePromptsMissingStartPlan(t *testing.T) {
 	cwd := isolateHome(t)
 	resetWorkflowTrackerForTest()
-	m := newTestModel(t, newFakeProvider())
-	m.cwd = cwd
-	m.workflowRun = &workflowRunState{
-		Workflow: workflowDef{
-			Name:  "wf",
-			Steps: []workflowStep{{Name: "first"}},
-		},
-		Source: issueWorkflowSource(issueRef{Provider: "github", Project: "ow/r", Number: 1}),
-	}
-	workflowTracker().markWorking(cwd, m.workflowRun.Source.Key(), "wf", m.id)
-	newM, _ := m.startWorkflowStep()
-	mm := newM.(model)
-	if !mm.workflowRun.failed {
-		t.Fatal("expected failed when start plan is missing")
-	}
-	if !strings.Contains(mm.workflowRun.failedReason, "start plan is missing") {
-		t.Errorf("failure reason must mention missing start plan; got %q", mm.workflowRun.failedReason)
-	}
-}
-
-// TestStartWorkflowStep_RejectsStartPlanAsFile: the LLM wrote
-// ask/plans/start as a regular file instead of a directory with files
-// inside it — the gate must reject with a clear, actionable message.
-func TestStartWorkflowStep_RejectsStartPlanAsFile(t *testing.T) {
-	cwd := isolateHome(t)
-	resetWorkflowTrackerForTest()
-	path := filepath.Join(cwd, "ask", "plans", "start")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, []byte("oops"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	m := newTestModel(t, newFakeProvider())
-	m.cwd = cwd
-	m.workflowRun = &workflowRunState{
-		Workflow: workflowDef{
-			Name:  "wf",
-			Steps: []workflowStep{{Name: "first"}},
-		},
-		Source: issueWorkflowSource(issueRef{Provider: "github", Project: "ow/r", Number: 1}),
-	}
-	workflowTracker().markWorking(cwd, m.workflowRun.Source.Key(), "wf", m.id)
-	newM, _ := m.startWorkflowStep()
-	mm := newM.(model)
-	if !mm.workflowRun.failed {
-		t.Fatal("expected failed when start plan is a file")
-	}
-	if !strings.Contains(mm.workflowRun.failedReason, "FILE") {
-		t.Errorf("failure reason must say start is a file; got %q", mm.workflowRun.failedReason)
-	}
-	if !strings.Contains(mm.workflowRun.failedReason, "directory") {
-		t.Errorf("failure reason must direct the LLM to use a directory; got %q", mm.workflowRun.failedReason)
-	}
-}
-
-// TestStartWorkflowStep_RejectsEmptyStartPlan: ask/plans/start/ exists
-// but contains no files — the gate must still reject.
-func TestStartWorkflowStep_RejectsEmptyStartPlan(t *testing.T) {
-	cwd := startPlanWorkspace(t)
-	resetWorkflowTrackerForTest()
-	withRegisteredProviders(t, newFakeProvider())
-	m := newTestModel(t, newFakeProvider())
+	fake := newFakeProvider()
+	withRegisteredProviders(t, fake)
+	m := newTestModel(t, fake)
 	m.cwd = cwd
 	m.workflowRun = &workflowRunState{
 		Workflow: workflowDef{
@@ -795,13 +746,198 @@ func TestStartWorkflowStep_RejectsEmptyStartPlan(t *testing.T) {
 		Source: issueWorkflowSource(issueRef{Provider: "github", Project: "ow/r", Number: 1}),
 	}
 	workflowTracker().markWorking(cwd, m.workflowRun.Source.Key(), "wf", m.id)
-	newM, _ := m.startWorkflowStep()
+	newM, cmd := m.startWorkflowStep()
 	mm := newM.(model)
-	if !mm.workflowRun.failed {
-		t.Fatal("expected failed when start plan is empty")
+	if mm.workflowRun.failed {
+		t.Fatalf("expected re-prompt, not failure; reason=%q", mm.workflowRun.failedReason)
 	}
-	if !strings.Contains(mm.workflowRun.failedReason, "start plan is empty") {
-		t.Errorf("failure reason must mention empty start plan; got %q", mm.workflowRun.failedReason)
+	if mm.workflowRun.remind != remindFixPlanDir {
+		t.Errorf("remind=%v want remindFixPlanDir", mm.workflowRun.remind)
+	}
+	if !strings.Contains(mm.workflowRun.remindDetail, "start plan is missing") {
+		t.Errorf("remindDetail must mention missing start plan; got %q", mm.workflowRun.remindDetail)
+	}
+	if !mm.busy {
+		t.Error("expected a provider dispatch (busy=true) for the re-prompt")
+	}
+	if cmd == nil {
+		t.Fatal("expected a dispatch cmd")
+	}
+}
+
+// TestStartWorkflowStep_RePromptsStartPlanAsFile: the LLM wrote
+// ask/plans/start as a regular file — kick it back to make a directory.
+func TestStartWorkflowStep_RePromptsStartPlanAsFile(t *testing.T) {
+	cwd := isolateHome(t)
+	resetWorkflowTrackerForTest()
+	path := filepath.Join(cwd, "ask", "plans", "start")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("oops"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fake := newFakeProvider()
+	withRegisteredProviders(t, fake)
+	m := newTestModel(t, fake)
+	m.cwd = cwd
+	m.workflowRun = &workflowRunState{
+		Workflow: workflowDef{
+			Name:  "wf",
+			Steps: []workflowStep{{Name: "first", Provider: "fake"}},
+		},
+		Source: issueWorkflowSource(issueRef{Provider: "github", Project: "ow/r", Number: 1}),
+	}
+	workflowTracker().markWorking(cwd, m.workflowRun.Source.Key(), "wf", m.id)
+	newM, cmd := m.startWorkflowStep()
+	mm := newM.(model)
+	if mm.workflowRun.failed {
+		t.Fatalf("expected re-prompt, not failure; reason=%q", mm.workflowRun.failedReason)
+	}
+	if mm.workflowRun.remind != remindFixPlanDir {
+		t.Errorf("remind=%v want remindFixPlanDir", mm.workflowRun.remind)
+	}
+	if !strings.Contains(mm.workflowRun.remindDetail, "FILE") {
+		t.Errorf("remindDetail must say start is a file; got %q", mm.workflowRun.remindDetail)
+	}
+	if !strings.Contains(mm.workflowRun.remindDetail, "directory") {
+		t.Errorf("remindDetail must direct the LLM to use a directory; got %q", mm.workflowRun.remindDetail)
+	}
+	if !mm.busy {
+		t.Error("expected a provider dispatch (busy=true) for the re-prompt")
+	}
+	if cmd == nil {
+		t.Fatal("expected a dispatch cmd")
+	}
+}
+
+// TestStartWorkflowStep_RePromptsEmptyStartPlan: ask/plans/start/ exists
+// but contains no files — kick it back to add files inside the directory.
+func TestStartWorkflowStep_RePromptsEmptyStartPlan(t *testing.T) {
+	cwd := startPlanWorkspace(t)
+	resetWorkflowTrackerForTest()
+	fake := newFakeProvider()
+	withRegisteredProviders(t, fake)
+	m := newTestModel(t, fake)
+	m.cwd = cwd
+	m.workflowRun = &workflowRunState{
+		Workflow: workflowDef{
+			Name:  "wf",
+			Steps: []workflowStep{{Name: "first", Provider: "fake"}},
+		},
+		Source: issueWorkflowSource(issueRef{Provider: "github", Project: "ow/r", Number: 1}),
+	}
+	workflowTracker().markWorking(cwd, m.workflowRun.Source.Key(), "wf", m.id)
+	newM, cmd := m.startWorkflowStep()
+	mm := newM.(model)
+	if mm.workflowRun.failed {
+		t.Fatalf("expected re-prompt, not failure; reason=%q", mm.workflowRun.failedReason)
+	}
+	if mm.workflowRun.remind != remindFixPlanDir {
+		t.Errorf("remind=%v want remindFixPlanDir", mm.workflowRun.remind)
+	}
+	if !strings.Contains(mm.workflowRun.remindDetail, "start plan is empty") {
+		t.Errorf("remindDetail must mention empty start plan; got %q", mm.workflowRun.remindDetail)
+	}
+	if !mm.busy {
+		t.Error("expected a provider dispatch (busy=true) for the re-prompt")
+	}
+	if cmd == nil {
+		t.Fatal("expected a dispatch cmd")
+	}
+}
+
+// TestStartWorkflowStep_RePromptsStepNotesDirAsFile: a non-start step's
+// notes directory (ask/plans/<step>/) must be a directory, not a file.
+func TestStartWorkflowStep_RePromptsStepNotesDirAsFile(t *testing.T) {
+	cwd := startPlanWorkspace(t)
+	resetWorkflowTrackerForTest()
+	// Step 1's notes dir is ask/plans/start/, already created by the fixture.
+	// Create step 2's notes dir as a file to trigger the guard.
+	stepDir := filepath.Join(cwd, "ask", "plans", "second")
+	if err := os.MkdirAll(filepath.Dir(stepDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stepDir, []byte("not a dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fake := newFakeProvider()
+	withRegisteredProviders(t, fake)
+	m := newTestModel(t, fake)
+	m.cwd = cwd
+	m.workflowRun = &workflowRunState{
+		Workflow: workflowDef{
+			Name: "wf",
+			Steps: []workflowStep{
+				{Name: "first", Provider: "fake"},
+				{Name: "second", Provider: "fake"},
+			},
+		},
+		Source:       issueWorkflowSource(issueRef{Provider: "github", Project: "ow/r", Number: 1}),
+		StepIdx:      1,
+		prevNotesDir: filepath.Join(cwd, "ask", "plans", "start"),
+	}
+	workflowTracker().markWorking(cwd, m.workflowRun.Source.Key(), "wf", m.id)
+	newM, cmd := m.startWorkflowStep()
+	mm := newM.(model)
+	if mm.workflowRun.failed {
+		t.Fatalf("expected re-prompt, not failure; reason=%q", mm.workflowRun.failedReason)
+	}
+	if mm.workflowRun.StepIdx != 1 {
+		t.Errorf("StepIdx must stay on step 2; got %d", mm.workflowRun.StepIdx)
+	}
+	if mm.workflowRun.remind != remindFixPlanDir {
+		t.Errorf("remind=%v want remindFixPlanDir", mm.workflowRun.remind)
+	}
+	if !strings.Contains(mm.workflowRun.remindDetail, "FILE") {
+		t.Errorf("remindDetail must say the path is a file; got %q", mm.workflowRun.remindDetail)
+	}
+	if !mm.busy {
+		t.Error("expected a provider dispatch (busy=true) for the re-prompt")
+	}
+	if cmd == nil {
+		t.Fatal("expected a dispatch cmd")
+	}
+}
+
+// TestStartWorkflowStep_CreatesMissingStepNotesDir: a missing non-start
+// notes directory is created automatically so the step can proceed.
+func TestStartWorkflowStep_CreatesMissingStepNotesDir(t *testing.T) {
+	cwd := startPlanWorkspace(t)
+	resetWorkflowTrackerForTest()
+	fake := newFakeProvider()
+	withRegisteredProviders(t, fake)
+	m := newTestModel(t, fake)
+	m.cwd = cwd
+	m.workflowRun = &workflowRunState{
+		Workflow: workflowDef{
+			Name: "wf",
+			Steps: []workflowStep{
+				{Name: "first", Provider: "fake"},
+				{Name: "second", Provider: "fake"},
+			},
+		},
+		Source:       issueWorkflowSource(issueRef{Provider: "github", Project: "ow/r", Number: 1}),
+		StepIdx:      1,
+		prevNotesDir: filepath.Join(cwd, "ask", "plans", "start"),
+	}
+	workflowTracker().markWorking(cwd, m.workflowRun.Source.Key(), "wf", m.id)
+	newM, cmd := m.startWorkflowStep()
+	mm := newM.(model)
+	if mm.workflowRun.failed {
+		t.Fatalf("expected dispatch, not failure; reason=%q", mm.workflowRun.failedReason)
+	}
+	if mm.workflowRun.remind != remindNone {
+		t.Errorf("remind should be none for auto-created dir; got %v", mm.workflowRun.remind)
+	}
+	if _, err := os.Stat(filepath.Join(cwd, "ask", "plans", "second")); err != nil {
+		t.Errorf("missing notes dir should be created; stat err=%v", err)
+	}
+	if !mm.busy {
+		t.Error("expected a provider dispatch (busy=true)")
+	}
+	if cmd == nil {
+		t.Fatal("expected a dispatch cmd")
 	}
 }
 


### PR DESCRIPTION
When a workflow plan directory has the wrong shape, the runner now re-prompts the current step instead of finalising the run as failed.

Changes:
- Start-plan errors (missing, empty, or a file) now kick back to step 1.
- Every subsequent step notes directory is guarded the same way: missing dirs are auto-created, but existing files kick the step back.
- Added remindFixPlanDir + remindDetail carry for dynamic LLM-facing error text.
- Re-validates the current notes directory before advancing the cursor.
- Updated/added tests for start and non-start directory failures and auto-creation.

Closes the remaining plan-directory defects from #58.