### PR TITLE
feat: add @-link following for agent markdown docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -841,3 +841,27 @@ agent_tools_bridge.go) and the question modal is driven by
 - Scrollbar column is drawn over `m.width-1`. If any text-rendering style grows a margin or a user-bar width past `m.width-1`, the scrollbar will be overwritten or vice-versa.
 - `askToolRequestMsg` is rejected if the modal is already open — only one MCP ask at a time. Double-calls from Claude return `cancelled: true` for the second one.
 - `contentFingerprint` must mix in `len(m.history[m.shellOutIdx].text)` whenever a shell output entry is active. The frame cache is keyed on `len(m.history) | m.width`, and shell mode appends streamed lines in place to a single history entry, so without that extra term the cache returns a stale (first-line-only) view until something else (spinner row, window resize) perturbs the key.
+
+## @-link references
+
+Markdown files that are part of the system prompt (CLAUDE.md, AGENTS.md, eager rules, skill bodies, subagent bodies) may reference other markdown files using `@path/to/file.md` syntax. These references are resolved at prompt-assembly time and the referenced files' bodies are inlined.
+
+Syntax: `@path/to/file.md` — exactly the @-prefixed relative path to a `.md` file.
+
+Do not place `@`-links inside fenced code blocks — they are stripped before extraction and are never followed.
+
+Resolution rules:
+- The path is relative to the repository root (or the working directory when there is no `.git` ancestor).
+- The path must not start with `/`, `./`, or `../`, and must not contain a `..` segment anywhere.
+- The path must end in `.md` (case-insensitive — `.MD`, `.Md` etc. are accepted).
+- The resolved absolute path must lie inside the repository root (checked via `filepath.Rel`).
+- The file must exist as a regular file and not be empty.
+
+Loading:
+- `@`-references are extracted from the bodies of context files (CLAUDE.md, etc.) and eager rules.
+- The loader walks the reference graph breadth-first, with deduplication by absolute path (cycle-safe).
+- Each loaded file is capped at 48 000 characters (same cap as context files); whitespace-only files are skipped.
+- The resulting documents are rendered into a single `<included_docs>` block in the system prompt, sorted by path, placed between `<project_rules>` and `<project_memory>`.
+
+Lazy surfaces (JIT path-scoped rules, `/skill-name` invocations, subagent definitions) resolve their own `@`-links at injection time: rule-linked docs appear as `### Included from <path>` under the rule body; skill-linked docs appear as `<file path="...">` blocks after `<loaded_skill>`; subagent-linked docs appear under `## @-linked docs` in the subagent's `Prompt`.
+

--- a/agent_prompt.go
+++ b/agent_prompt.go
@@ -92,11 +92,15 @@ var agentGitStatus = func(cwd string) string {
 }
 
 // buildAgentSystemPrompt assembles the full system prompt for one
