### PR TITLE
deepseek: change default reasoning effort from high to max

### DIFF
--- a/deepseek.go
+++ b/deepseek.go
@@ -53,7 +53,7 @@ var deepseekLanguageModel = func(cfg apiProviderConfig, modelID string) (fantasy
 // controls, returning the per-call provider options and the sampling
 // temperature (DeepSeek recommends 0.0 for coding, but thinking mode
 // does not accept sampling params at all, so it only applies to
-// thinking=off).
+// thinking=off). The default (empty effort) is max.
 func deepseekProviderOptions(effort string) (fantasy.ProviderOptions, *float64) {
 	opts := &openaicompat.ProviderOptions{}
 	var temperature *float64
@@ -62,11 +62,11 @@ func deepseekProviderOptions(effort string) (fantasy.ProviderOptions, *float64) 
 		opts.ExtraBody = map[string]any{"thinking": map[string]any{"type": "disabled"}}
 		t := 0.0
 		temperature = &t
-	case "max":
-		e := openai.ReasoningEffortXHigh
-		opts.ReasoningEffort = &e
-	default: // "high" and unset both ride the default thinking mode
+	case "high":
 		e := openai.ReasoningEffortHigh
+		opts.ReasoningEffort = &e
+	default: // "max" and empty/unset both map to max effort (xhigh on the wire)
+		e := openai.ReasoningEffortXHigh
 		opts.ReasoningEffort = &e
 	}
 	return fantasy.ProviderOptions{deepseekProviderID: opts}, temperature

--- a/deepseek_test.go
+++ b/deepseek_test.go
@@ -92,8 +92,8 @@ func TestDeepseekProviderOptions(t *testing.T) {
 
 	opts, temp = deepseekProviderOptions("")
 	ds = opts["deepseek"].(*openaicompat.ProviderOptions)
-	if ds.ReasoningEffort == nil || string(*ds.ReasoningEffort) != "high" || temp != nil {
-		t.Errorf("default effort must be high thinking: %+v", ds)
+	if ds.ReasoningEffort == nil || string(*ds.ReasoningEffort) != "xhigh" || temp != nil {
+		t.Errorf("default effort must be max thinking: %+v", ds)
 	}
 }
 


### PR DESCRIPTION
## Summary
Change DeepSeek's default reasoning effort from `high` to `max`. Unset/empty effort and explicit `"max"` now both map to `reasoning_effort=xhigh` (the wire value for max thinking). Explicit `"high"` still maps to `reasoning_effort=high` unchanged.

## Motivation
DeepSeek defaulting to `high` reasoning effort means the model under-thinks on complex coding tasks. `max` reasoning effort gives better results for ask sessions where correctness matters more than latency. Users who prefer `high` can still set it explicitly — this only changes the *default*.

## Changes
- **`deepseek.go`**: Split the effort switch — explicit `"high"` case maps to `ReasoningEffortHigh`; the default case (covering `""` and `"max"`) maps to `ReasoningEffortXHigh`. Updated the function comment to state the default is max.
- **`deepseek_test.go`**: Updated empty-effort assertion to expect `"xhigh"` instead of `"high"`.

## Verification
- `go test ./...` passes
- `go build ./...` passes
- `go vet ./...` passes

### Behavior matrix
| Input | Reasoning effort | Temperature |
|-------|-----------------|-------------|
| `""` (default) | `xhigh` | nil |
| `"high"` | `high` | nil |
| `"max"` | `xhigh` | nil |
| `"off"` | disabled | 0.0 |