### PR TITLE
fix(memory,question): close F1+F2 recall rank bugs and document F3

### DIFF
--- a/agent_memory.go
+++ b/agent_memory.go
@@ -141,12 +141,12 @@ const memoryHookCtxTimeout = 8 * time.Second
 // Empty hits → empty string (claude sees no injection at all rather
 // than a header with no content underneath).
 func formatRecallContext(hits []memmy.RecallHit, heading string) string {
-	if len(hits) == 0 {
-		return ""
-	}
-	var b strings.Builder
-	fmt.Fprintf(&b, "## %s\n\n", heading)
-	for i, h := range hits {
+	// First pass: collect the text of every hit that would render,
+	// dropping entries whose Text and SourceText are both blank. We
+	// renumber from 1 in the second pass so a skipped hit doesn't
+	// leave a gap in the rank the user sees.
+	lines := make([]string, 0, len(hits))
+	for _, h := range hits {
 		text := strings.TrimSpace(h.Text)
 		if text == "" {
 			text = strings.TrimSpace(h.SourceText)
@@ -154,6 +154,19 @@ func formatRecallContext(hits []memmy.RecallHit, heading string) string {
 		if text == "" {
 			continue
 		}
+		lines = append(lines, text)
+	}
+	if len(lines) == 0 {
+		// Doc: "Empty hits → empty string (claude sees no injection
+		// at all rather than a header with no content underneath)."
+		// We treat "no hits that would render text" the same as
+		// "no hits at all" — both paths produce no additionalContext
+		// block, no bare heading.
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "## %s\n\n", heading)
+	for i, text := range lines {
 		fmt.Fprintf(&b, "%d. %s\n", i+1, text)
 	}
 	return strings.TrimRight(b.String(), "\n")

--- a/agent_memory_test.go
+++ b/agent_memory_test.go
@@ -150,52 +150,36 @@ func TestFileToolPath(t *testing.T) {
 	}
 }
 
-// TestFormatRecallContext_AllHitsEmptyTextsAreSkipped: the doc
-// comment says "Empty hits → empty string (claude sees no injection
-// at all rather than a header with no content underneath)". With
-// `len(hits) > 0` but every hit's text/source-text empty, the
-// current implementation renders ONLY the heading (`## X`) and
-// returns that — so an all-empty list leaks a bare heading instead
-// of an empty string. This is a test-vs-code mismatch (a finding,
-// not a test to weaken): the spec says empty content → empty
-// string; the code emits a bare header. See PR description.
+// TestFormatRecallContext_AllHitsEmptyTextsAreSkipped: when every
+// hit's Text and SourceText are blank, no block is injected at all
+// (no bare heading). The doc says "Empty hits → empty string
+// (claude sees no injection at all rather than a header with no
+// content underneath)"; we treat "no hits would render text" the
+// same as "no hits at all".
 func TestFormatRecallContext_AllHitsEmptyTextsAreSkipped(t *testing.T) {
 	hits := []memmy.RecallHit{
 		{NodeID: "1", Text: "", SourceText: ""},
 		{NodeID: "2", Text: "", SourceText: ""},
 	}
 	got := formatRecallContext(hits, "X")
-	if got == "" {
-		return
+	if got != "" {
+		t.Errorf("all-empty-text hits should produce empty context; got %q", got)
 	}
-	t.Logf("FINDING: formatRecallContext returned %q for all-empty hits; doc comment says 'Empty hits → empty string'", got)
 }
 
-// TestFormatRecallContext_MixedHitsRenumberAfterSkip: the spec
-// suggests the bullets are re-numbered after empty hits are
-// skipped (1, 2, 3, …) so the user sees a clean sequential list.
-// The current implementation uses the original `i+1` index, so a
-// skipped hit leaves a gap. With the second hit carrying text and
-// the first skipped, the code renders it as "2." (not "1."). This
-// is a test-vs-code mismatch (finding): the expected behavior is
-// renumber; the code preserves the source index. See PR description.
+// TestFormatRecallContext_MixedHitsRenumberAfterSkip: bullets are
+// re-numbered 1..N from the surviving hits so the user sees a
+// clean sequential list. The source index of an empty hit does
+// not leak into the rank.
 func TestFormatRecallContext_MixedHitsRenumberAfterSkip(t *testing.T) {
 	hits := []memmy.RecallHit{
 		{NodeID: "1", Text: "", SourceText: ""},
 		{NodeID: "2", Text: "survivor"},
 	}
 	got := formatRecallContext(hits, "H")
-	// Spec: re-number → "1. survivor". Code: original index → "2. survivor".
-	// We log whichever we see; the test does not fail either way so the
-	// test suite still runs, but the discrepancy is recorded.
-	if strings.Contains(got, "1. survivor") {
-		return
+	if !strings.Contains(got, "1. survivor") {
+		t.Errorf("expected renumbered 1. survivor; got %q", got)
 	}
-	if strings.Contains(got, "2. survivor") {
-		t.Logf("FINDING: formatRecallContext preserved the original hit index after skipping an empty hit; got %q", got)
-		return
-	}
-	t.Errorf("hit text missing from output: %q", got)
 }
 
 // fakeMemoryTool is a hand-rolled AgentTool that returns the

--- a/ask_question.go
+++ b/ask_question.go
@@ -715,6 +715,13 @@ func normalizeDiagrams(diagrams []string) []string {
 	return out
 }
 
+// diagramExtent returns the bounding box of the diagrams: the
+// maximum line width across all non-empty diagrams as the width, and
+// the maximum per-diagram line count as the height (NOT the sum —
+// only one diagram is shown at a time, so a single row reserves the
+// preview space). Empty entries are skipped, and an all-empty input
+// falls back to the minimum preview box (16 wide × 4 tall) so a
+// no-diagram prompt still reserves the same preview area.
 func diagramExtent(diagrams []string) (w, h int) {
 	for _, d := range diagrams {
 		if d == "" {


### PR DESCRIPTION
## Summary

Closes three findings flagged in PR #66 review: two real bugs in `formatRecallContext` and a missing doc comment on `diagramExtent`. ~15 lines of code, 1 doc comment, 2 test-strengthening edits.

## F1 + F2 — `formatRecallContext` (agent_memory.go:143-)

The function had two test-vs-code mismatches that the two `FINDING` tests in PR #66 logged with `t.Logf` instead of failing.

| Finding | Spec the tests pin | Old code's behavior |
|---------|--------------------|---------------------|
| F1 | "Empty hits → empty string (no header with no content underneath)" | When `len(hits) > 0` but every hit's Text and SourceText were blank, the code emitted only `## heading\n\n` and returned that — a bare heading with no bullets under it. |
| F2 | Bullets numbered `1..N` from the surviving hits | The single-pass loop used `i+1` from the source slice, so a skipped hit left a gap (hit 2 rendered as `2.`, not `1.`). |

Replaced with a two-pass implementation: first pass collects the text of every hit that would render (Text → SourceText → skip if both blank), second pass numbers the survivors `1..N`. An all-blank list now returns `""` and matches the existing `len(hits) == 0` branch.

## F3 — `diagramExtent` doc (ask_question.go:718-)

The function had no doc comment; the contract (max line width as `w`, max per-diagram line count as `h` — NOT the sum, only one diagram is shown at a time — with a 16×4 minimum for an all-empty input) lived only in the test's docstring. Promoted it to the function so the spec travels with the code. No behavior change.

## Test strengthening

The two `FINDING` tests added in PR #66 (one per bug) used `t.Logf` and never failed — a future regression would have been invisible to CI. Replaced their bodies with real `t.Errorf` assertions:

- `TestFormatRecallContext_AllHitsEmptyTextsAreSkipped`: now `t.Errorf` on `got != ""` (was: log and continue).
- `TestFormatRecallContext_MixedHitsRenumberAfterSkip`: now `t.Errorf` if `!strings.Contains(got, "1. survivor")` (was: log the `2. survivor` outcome and continue).

**Verified the regression check** — temporarily reverted the `formatRecallContext` change, ran `go test -run 'TestFormatRecallContext_'`, observed both tests fail with the exact discrepancies:
- `TestFormatRecallContext_AllHitsEmptyTextsAreSkipped` got `"## X"` (the bare heading F1 was about).
- `TestFormatRecallContext_MixedHitsRenumberAfterSkip` got `"## H\n\n2. survivor"` (the index leak F2 was about).

Re-applied the fix and confirmed all tests pass.

## F4 — not a bug, left untouched

`padDiagrams` no-trailing-newline: the test doc was over-specified. The behavior is consistent with the rest of the function (it just `strings.Join`s, never appends a trailing `\n`). Closing F4 as not-a-bug.

## Verification

- `go build ./...` — clean.
- `go vet ./...` — clean.
- `go test ./...` — ok 8.2s (under 9s budget).
- `go test -cover ./...` — **75.4% of statements** (no regression; the two new assertions add tiny new-branch coverage but round to the same percent).
- The two new assertions fail on pre-fix code, pass on the fix.

## Branch

Cut off `origin/main` (not off `test/coverage-gap-fill-75pct`, which is the merged PR #66).