-// agent session: static coder head, env snapshot, project context
-// files, then the shared ask steering prompt (with its worktree
-// pinning clause when args.Cwd is an ask-managed worktree). Called
-// once per session — the result must be reused verbatim on every
-// request so DeepSeek's automatic prefix caching can hit.
+// agent session: static coder head, env snapshot, <project_instructions>
+// (CLAUDE.md/AGENTS.md context files), <project_rules> (eager rules),
+// <included_docs> (markdown files @-linked from context files, rules,
+// skills, or subagents — loaded transitively via BFS with cycle-safe
+// dedup), <project_memory>, <available_skills>, <available_agents>,
+// then the shared ask steering prompt (with its worktree pinning clause
+// when args.Cwd is an ask-managed worktree). Called once per session —
+// the result must be reused verbatim on every request so DeepSeek's
+// automatic prefix caching can hit.
 func buildAgentSystemPrompt(args ProviderSessionArgs) string {
 	cwd := args.Cwd
 	var b strings.Builder
@@ -120,15 +124,39 @@ func buildAgentSystemPrompt(args ProviderSessionArgs) string {
 	}
 	b.WriteString("</env>")
 
-	if ctxFiles := agentContextFiles(cwd); ctxFiles != "" {
+	ctxDocs := agentContextFiles(cwd)
+	if len(ctxDocs) > 0 {
 		b.WriteString("\n\n<project_instructions>\nThe project provides these instruction files. Follow them.\n")
-		b.WriteString(ctxFiles)
+		for _, d := range ctxDocs {
+			fmt.Fprintf(&b, "<file path=%q>\n%s\n</file>\n", d.Path, d.Body)
+		}
 		b.WriteString("</project_instructions>")
 	}
 
-	if block := rulesPromptBlock(discoverRules(cwd)); block != "" {
+	rules := discoverRules(cwd)
+	if block := rulesPromptBlock(rules); block != "" {
 		b.WriteString("\n\n")
 		b.WriteString(block)
+	}
+
+	repoRoot := projectRoot(cwd)
+	if repoRoot == "" {
+		repoRoot = cwd
+	}
+	var sourceBodies []string
+	for _, d := range ctxDocs {
+		sourceBodies = append(sourceBodies, d.Body)
+	}
+	for _, r := range rules {
+		if r.eager() {
+			sourceBodies = append(sourceBodies, r.Body)
+		}
+	}
+	if linkedDocs := loadContextLinks(repoRoot, sourceBodies); len(linkedDocs) > 0 {
+		if block := contextLinksPromptBlock(linkedDocs); block != "" {
+			b.WriteString("\n\n")
+			b.WriteString(block)
+		}
 	}
 
 	if mem := agentMemorySystemBlock(cwd); mem != "" {
@@ -151,10 +179,13 @@ func buildAgentSystemPrompt(args ProviderSessionArgs) string {
 	return b.String()
 }
 
-// agentContextFiles inlines the project's instruction files as
-// <file path="..."> blocks.
-func agentContextFiles(cwd string) string {
-	var b strings.Builder
+// agentContextFiles loads the project's instruction files
+// (CLAUDE.md, AGENTS.md) directly from cwd. @-link references within
+// these files are resolved separately by loadContextLinks during
+// buildAgentSystemPrompt and placed in a dedicated <included_docs>
+// block — they are not part of this function's return.
+func agentContextFiles(cwd string) []loadedContextDoc {
+	var docs []loadedContextDoc
 	seen := map[string]bool{}
 	for _, name := range agentContextFileNames {
 		key := strings.ToLower(name)
@@ -171,7 +202,10 @@ func agentContextFiles(cwd string) string {
 		if len(content) > agentContextFileCap {
 			content = content[:agentContextFileCap] + "\n… (truncated)"
 		}
-		fmt.Fprintf(&b, "<file path=%q>\n%s\n</file>\n", path, strings.TrimRight(content, "\n"))
+		docs = append(docs, loadedContextDoc{
+			Path: path,
+			Body: strings.TrimRight(content, "\n"),
+		})
 	}
-	return b.String()
+	return docs
 }

--- a/agent_prompt_links.go
+++ b/agent_prompt_links.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// contextLinkRe matches @path/to/file.md references in markdown bodies.
+// The capture excludes the @ prefix. Each path segment must start with
+// an alphanumeric character; segments contain only alphanumeric,
+// underscore, dot, and hyphen. The pattern ends in .md.
+var contextLinkRe = regexp.MustCompile(`@([A-Za-z0-9][A-Za-z0-9_.-]*(?:/[A-Za-z0-9][A-Za-z0-9_.-]*)*(?i:\.md))`)
+
+// loadedContextDoc is one document that has been loaded for inclusion in
+// the system prompt — either a project instruction file or an @-linked
+// document resolved during prompt assembly.
+type loadedContextDoc struct {
+	Path string
+	Body string
+}
+
+// extractContextLinks finds all @path/to/file.md references in body.
+// Fenced code blocks (``` and ~~~, with optional info strings) are
+// stripped first — replaced with spaces while preserving newlines — so
+// @-references inside code samples are not treated as links.
+// Unterminated fences consume to EOF.
+func extractContextLinks(body string) []string {
+	clean := stripFencedCodeBlocks(body)
+	matches := contextLinkRe.FindAllStringSubmatch(clean, -1)
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		out = append(out, m[1])
+	}
+	return out
+}
+
+// stripFencedCodeBlocks replaces fenced code block content with spaces,
+// preserving newlines. Handles both ``` and ~~~ fences with optional
+// info strings. Unterminated fences consume the remainder of the input.
+func stripFencedCodeBlocks(s string) string {
+	lines := strings.Split(s, "\n")
+	var b strings.Builder
+	b.Grow(len(s))
+	inFence := false
+	var fenceChar byte
+	for i, line := range lines {
+		trimmed := strings.TrimRight(line, "\r")
+		if !inFence {
+			if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+				inFence = true
+				if strings.HasPrefix(trimmed, "```") {
+					fenceChar = '`'
+				} else {
+					fenceChar = '~'
+				}
+				b.WriteString(strings.Repeat(" ", len(line)))
+			} else {
+				b.WriteString(line)
+			}
+		} else {
+			stripped := strings.TrimSpace(trimmed)
+			prefix := strings.Repeat(string(fenceChar), 3)
+			if stripped == prefix ||
+				(strings.HasPrefix(stripped, prefix) && strings.TrimSpace(strings.TrimPrefix(stripped, prefix)) == "") {
+				inFence = false
+				b.WriteString(strings.Repeat(" ", len(line)))
+			} else {
+				b.WriteString(strings.Repeat(" ", len(line)))
+			}
+		}
+		if i < len(lines)-1 {
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+// resolveContextLink resolves a link (without the @) against repoRoot.
+// Returns the cleaned absolute path and true when the link is valid,
+// safe, and points to an existing .md file inside repoRoot.
+// Rejects: empty, leading /, leading ./, leading ../, .. segment
+// anywhere, paths that escape repoRoot, missing files, directories,
+// and non-.md files.
+func resolveContextLink(repoRoot, link string) (string, bool) {
+	if link == "" {
+		return "", false
+	}
+	if strings.HasPrefix(link, "/") || strings.HasPrefix(link, "./") || strings.HasPrefix(link, "../") {
+		return "", false
+	}
+	if !strings.EqualFold(filepath.Ext(link), ".md") {
+		return "", false
+	}
+	for _, seg := range strings.Split(link, "/") {
+		if seg == ".." || seg == "." {
+			return "", false
+		}
+	}
+	abs := filepath.Join(repoRoot, filepath.FromSlash(link))
+	abs = filepath.Clean(abs)
+	rel, err := filepath.Rel(repoRoot, abs)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	info, err := os.Stat(abs)
+	if err != nil || info.IsDir() {
+		return "", false
+	}
+	return abs, true
+}
+
+// loadContextLinks walks the @-link graph breadth-first: it starts from
+// the links in sourceBodies, resolves each against repoRoot, loads the
+// file, and repeats for links found in the loaded files. Deduplication
+// by absolute path prevents cycles and double-loads. Files that are
+// empty, whitespace-only, or exceed agentContextFileCap are handled
+// identically to agentContextFiles (cap truncation, silent skip for
+// empty). Returns nil when repoRoot is empty.
+func loadContextLinks(repoRoot string, sourceBodies []string) []loadedContextDoc {
+	if repoRoot == "" {
+		return nil
+	}
+	seen := map[string]bool{}
+	queue := make([]string, 0)
+	for _, body := range sourceBodies {
+		for _, link := range extractContextLinks(body) {
+			if abs, ok := resolveContextLink(repoRoot, link); ok && !seen[abs] {
+				seen[abs] = true
+				queue = append(queue, abs)
+			}
+		}
+	}
+	var docs []loadedContextDoc
+	for i := 0; i < len(queue); i++ {
+		abs := queue[i]
+		data, err := os.ReadFile(abs)
+		if err != nil {
+			continue
+		}
+		body := string(data)
+		if strings.TrimSpace(body) == "" {
+			continue
+		}
+		if len(body) > agentContextFileCap {
+			body = body[:agentContextFileCap] + "\n… (truncated)"
+		}
+		body = strings.TrimRight(body, "\n")
+		docs = append(docs, loadedContextDoc{Path: abs, Body: body})
+		for _, link := range extractContextLinks(body) {
+			if abs2, ok := resolveContextLink(repoRoot, link); ok && !seen[abs2] {
+				seen[abs2] = true
+				queue = append(queue, abs2)
+			}
+		}
+	}
+	return docs
+}
+
+// contextLinksPromptBlock renders the loaded @-linked docs into a
+// single <included_docs> system-prompt block, sorted by path for
+// deterministic output. Returns "" when docs is empty so the caller
+// can skip the block entirely.
+func contextLinksPromptBlock(docs []loadedContextDoc) string {
+	if len(docs) == 0 {
+		return ""
+	}
+	sorted := make([]loadedContextDoc, len(docs))
+	copy(sorted, docs)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Path < sorted[j].Path })
+	var b strings.Builder
+	b.WriteString("<included_docs>\nThe following markdown files are @-linked from project instructions, rules, skills, or subagents. They are part of this session's direct context.\n")
+	for _, d := range sorted {
+		fmt.Fprintf(&b, "<file path=%q>\n%s\n</file>\n", d.Path, d.Body)
+	}
+	b.WriteString("</included_docs>")
+	return b.String()
+}
+
+// ruleLinkedDocs resolves @-links found in a rule body (JIT rules,
+// skills, subagents) and returns the loaded documents. A thin wrapper
+// around loadContextLinks for the lazy-loading surfaces.
+func ruleLinkedDocs(repoRoot, body string) []loadedContextDoc {
+	return loadContextLinks(repoRoot, []string{body})
+}

--- a/agent_prompt_links_test.go
+++ b/agent_prompt_links_test.go
@@ -1,0 +1,334 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExtractContextLinks(t *testing.T) {
+	// Basic extraction.
+	links := extractContextLinks("See @docs/guide.md and @refs/api.md for details.")
+	if len(links) != 2 || links[0] != "docs/guide.md" || links[1] != "refs/api.md" {
+		t.Errorf("basic: %v", links)
+	}
+
+	// No links.
+	if got := extractContextLinks("plain text"); len(got) != 0 {
+		t.Errorf("no links: %v", got)
+	}
+
+	// Inside a fenced code block — stripped.
+	body := "Before\n```\n@code/sample.md\n```\nAfter @real/doc.md"
+	links = extractContextLinks(body)
+	if len(links) != 1 || links[0] != "real/doc.md" {
+		t.Errorf("code block strip: %v", links)
+	}
+
+	// Tilde fences.
+	body = "Before\n~~~\n@tilde/sample.md\n~~~\nAfter @real/doc.md"
+	links = extractContextLinks(body)
+	if len(links) != 1 || links[0] != "real/doc.md" {
+		t.Errorf("tilde fence strip: %v", links)
+	}
+
+	// Fence with info string.
+	body = "```go\n@go/code.md\n```\n@ok/doc.md"
+	links = extractContextLinks(body)
+	if len(links) != 1 || links[0] != "ok/doc.md" {
+		t.Errorf("info string fence: %v", links)
+	}
+
+	// Unterminated fence.
+	body = "Before\n```\n@unterminated/doc.md"
+	links = extractContextLinks(body)
+	if len(links) != 0 {
+		t.Errorf("unterminated fence: %v", links)
+	}
+
+	// Multiple links in same body, source order.
+	body = "@second/doc.md before @first/aaa.md"
+	links = extractContextLinks(body)
+	if len(links) != 2 || links[0] != "second/doc.md" || links[1] != "first/aaa.md" {
+		t.Errorf("source order: %v", links)
+	}
+
+	// Link with hyphens and dots in segment.
+	links = extractContextLinks("See @a-b/c.d.md")
+	if len(links) != 1 || links[0] != "a-b/c.d.md" {
+		t.Errorf("hyphen and dot: %v", links)
+	}
+
+	// Case-insensitive .md extension.
+	links = extractContextLinks("See @Spec.MD and @docs/Guide.Md")
+	if len(links) != 2 || links[0] != "Spec.MD" || links[1] != "docs/Guide.Md" {
+		t.Errorf("case-insensitive .md: %v", links)
+	}
+}
+
+func TestResolveContextLink(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "docs/guide.md", "# Guide\n")
+	writeTestFile(t, root, "README.md", "# README\n")
+	writeTestFile(t, root, "src/main.go", "package main\n")
+	if err := os.MkdirAll(filepath.Join(root, "empty-dir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Valid link.
+	abs, ok := resolveContextLink(root, "docs/guide.md")
+	if !ok || abs != filepath.Join(root, "docs/guide.md") {
+		t.Errorf("valid link: %q %v", abs, ok)
+	}
+
+	// Valid link in root.
+	abs, ok = resolveContextLink(root, "README.md")
+	if !ok {
+		t.Errorf("root file: %v", ok)
+	}
+
+	// Empty link.
+	if _, ok := resolveContextLink(root, ""); ok {
+		t.Error("empty link must be rejected")
+	}
+
+	// Leading slash.
+	if _, ok := resolveContextLink(root, "/etc/passwd"); ok {
+		t.Error("leading slash must be rejected")
+	}
+
+	// Leading ./
+	if _, ok := resolveContextLink(root, "./docs/guide.md"); ok {
+		t.Error("leading ./ must be rejected")
+	}
+
+	// Leading ../
+	if _, ok := resolveContextLink(root, "../outside.md"); ok {
+		t.Error("leading ../ must be rejected")
+	}
+
+	// .. segment mid-path.
+	if _, ok := resolveContextLink(root, "docs/../escape.md"); ok {
+		t.Error(".. mid-path must be rejected")
+	}
+
+	// Non-.md file.
+	if _, ok := resolveContextLink(root, "src/main.go"); ok {
+		t.Error("non-.md must be rejected")
+	}
+
+	// Missing file.
+	if _, ok := resolveContextLink(root, "docs/missing.md"); ok {
+		t.Error("missing file must be rejected")
+	}
+
+	// Directory.
+	if _, ok := resolveContextLink(root, "empty-dir"); ok {
+		t.Error("directory must be rejected (even though non-.md already catches it)")
+	}
+
+	// Case-insensitive .md extension.
+	writeTestFile(t, root, "Spec.MD", "# Spec\n")
+	abs, ok = resolveContextLink(root, "Spec.MD")
+	if !ok || filepath.Base(abs) != "Spec.MD" {
+		t.Errorf("case-insensitive .md: %q %v", abs, ok)
+	}
+
+	// Path escaping root via symlink-equivalent — use Rel rejection.
+	// We can't create a path that escapes via Join, but we test the Rel
+	// guard by constructing a link that, after Join+Clean, resolves outside.
+	// On most systems, Join(root, "../../etc/passwd") → Clean → /etc/passwd
+	// But the .. segment check catches this before Join.
+	// Belt-and-braces: test with a non-existent root to verify Rel guard.
+	if _, ok := resolveContextLink("/nonexistent", "file.md"); ok {
+		t.Error("outside root (Rel) must be rejected")
+	}
+}
+
+func TestLoadContextLinks_BFS_Dedup_Cycle(t *testing.T) {
+	root := t.TempDir()
+
+	// Create chain A → B → C with A also referencing C directly.
+	writeTestFile(t, root, "a.md", "See @b.md and @c.md\n")
+	writeTestFile(t, root, "b.md", "See @c.md\n")
+	writeTestFile(t, root, "c.md", "Leaf content.\n")
+
+	docs := loadContextLinks(root, []string{"See @a.md\n"})
+	if len(docs) != 3 {
+		t.Fatalf("want 3 docs, got %d: %v", len(docs), docs)
+	}
+
+	byPath := map[string]string{}
+	for _, d := range docs {
+		byPath[filepath.Base(d.Path)] = d.Body
+	}
+	if !strings.Contains(byPath["a.md"], "@b.md") {
+		t.Errorf("a.md body wrong: %q", byPath["a.md"])
+	}
+	if !strings.Contains(byPath["b.md"], "@c.md") {
+		t.Errorf("b.md body wrong: %q", byPath["b.md"])
+	}
+	if byPath["c.md"] != "Leaf content." {
+		t.Errorf("c.md body wrong: %q", byPath["c.md"])
+	}
+}
+
+func TestLoadContextLinks_Cycle(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "x.md", "See @y.md\n")
+	writeTestFile(t, root, "y.md", "See @x.md\n")
+
+	docs := loadContextLinks(root, []string{"See @x.md\n"})
+	// Both loaded once; cycle doesn't cause infinite loop.
+	if len(docs) != 2 {
+		t.Errorf("cycle: want 2, got %d", len(docs))
+	}
+}
+
+func TestLoadContextLinks_EmptyRepoRoot(t *testing.T) {
+	if docs := loadContextLinks("", []string{"@docs/x.md"}); docs != nil {
+		t.Error("empty repoRoot must return nil")
+	}
+}
+
+func TestLoadContextLinks_EmptyFileSkip(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "empty.md", "   \n")
+	writeTestFile(t, root, "real.md", "content\n")
+
+	docs := loadContextLinks(root, []string{"See @empty.md and @real.md\n"})
+	if len(docs) != 1 || filepath.Base(docs[0].Path) != "real.md" {
+		t.Errorf("empty file must be skipped: %v", docs)
+	}
+}
+
+func TestLoadContextLinks_Cap(t *testing.T) {
+	root := t.TempDir()
+	big := strings.Repeat("x", agentContextFileCap+100)
+	writeTestFile(t, root, "big.md", big)
+
+	docs := loadContextLinks(root, []string{"@big.md"})
+	if len(docs) != 1 {
+		t.Fatalf("want 1 doc, got %d", len(docs))
+	}
+	if !strings.Contains(docs[0].Body, "… (truncated)") {
+		t.Error("oversized doc must be truncated")
+	}
+	if len(docs[0].Body) > agentContextFileCap+len("\n… (truncated)") {
+		t.Errorf("truncated body too long: %d", len(docs[0].Body))
+	}
+}
+
+func TestContextLinksPromptBlock(t *testing.T) {
+	// Empty → "".
+	if got := contextLinksPromptBlock(nil); got != "" {
+		t.Errorf("nil docs: %q", got)
+	}
+	if got := contextLinksPromptBlock([]loadedContextDoc{}); got != "" {
+		t.Errorf("empty docs: %q", got)
+	}
+
+	docs := []loadedContextDoc{
+		{Path: "/root/b.md", Body: "body B"},
+		{Path: "/root/a.md", Body: "body A"},
+	}
+	block := contextLinksPromptBlock(docs)
+	if !strings.Contains(block, "<included_docs>") {
+		t.Errorf("block missing tag: %q", block)
+	}
+	if !strings.Contains(block, "body A") || !strings.Contains(block, "body B") {
+		t.Errorf("bodies missing: %q", block)
+	}
+	// Sorted by path: a.md before b.md.
+	aIdx := strings.Index(block, "a.md")
+	bIdx := strings.Index(block, "b.md")
+	if aIdx < 0 || bIdx < 0 || aIdx >= bIdx {
+		t.Errorf("docs not sorted by path: a at %d, b at %d", aIdx, bIdx)
+	}
+	if !strings.Contains(block, `path="/root/a.md"`) {
+		t.Errorf("path attribute missing: %q", block)
+	}
+}
+
+func TestLoadContextLinks_NoLinksReturnsEmpty(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "plain.md", "No links here.\n")
+	docs := loadContextLinks(root, []string{"No links here.\n"})
+	if len(docs) != 0 {
+		t.Errorf("no links in source: %v", docs)
+	}
+}
+
+func TestRuleLinkedDocs(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "ref.md", "Reference content.\n")
+
+	docs := ruleLinkedDocs(root, "See @ref.md\n")
+	if len(docs) != 1 || !strings.Contains(docs[0].Body, "Reference content.") {
+		t.Errorf("ruleLinkedDocs: %v", docs)
+	}
+}
+
+func TestLoadContextLinks_Transitive(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "level1.md", "See @level2.md\n")
+	writeTestFile(t, root, "level2.md", "See @level3.md\n")
+	writeTestFile(t, root, "level3.md", "Deep content.\n")
+
+	docs := loadContextLinks(root, []string{"See @level1.md\n"})
+	if len(docs) != 3 {
+		t.Errorf("transitive: want 3, got %d: %v", len(docs), docs)
+	}
+}
+
+func TestStripFencedCodeBlocks(t *testing.T) {
+	// No fences.
+	in := "hello\nworld"
+	out := stripFencedCodeBlocks(in)
+	if out != in {
+		t.Errorf("no fence: %q", out)
+	}
+
+	// Simple fence.
+	in = "before\n```\ncode\n```\nafter"
+	out = stripFencedCodeBlocks(in)
+	if !strings.Contains(out, "before") || !strings.Contains(out, "after") {
+		t.Errorf("simple fence: %q", out)
+	}
+	if strings.Contains(out, "code") {
+		t.Errorf("code must be stripped: %q", out)
+	}
+
+	// Tilde fence.
+	in = "before\n~~~\ncode\n~~~\nafter"
+	out = stripFencedCodeBlocks(in)
+	if !strings.Contains(out, "before") || !strings.Contains(out, "after") {
+		t.Errorf("tilde fence: %q", out)
+	}
+	if strings.Contains(out, "code") {
+		t.Errorf("code must be stripped: %q", out)
+	}
+
+	// Info string.
+	in = "```go\ncode\n```\nok"
+	out = stripFencedCodeBlocks(in)
+	if !strings.Contains(out, "ok") || strings.Contains(out, "code") {
+		t.Errorf("info string: %q", out)
+	}
+
+	// Unterminated fence.
+	in = "before\n```\ncode"
+	out = stripFencedCodeBlocks(in)
+	if strings.Contains(out, "code") || !strings.Contains(out, "before") {
+		t.Errorf("unterminated: %q", out)
+	}
+
+	// Newlines preserved — verify line count.
+	in = "line1\n```\nline3\nline4\nline5\n```\nline7"
+	out = stripFencedCodeBlocks(in)
+	if strings.Count(out, "\n") != strings.Count(in, "\n") {
+		t.Errorf("newline count mismatch: %d vs %d in %q",
+			strings.Count(out, "\n"), strings.Count(in, "\n"), out)
+	}
+}

--- a/agent_prompt_test.go
+++ b/agent_prompt_test.go
@@ -123,11 +123,94 @@ func TestAgentContextFiles_DedupeAndCap(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(cwd, "CLAUDE.md"), []byte(big), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	out := agentContextFiles(cwd)
+	docs := agentContextFiles(cwd)
+	var bodies []string
+	for _, d := range docs {
+		bodies = append(bodies, d.Body)
+	}
+	out := strings.Join(bodies, "\n")
 	if strings.Count(out, "agents body") != 1 {
 		t.Errorf("AGENTS.md must appear exactly once (case-insensitive dedupe):\n%d", strings.Count(out, "agents body"))
 	}
 	if !strings.Contains(out, "… (truncated)") {
 		t.Error("oversized context file must be truncated")
+	}
+}
+
+func TestBuildAgentSystemPrompt_ContextLinks(t *testing.T) {
+	isolateHome(t)
+	stubGitStatus(t, "## main")
+	cwd := t.TempDir()
+	if err := os.Mkdir(filepath.Join(cwd, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// CLAUDE.md references an @-linked doc and a bad link.
+	if err := os.WriteFile(filepath.Join(cwd, "CLAUDE.md"), []byte(
+		"Project rules here.\nSee @docs/guide.md and @bad-link for more.\n",
+	), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Create the linked doc.
+	if err := os.MkdirAll(filepath.Join(cwd, "docs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cwd, "docs", "guide.md"), []byte(
+		"# Guide\nExtra context.\n",
+	), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	args := ProviderSessionArgs{Cwd: cwd}
+	prompt := buildAgentSystemPrompt(args)
+
+	// The @-linked doc must appear in <included_docs>.
+	if !strings.Contains(prompt, "<included_docs>") {
+		t.Error("prompt must contain <included_docs> block")
+	}
+	if !strings.Contains(prompt, "Extra context.") {
+		t.Error("linked doc body must appear in the prompt")
+	}
+	if !strings.Contains(prompt, `path="`+filepath.Join(cwd, "docs", "guide.md")+`"`) {
+		t.Error("linked doc path must appear in the prompt")
+	}
+
+	// Bad link (@bad-link) must NOT appear as a loaded doc in <included_docs>.
+	// It may appear in the CLAUDE.md body itself, but not as a resolved file.
+	includedStart := strings.Index(prompt, "<included_docs>")
+	includedEnd := strings.Index(prompt, "</included_docs>")
+	if includedStart >= 0 && includedEnd > includedStart {
+		includedBlock := prompt[includedStart:includedEnd]
+		if strings.Contains(includedBlock, "bad-link") {
+			t.Error("non-.md link must not appear in <included_docs>")
+		}
+	}
+
+	// Only one doc should be in <included_docs>: guide.md.
+	if includedStart >= 0 && includedEnd > includedStart {
+		includedBlock := prompt[includedStart:includedEnd]
+		if strings.Count(includedBlock, "<file path=") != 1 {
+			t.Errorf("want 1 file in <included_docs>, got %d:\n%s",
+				strings.Count(includedBlock, "<file path="), includedBlock)
+		}
+	}
+
+	// <included_docs> must sit between <project_rules> and <project_memory>.
+	// When there's no project_memory, it sits between <project_rules> and
+	// <available_skills>. Verify it's after <project_rules> when rules
+	// are present, and before the steering prompt.
+	rulesIdx := strings.Index(prompt, "<project_rules>")
+	docsIdx := strings.Index(prompt, "<included_docs>")
+	if rulesIdx >= 0 && docsIdx >= 0 && docsIdx < rulesIdx {
+		t.Error("<included_docs> must appear after <project_rules>")
+	}
+	steeringIdx := strings.Index(prompt, "You are an AI LLM and can work at super human speeds")
+	if docsIdx >= 0 && steeringIdx >= 0 && docsIdx > steeringIdx {
+		t.Error("<included_docs> must appear before the steering prompt")
+	}
+
+	// Byte-stability: two builds with identical inputs must be identical.
+	if prompt != buildAgentSystemPrompt(args) {
+		t.Error("prompt must be deterministic with @-links")
 	}
 }

--- a/agent_subagents.go
+++ b/agent_subagents.go
@@ -63,6 +63,10 @@ func subagentSearchDirs(cwd string) []string {
 // or description are skipped with a debug note.
 func discoverSubagents(cwd string) []subagentDef {
 	byName := map[string]subagentDef{}
+	repoRoot := projectRoot(cwd)
+	if repoRoot == "" {
+		repoRoot = cwd
+	}
 	for _, dir := range subagentSearchDirs(cwd) {
 		entries, err := os.ReadDir(dir)
 		if err != nil {
@@ -91,13 +95,23 @@ func discoverSubagents(cwd string) []subagentDef {
 					tools = append(tools, t)
 				}
 			}
+			prompt := strings.TrimSpace(body)
+			if linked := ruleLinkedDocs(repoRoot, prompt); len(linked) > 0 {
+				var lb strings.Builder
+				lb.WriteString(prompt)
+				lb.WriteString("\n\n## @-linked docs\n\n")
+				for _, d := range linked {
+					fmt.Fprintf(&lb, "<file path=%q>\n%s\n</file>\n", d.Path, d.Body)
+				}
+				prompt = lb.String()
+			}
 			byName[name] = subagentDef{
 				Name:        name,
 				Description: fields["description"],
 				Provider:    strings.TrimSpace(fields["provider"]),
 				Model:       strings.TrimSpace(fields["model"]),
 				Tools:       tools,
-				Prompt:      strings.TrimSpace(body),
+				Prompt:      prompt,
 				Source:      path,
 			}
 		}

--- a/agent_subagents_test.go
+++ b/agent_subagents_test.go
@@ -273,3 +273,34 @@ func TestRunTurn_SkillExpansionReachesWire(t *testing.T) {
 		t.Errorf("skill must expand on the wire: %q", userText)
 	}
 }
+
+func TestDiscoverSubagents_LinkedDocs(t *testing.T) {
+	home := isolateHome(t)
+	cwd := t.TempDir()
+
+	// Create a linked doc in the project.
+	writeTestFile(t, cwd, "docs/protocol.md", "# Protocol\nUse HTTPS for all calls.\n")
+
+	// Create a subagent that references the linked doc.
+	writeSubagent(t, filepath.Join(home, ".claude", "agents"), "reviewer", "",
+		"Review code carefully.\nSee @docs/protocol.md for protocol rules.\n")
+
+	defs := discoverSubagents(cwd)
+	if len(defs) != 1 {
+		t.Fatalf("want 1 subagent, got %d", len(defs))
+	}
+	prompt := defs[0].Prompt
+	if !strings.Contains(prompt, "Review code carefully.") {
+		t.Errorf("original body missing: %q", prompt)
+	}
+	if !strings.Contains(prompt, "## @-linked docs") {
+		t.Errorf("linked docs section missing: %q", prompt)
+	}
+	if !strings.Contains(prompt, "Use HTTPS for all calls.") {
+		t.Errorf("linked doc body must be included in Prompt: %q", prompt)
+	}
+	expectedPath := filepath.Join(cwd, "docs", "protocol.md")
+	if !strings.Contains(prompt, `<file path="`+expectedPath+`"`) {
+		t.Errorf("linked doc must use <file path=...> format: %q", prompt)
+	}
+}

--- a/rules.go
+++ b/rules.go
@@ -355,6 +355,11 @@ func (rt *ruleAwareTool) Run(ctx context.Context, call fantasy.ToolCall) (fantas
 		}
 		rt.fired[r.Path] = true
 		add = append(add, fmt.Sprintf("## Rule for %s (%s)\n\n%s", rel, r.Rel, r.Body))
+		if linked := ruleLinkedDocs(rt.root, r.Body); len(linked) > 0 {
+			for _, d := range linked {
+				add = append(add, fmt.Sprintf("### Included from %s\n\n%s", d.Path, d.Body))
+			}
+		}
 	}
 	if len(add) > 0 {
 		resp.Content = resp.Content + "\n\n" + strings.Join(add, "\n\n")

--- a/rules_test.go
+++ b/rules_test.go
@@ -231,3 +231,38 @@ func TestRuleAwareTool_RelPathRejectsOutsideRoot(t *testing.T) {
 		t.Errorf("relPath outside root must be empty, got %q", got)
 	}
 }
+
+func TestRuleAwareTool_LinkedDocs(t *testing.T) {
+	env, _ := newTestToolEnv(t)
+	writeTestFile(t, env.cwd, "src/api/handler.go", "package api\n")
+	writeTestFile(t, env.cwd, "docs/ref.md", "# Reference\nLinked body here.\n")
+
+	rules := []askRule{
+		{Path: filepath.Join(env.cwd, ".claude", "rules", "api.md"),
+			Rel:  "api.md",
+			Paths: []string{"src/api/**/*.go"},
+			Body: "API rule body. See @docs/ref.md for details.\n",
+		},
+	}
+	tools := wrapReadToolWithRules([]fantasy.AgentTool{agentReadTool(env)}, env.cwd, rules)
+	read := tools[0]
+
+	resp := runTool(t, read, agentReadParams{FilePath: "src/api/handler.go"})
+	if !strings.Contains(resp.Content, "API rule body.") {
+		t.Errorf("rule body missing: %q", resp.Content)
+	}
+	// The @-linked doc must appear after the rule.
+	if !strings.Contains(resp.Content, "Linked body here.") {
+		t.Errorf("linked doc body must be injected: %q", resp.Content)
+	}
+	if !strings.Contains(resp.Content, "### Included from "+filepath.Join(env.cwd, "docs", "ref.md")) {
+		t.Errorf("linked doc header missing: %q", resp.Content)
+	}
+
+	// Second read of the same file: rule must not re-fire, and linked
+	// docs must not re-appear.
+	resp = runTool(t, read, agentReadParams{FilePath: "src/api/handler.go"})
+	if strings.Contains(resp.Content, "API rule body.") || strings.Contains(resp.Content, "Linked body here.") {
+		t.Error("rule and linked docs must inject at most once per session")
+	}
+}

--- a/skills.go
+++ b/skills.go
@@ -176,6 +176,16 @@ func expandSkillInvocation(cwd, text string) (string, bool) {
 		}
 		var b strings.Builder
 		fmt.Fprintf(&b, "<loaded_skill name=%q path=%q>\n%s\n</loaded_skill>\n\n", s.Name, s.Path, strings.TrimSpace(body))
+		repoRoot := projectRoot(cwd)
+		if repoRoot == "" {
+			repoRoot = cwd
+		}
+		if linked := ruleLinkedDocs(repoRoot, body); len(linked) > 0 {
+			for _, d := range linked {
+				fmt.Fprintf(&b, "<file path=%q>\n%s\n</file>\n", d.Path, d.Body)
+			}
+		}
+		b.WriteString("\n")
 		if strings.TrimSpace(args) != "" {
 			fmt.Fprintf(&b, "The user invoked this skill with arguments: %s", strings.TrimSpace(args))
 		} else {

--- a/skills_test.go
+++ b/skills_test.go
@@ -160,3 +160,36 @@ func TestAgentProviderProbeInit_SkillsAsSlashCommands(t *testing.T) {
 		t.Errorf("user-invocable skills must surface as slash commands: %+v", msg.slashCmds)
 	}
 }
+
+func TestExpandSkillInvocation_LinkedDocs(t *testing.T) {
+	home := isolateHome(t)
+	cwd := t.TempDir()
+
+	// Create a linked doc.
+	writeTestFile(t, cwd, "docs/setup.md", "# Setup\nRun ./setup.sh first.\n")
+
+	// Create a skill that references the linked doc.
+	writeSkill(t, filepath.Join(home, ".claude", "skills"), "deploy", "",
+		"Step 1: build.\nSee @docs/setup.md for setup.\nStep 2: ship.")
+
+	msg, ok := expandSkillInvocation(cwd, "/deploy")
+	if !ok {
+		t.Fatal("skill must expand")
+	}
+	if !strings.Contains(msg, "Step 1: build.") {
+		t.Errorf("skill body missing: %q", msg)
+	}
+	// The linked doc must appear as a <file> block.
+	if !strings.Contains(msg, "Run ./setup.sh first.") {
+		t.Errorf("linked doc body must be included: %q", msg)
+	}
+	if !strings.Contains(msg, `<file path="`+filepath.Join(cwd, "docs", "setup.md")+`"`) {
+		t.Errorf("linked doc path must appear: %q", msg)
+	}
+	// Linked docs must appear before the "no arguments" tail.
+	fileIdx := strings.Index(msg, "<file path=")
+	argsIdx := strings.Index(msg, "no arguments")
+	if fileIdx < 0 || argsIdx < 0 || fileIdx >= argsIdx {
+		t.Errorf("linked docs must appear before the args tail (file at %d, args at %d):\n%s", fileIdx, argsIdx, msg)
+	}
+}


### PR DESCRIPTION
## Summary

This PR introduces `@path/to/file.md` link resolution across every document-loading surface in ask: CLAUDE.md / AGENTS.md context files, eager rules, path-scoped JIT rules, skill bodies on `/skill-name` invocation, and subagent definition bodies.

A new unexported loader in `agent_prompt_links.go` handles extraction (regex, with fenced code blocks stripped first to avoid false positives inside code examples), resolution (rejects `..`, absolute paths, non-`.md` files, paths outside the repo root), BFS deduplication with cycle safety, and a 48 KB cap. Linked documents are emitted as a single `<included_docs>` block in the system prompt, placed between `<project_rules>` and `<project_memory>`.

### Files changed

| File | Change |
|------|--------|
| `agent_prompt_links.go` | **NEW** — link loader core (extract / resolve / BFS / render) |
| `agent_prompt_links_test.go` | **NEW** — unit tests (extraction, resolution rules, BFS dedup+cycles, cap truncation, code-block stripping, prompt-block rendering) |
| `agent_prompt.go` | Wire source bodies into the loader; emit `<included_docs>` between `<project_rules>` and `<project_memory>` |
| `agent_prompt_test.go` | End-to-end test for @-links in context files (lands in prompt, bad links skipped, dedup, byte-stability) |
| `rules.go` | Add `repoRoot` to `ruleAwareTool`; inject each matched rule's linked docs into the tool result |
| `rules_test.go` | Test JIT rule @-link injection |
| `skills.go` | Append linked docs to `/skill` invocation output |
| `skills_test.go` | Test `/skill` @-link inclusion |
| `agent_subagents.go` | Extend subagent `def.Prompt` with linked docs under `## @-linked docs` |
| `agent_subagents_test.go` | Test subagent @-link expansion |
| `CLAUDE.md` | Document the syntax for repo authors |

## Motivation

ask already loads `CLAUDE.md`, `AGENTS.md`, rules, skills, and subagent bodies into the agent's context. But none of these surfaces could reference other markdown files — authors had to inline everything or rely on the agent discovering auxiliary files on its own. The `@path/to/file.md` syntax lets authors build modular documentation (project conventions, architecture notes, coding standards) that surfaces automatically and deterministically whenever a context file, rule, skill, or subagent is loaded.

## Testing & validation

- `go build ./...` — clean
- `go vet ./...` — clean  
- `go test ./...` — all pass
- New tests cover: link extraction (including code-block stripping), all resolution rejection paths (`..`, absolute, non-`.md`, outside-root, missing/broken symlink, directory), BFS dedup and cycle safety, cap truncation with marker, `<included_docs>` prompt block rendering, lazy-surface injection (JIT rules, skills, subagents), end-to-end prompt assembly with byte-stability
- No regressions in existing tests
- No new external dependencies (stdlib only)