### PR TITLE
fix: remove hard line-wrapping from workflow step summaries

### DIFF
--- a/workflows_run.go
+++ b/workflows_run.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
-	lipgloss "charm.land/lipgloss/v2"
 )
 
 // workflowTabHandleKey gates input on a workflow tab. The user
@@ -307,7 +306,7 @@ func (m model) advanceWorkflowStep(stepErr error) (tea.Model, tea.Cmd) {
 			return m.dispatchOrFinalize()
 		}
 		// Got the summary: render the step's line, record output, advance.
-		m.appendHistory(stepSummaryLine(step.Name, step.Provider, step.Model, sig.summary, m.width))
+		m.appendHistory(stepSummaryLine(step.Name, step.Provider, step.Model, sig.summary))
 		if err := revalidateWorkflowNotesDir(m.cwd, r); err != nil {
 			r.remind = remindFixPlanDir
 			r.remindDetail = err.Error()
@@ -341,7 +340,7 @@ func (m model) advanceWorkflowStep(stepErr error) (tea.Model, tea.Cmd) {
 	}
 
 	// We have a summary: render the inner step's line.
-	m.appendHistory(stepSummaryLine(inner.Name, inner.Provider, inner.Model, sig.summary, m.width))
+	m.appendHistory(stepSummaryLine(inner.Name, inner.Provider, inner.Model, sig.summary))
 
 	// Break from any inner step exits the loop immediately, skipping the
 	// rest of the iteration.
@@ -699,26 +698,18 @@ func loopNoteLine(loopName, action, detail string) string {
 
 // stepSummaryLine renders a completed step's entry in the workflow log: a
 // styled "▸ name (provider/model)" header with the agent's end_turn
-// summary wrapped beneath it. This per-step content is what replaces the
-// raw transcript on a workflow tab. width is the tab width; the summary
-// wraps to fit with a small indent.
-func stepSummaryLine(name, provider, model, summary string, width int) string {
+// summary beneath it. This per-step content is what replaces the raw
+// transcript on a workflow tab. The summary is not pre-wrapped; the
+// viewport soft-wraps it at render time.
+func stepSummaryLine(name, provider, model, summary string) string {
 	header := promptStyle.Render("▸ " + nonEmpty(name, "step"))
 	if meta := providerMeta(provider, model); meta != "" {
 		header += dimStyle.Render(" (" + meta + ")")
 	}
-	lines := []string{outputStyle.Render(header)}
 	if s := strings.TrimSpace(summary); s != "" {
-		wrapWidth := width - 4
-		if wrapWidth < 20 {
-			wrapWidth = 20
-		}
-		wrapped := lipgloss.NewStyle().Width(wrapWidth).Render(s)
-		for _, ln := range strings.Split(wrapped, "\n") {
-			lines = append(lines, outputStyle.Render("  "+ln))
-		}
+		header += "\n" + outputStyle.Render("  " + s)
 	}
-	return strings.Join(lines, "\n")
+	return header
 }
 
 // providerMeta renders the "provider/model" suffix shown next to a step

--- a/workflows_run_test.go
+++ b/workflows_run_test.go
@@ -652,12 +652,29 @@ func TestBuildWorkflowStepPrompt_EndTurnInstructions(t *testing.T) {
 }
 
 // TestStepSummaryLine renders the per-step log entry: name, provider/model
-// meta, and the agent's summary.
+// meta, and the agent's summary. The summary must NOT be pre-wrapped — the
+// viewport soft-wraps it at render time, so stepSummaryLine returns it as a
+// single unbroken rendered string.
 func TestStepSummaryLine(t *testing.T) {
-	got := stepSummaryLine("review", "codex", "gpt-5", "found two bugs", 100)
-	for _, want := range []string{"review", "codex/gpt-5", "found two bugs"} {
+	summary := "This is a very long summary that would absolutely wrap under the old narrow width-based logic and must remain a single unbroken rendered string"
+	got := stepSummaryLine("review", "codex", "gpt-5", summary)
+	for _, want := range []string{"review", "codex/gpt-5"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("summary line missing %q; got %q", want, got)
+		}
+	}
+	if !strings.Contains(got, summary) {
+		t.Errorf("full summary text must appear verbatim; got %q", got)
+	}
+	// No hard newline should break a word in the summary body. Splitting on
+	// newlines and looking for the summary header line (which starts with "▸")
+	// vs the summary body line — the body line must carry the full text.
+	for _, ln := range strings.Split(got, "\n") {
+		if strings.HasPrefix(ln, "▸") {
+			continue
+		}
+		if strings.Contains(ln, "summary") && !strings.Contains(ln, summary) {
+			t.Errorf("summary body line contains a fragment but not the full text — hard-wrapped; line=%q", ln)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

`stepSummaryLine` in `workflows_run.go` previously hard-wrapped the agent's `end_turn` summary using lipgloss width-based wrapping at step-completion time. Because wrapping happened at a fixed width (the tab width at that moment), narrow terminals produced persistent hard line breaks that remained even after the terminal was resized wider.

This change removes the `width int` parameter from `stepSummaryLine` entirely and lets the viewport soft-wrap the summary at render time — matching how the main chat screen handles content.

## Motivation

The hard-wrapped lines were a user-visible bug: if a workflow step completed while the terminal was narrow, the summary text would be permanently broken across multiple lines and never reflow when the user later resized the terminal. The fix aligns workflow step summaries with the main chat screen's approach of storing raw text and soft-wrapping at view time.

## Changes

| File | Change |
|------|--------|
| `workflows_run.go` | Removed `width int` parameter from `stepSummaryLine`. Removed `lipgloss` import. Summary now returned as a single unbroken rendered string. |
| `workflows_run.go` (call sites) | Two call sites (linear step ~L309, loop step ~L343) no longer pass `m.width`. |
| `workflows_run_test.go` | `TestStepSummaryLine` now uses a 120+ char summary, asserts full text appears verbatim, and checks no hard newlines fragment the summary body. |

## Testing

- `go build ./...` — passes
- `go vet ./...` — passes
- `go test ./...` — all tests pass (9.36s)