### PR TITLE
feat(workflows): add a third 'global' scope for machine-local workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ One `package main`, one file per concern.
 | `kitty_diacritics.go`  | The canonical 297-entry Kitty row/column diacritic table.               |
 | `ask_question.go`      | Question modal state, rendering, navigation, submit/cancel flow.        |
 | `workflows.go`         | Workflow runtime tracker singleton + persistence helpers + status broadcast. |
-| `workflow_store.go`    | Two-scope workflow persistence: user (ask.json) + repo (`<root>/.ask/workflows/*.json`, committed), merged repo-first listing, ambiguity-strict name resolution, dir sync on save, cross-scope copy. |
+| `workflow_store.go`    | Three-scope workflow persistence: user (ask.json) + repo (`<root>/.ask/workflows/*.json`, committed) + global (`~/.config/ask/workflows/*.json`, machine-local, visible from every project); merged global-first listing (personal-wins), ambiguity-strict name resolution, dir sync on save, cross-scope copy. |
 | `workflows_screen.go`  | Workflows builder screen — list/steps/step editor levels with multi-line prompt textarea. `e` on a selected workflow opens that same textarea (workflow-scoped `promptTarget=="description"`) to edit the workflow's free-text Description; it commits to `workflowDef.Description` and shows as the steps-pane subtitle. |
 | `workflows_picker.go`  | Small centred modal popped on `f` (issues) / `Ctrl+F` (chat) to pick which workflow to run. |
 | `workflows_run.go`     | Step runner: prompt assembly, advance-on-turn-complete, finalise on done/failed. |
@@ -136,7 +136,7 @@ exercised by the user; code alone won't catch layout regressions.
 | `tool_output_test.go`      | Tool-call rendering — phrase headline (short mode = phrase only, full = phrase + param rows, no duplicate description row), payload-description rejection heuristics (`toolCallPhrase`), `shortToolFields` native-lowercase-name coverage, tri-state cycling, result clamping. |
 | `workflows_test.go`        | Workflow tracker (markWorking/markFinal/lookup/clear), schema round-trip (incl. loop steps), prompt assembly, glyph table, `effectiveMaxIterations`. |
 | `workflows_screen_test.go` | Workflows builder state machine — add/rename/delete persistence + edit-while-running guard + description edit (`e` → prompt textarea → Ctrl+S persists `Description`) + loop tree (`stepRows`, add loop/inner, edit max-iters, delete loop/child) + scope copy/move (`c`/`s`, conflict auto-suffix, running guard, per-scope rename). |
-| `workflow_store_test.go`   | Two-scope store — filename sanitization, user/repo round-trip (Scope never persisted), Description round-trip (persisted under `json:description`, absent ⇒ key omitted), dir sync rename/delete, junk-file skip, repo-first resolution + ambiguity errors, cross-scope copy (conflict → new_name, deep clone), projectRoot anchoring. |
+| `workflow_store_test.go`   | Three-scope store — filename sanitization, user/repo/global round-trip (Scope never persisted), Description round-trip (persisted under `json:description`, absent ⇒ key omitted), dir sync rename/delete (both repo and global dirs tidy on empty), junk-file skip, global-first resolution + ambiguity errors, cross-scope copy (conflict → new_name, deep clone), `workflowsGlobalDir_NonHome` for empty-home fallback. |
 | `workflows_picker_test.go` | Picker open/navigate/Enter dispatches `spawnWorkflowTabMsg`. |
 | `workflows_run_test.go`    | Step runner — advance (incl. linear no-`end_turn` re-prompt), finalise, fail, idempotent finalise, unknown-provider rejection; loop decision table (iterate / tail break / non-tail break / non-tail proceed / non-tail + tail no-`end_turn` re-prompt / tail no-decision re-prompt / max-iter soft-exit), enter-loop, bounded context, `stepSummaryLine`, `end_turn` signal handling. |
 | `issues_workflow_test.go`  | `f` keybind dispatch on the issues screen — toast / picker / focus-existing-tab. |
@@ -313,7 +313,7 @@ is one new constant + a switch arm per accessor.
 
 ### Schema & scopes
 
-A workflow lives in one of two scopes (`workflow_store.go`):
+A workflow lives in one of three scopes (`workflow_store.go`):
 
 - **user** — `projectConfig.Workflows` alongside `projectConfig.Issues`
   in `~/.config/ask/ask.json` (machine-local, the pre-scope default).
@@ -321,18 +321,22 @@ A workflow lives in one of two scopes (`workflow_store.go`):
   `<projectRoot>/.ask/workflows/` (committed, shared with the team).
   `projectRoot` walks to the main checkout, so every worktree/subdir
   sees the same files — consistent with projectConfig tenancy.
+- **global** — one JSON file per workflow under
+  `~/.config/ask/workflows/` (machine-local, visible from every
+  project — a personal toolbox that follows the user between
+  checkout roots).
 
 `workflowDef.Scope` is runtime-only (`json:"-"`) — the storage
-location IS the scope, so both on-disk shapes are byte-identical to
-pre-scope workflows. Every read merges repo-first (`listAllWorkflows`;
-name-only lookup prefers repo, the same project-wins convention as
-skills/subagents). Names are unique *within* a scope; the same name in
-both scopes is legal — UI surfaces show a scope tag, and the mutating
-tools refuse to guess (`resolveWorkflowByName` errors on ambiguity
-without an explicit scope). All mutations funnel through
-`mutateWorkflows`/`saveAllWorkflows`, which split the merged list by
-scope and sync the repo dir (write changed files, remove stale ones —
-rename = delete+add, VCS-friendly) under the config lock.
+location IS the scope, so every on-disk shape is byte-identical to
+pre-scope workflows. Every read merges in the order global → repo →
+user (`listAllWorkflows`; name-only lookup prefers global, the
+personal-wins convention). Names are unique *within* a scope; the
+same name across multiple scopes is legal — UI surfaces show a scope
+tag, and the mutating tools refuse to guess (`resolveWorkflowByName`
+errors on ambiguity without an explicit scope). All mutations funnel
+through `mutateWorkflows`/`saveAllWorkflows`, which split the merged
+list by scope and sync both dirs (write changed files, remove stale
+ones — rename = delete+add, VCS-friendly) under the config lock.
 `copyWorkflowDef` copies across scopes (or duplicates within one);
 target-name conflicts error and demand a `new_name` (the builder
 auto-suffixes `-2`, `-3`… instead). Malformed/duplicate committed
@@ -552,7 +556,7 @@ with `/config`. Three navigation levels:
 
 | Level | Cursor over | Keys |
 |-------|------------|------|
-| List (left pane) | workflows (with repo/user scope tags) + "+ New" | enter open / r rename / c copy to other scope / s move scope / d delete / esc back to ask |
+| List (left pane) | workflows (with user/repo/global scope tags) + "+ New" | enter open / r rename / c copy / s move (rotates user→repo→global→user) / d delete / esc back to ask |
 | Steps (right pane) | the step tree + affordances | enter edit/create / d delete / tab focus left / esc list |
 | Step (right pane) | agent: Name/Provider/Model/Prompt · loop: Name/Max iters/Exit | enter edits the field / esc back to steps |
 

--- a/config.go
+++ b/config.go
@@ -180,11 +180,13 @@ type workflowsConfig struct {
 // prior step (forwarded as a `Previous step output:` block in the
 // next step's user prompt).
 //
-// A workflow lives in one of two scopes (see workflow_store.go):
+// A workflow lives in one of three scopes (see workflow_store.go):
 // "user" defs persist under projectConfig.Workflows.Items in
 // ~/.config/ask/ask.json; "repo" defs are one-file-per-workflow JSON
 // under <projectRoot>/.ask/workflows/ so they can be committed and
-// shared. Scope is runtime-only (json:"-") — the storage location IS
+// shared; "global" defs are one-file-per-workflow JSON under
+// ~/.config/ask/workflows/ — machine-local but visible from every
+// project. Scope is runtime-only (json:"-") — the storage location IS
 // the scope, so the on-disk shapes stay byte-identical to pre-scope
 // workflows.
 type workflowDef struct {
@@ -214,6 +216,11 @@ const (
 	// workflowScopeRepo marks a workflow stored under
 	// <projectRoot>/.ask/workflows/ (committed, shared with the team).
 	workflowScopeRepo = "repo"
+	// workflowScopeGlobal marks a workflow stored under
+	// ~/.config/ask/workflows/ (machine-local, visible from every
+	// project — a personal toolbox that follows the user between
+	// checkout roots).
+	workflowScopeGlobal = "global"
 )
 
 // workflowStep is one stage of a workflow. A step is one of two kinds,

--- a/mcp_workflows.go
+++ b/mcp_workflows.go
@@ -53,18 +53,18 @@ type workflowListStepView struct {
 
 type workflowListItem struct {
 	Name        string                 `json:"name" jsonschema:"workflow name"`
-	Scope       string                 `json:"scope" jsonschema:"where the workflow is stored: 'user' (~/.config/ask/ask.json, machine-local) or 'repo' (<root>/.ask/workflows/, committed and shared)"`
+	Scope       string                 `json:"scope" jsonschema:"where the workflow is stored: 'user' (~/.config/ask/ask.json, machine-local), 'repo' (<root>/.ask/workflows/, committed and shared), or 'global' (~/.config/ask/workflows/, machine-local and visible from every project)"`
 	Description string                 `json:"description,omitempty" jsonschema:"the author's statement of what this workflow is for and when to use it; judge fit against THIS, not the step names"`
 	Steps       []workflowListStepView `json:"steps" jsonschema:"steps in execution order; prompts omitted to keep the listing small"`
 }
 
 type workflowListOutput struct {
-	Workflows []workflowListItem `json:"workflows" jsonschema:"all workflows visible to the current project, repo scope first"`
+	Workflows []workflowListItem `json:"workflows" jsonschema:"all workflows visible to the current project, in scope order global → repo → user"`
 }
 
 type workflowGetInput struct {
 	Name  string `json:"name" jsonschema:"workflow name"`
-	Scope string `json:"scope,omitempty" jsonschema:"optional scope to read from ('user' or 'repo'); empty resolves repo first, then user"`
+	Scope string `json:"scope,omitempty" jsonschema:"optional scope to read from ('user', 'repo', or 'global'); empty resolves global first, then repo, then user (personal-wins)"`
 }
 
 // workflowInnerStepView is an agent step inside a loop, in the full
@@ -95,7 +95,7 @@ type workflowStepView struct {
 
 type workflowDefView struct {
 	Name        string             `json:"name"`
-	Scope       string             `json:"scope" jsonschema:"where the workflow is stored: 'user' or 'repo'"`
+	Scope       string             `json:"scope" jsonschema:"where the workflow is stored: 'user', 'repo', or 'global'"`
 	Description string             `json:"description,omitempty" jsonschema:"the author's statement of what this workflow is for and when to use it"`
 	Steps       []workflowStepView `json:"steps"`
 }
@@ -106,7 +106,7 @@ type workflowGetOutput struct {
 
 type workflowCreateInput struct {
 	Name        string             `json:"name" jsonschema:"new workflow name; must be unique within the chosen scope"`
-	Scope       string             `json:"scope,omitempty" jsonschema:"where to store the workflow: 'user' (default; machine-local ask.json) or 'repo' (<root>/.ask/workflows/, committed and shared with the team)"`
+	Scope       string             `json:"scope,omitempty" jsonschema:"where to store the workflow: 'user' (default; machine-local ask.json), 'repo' (<root>/.ask/workflows/, committed and shared with the team), or 'global' (~/.config/ask/workflows/, machine-local and visible from every project)"`
 	Description string             `json:"description,omitempty" jsonschema:"what this workflow is for and when to use it; surfaced in workflow_list so the agent judges fit against your stated intent"`
 	Steps       []workflowStepView `json:"steps,omitempty" jsonschema:"steps to create the workflow with; may be empty"`
 }
@@ -117,7 +117,7 @@ type workflowCreateOutput struct {
 
 type workflowEditInput struct {
 	Name        string              `json:"name" jsonschema:"existing workflow name to edit"`
-	Scope       string              `json:"scope,omitempty" jsonschema:"scope holding the workflow ('user' or 'repo'); required when the name exists in both scopes"`
+	Scope       string              `json:"scope,omitempty" jsonschema:"scope holding the workflow ('user', 'repo', or 'global'); required when the name exists in multiple scopes"`
 	NewName     string              `json:"new_name,omitempty" jsonschema:"optional new name; must be unique within the workflow's scope"`
 	Description *string             `json:"description,omitempty" jsonschema:"if provided, replaces the description (pass an empty string to clear it); omit to leave it unchanged"`
 	Steps       *[]workflowStepView `json:"steps,omitempty" jsonschema:"if provided, replaces the entire steps array (full-replace semantics); omit to leave steps unchanged"`
@@ -129,7 +129,7 @@ type workflowEditOutput struct {
 
 type workflowDeleteInput struct {
 	Name  string `json:"name" jsonschema:"workflow name to delete"`
-	Scope string `json:"scope,omitempty" jsonschema:"scope holding the workflow ('user' or 'repo'); required when the name exists in both scopes"`
+	Scope string `json:"scope,omitempty" jsonschema:"scope holding the workflow ('user', 'repo', or 'global'); required when the name exists in multiple scopes"`
 }
 
 type workflowDeleteOutput struct {
@@ -138,8 +138,8 @@ type workflowDeleteOutput struct {
 
 type workflowCopyInput struct {
 	Name    string `json:"name" jsonschema:"workflow name to copy"`
-	Scope   string `json:"scope,omitempty" jsonschema:"scope holding the source ('user' or 'repo'); required when the name exists in both scopes"`
-	To      string `json:"to" jsonschema:"destination scope: 'user' (machine-local) or 'repo' (committed under <root>/.ask/workflows/)"`
+	Scope   string `json:"scope,omitempty" jsonschema:"scope holding the source ('user', 'repo', or 'global'); required when the name exists in multiple scopes"`
+	To      string `json:"to" jsonschema:"destination scope: 'user' (machine-local ask.json), 'repo' (committed under <root>/.ask/workflows/), or 'global' (machine-local under ~/.config/ask/workflows/, visible from every project)"`
 	NewName string `json:"new_name,omitempty" jsonschema:"optional name for the copy; required when the destination scope already has a workflow named after the source"`
 }
 
@@ -149,7 +149,7 @@ type workflowCopyOutput struct {
 
 type workflowRunInput struct {
 	Name   string `json:"name" jsonschema:"workflow name to run"`
-	Scope  string `json:"scope,omitempty" jsonschema:"scope holding the workflow ('user' or 'repo'); required when the name exists in both scopes"`
+	Scope  string `json:"scope,omitempty" jsonschema:"scope holding the workflow ('user', 'repo', or 'global'); required when the name exists in multiple scopes"`
 	Append string `json:"append" jsonschema:"REQUIRED. The workflow runs in a fresh session with NO access to this conversation — its history, file reads, and tool results do not carry over. This text is the ONLY context the run receives, threaded into step 1's prompt as a Reference block. Submit the FULL plan and all context the workflow needs to execute the task end to end: the goal, the concrete steps, relevant file paths, constraints, and acceptance criteria. Do not pass a one-line summary or a pointer back to this chat."`
 }
 
@@ -182,19 +182,19 @@ type endTurnSignalMsg struct {
 // ----- Tool descriptions -----
 
 const (
-	workflowListToolDescription = `List all workflows visible to the current project, from both scopes.
+	workflowListToolDescription = `List all workflows visible to the current project, across three scopes.
 
-A workflow lives in one of two scopes: 'user' (machine-local, stored in ~/.config/ask/ask.json) or 'repo' (stored as one JSON file per workflow under <project root>/.ask/workflows/ — committed to the repo and shared with the team). Repo-scope workflows list first. The same name may exist in both scopes; each item's 'scope' field disambiguates.
+A workflow lives in one of three scopes: 'user' (machine-local, stored in ~/.config/ask/ask.json), 'repo' (one JSON file per workflow under <project root>/.ask/workflows/ — committed to the repo and shared with the team), or 'global' (one JSON file per workflow under ~/.config/ask/workflows/ — machine-local but visible from every project). The merged list is ordered global → repo → user; the same name may exist in more than one scope, and each item's 'scope' field disambiguates.
 
 Returns each workflow's name, scope, description (what it's for and when to use it — judge fit against this), and its steps' (name, provider, model). Step prompts are omitted to keep the listing payload small — call workflow_get to see the full prompt for a specific workflow.`
 
 	workflowGetToolDescription = `Get the full definition of a workflow including each step's prompt.
 
-Pass scope ('user' or 'repo') to read a specific copy; with no scope the repo copy wins when the name exists in both. Errors when the named workflow does not exist.`
+Pass scope ('user', 'repo', or 'global') to read a specific copy; with no scope the global copy wins when the name exists in multiple scopes (personal-wins — a global workflow is the user's explicit pick). Errors when the named workflow does not exist.`
 
 	workflowCreateToolDescription = `Create a new workflow.
 
-The name must be non-empty and not collide with any existing workflow in the chosen scope. scope picks where it is stored: 'user' (default — machine-local ask.json) or 'repo' (one JSON file under <project root>/.ask/workflows/, committed and shared with the team).
+The name must be non-empty and not collide with any existing workflow in the chosen scope. scope picks where it is stored: 'user' (default — machine-local ask.json), 'repo' (one JSON file under <project root>/.ask/workflows/, committed and shared with the team), or 'global' (one JSON file under ~/.config/ask/workflows/, machine-local but visible from every project).
 
 description is optional but strongly recommended: state what the workflow is FOR and when to use it (its trigger conditions, in plain words). That text is surfaced verbatim in workflow_list, and the agent judges whether the workflow fits a task against it — without a description it must guess intent from the step names, which is unreliable.
 
@@ -208,17 +208,17 @@ Errors on duplicate name within the scope, empty step name, unknown provider, a 
 
 	workflowEditToolDescription = `Edit an existing workflow in place (it stays in its scope).
 
-Pass new_name to rename. Pass description to replace the workflow's purpose statement (empty string clears it). Pass steps to replace the entire steps array (full-replace semantics — no per-step CRUD). Omit a field to leave it unchanged. Steps follow the same agent/loop shape documented on workflow_create. When the name exists in both scopes you must pass scope to pick which copy to edit; use workflow_copy to move a workflow between scopes.
+Pass new_name to rename. Pass description to replace the workflow's purpose statement (empty string clears it). Pass steps to replace the entire steps array (full-replace semantics — no per-step CRUD). Omit a field to leave it unchanged. Steps follow the same agent/loop shape documented on workflow_create. When the name exists in multiple scopes you must pass scope to pick which copy to edit; use workflow_copy to move a workflow between scopes.
 
 Errors when the workflow doesn't exist, when the name is ambiguous across scopes and no scope was given, when new_name collides within the scope, when a step is malformed (empty name, unknown provider, nested loop, empty loop), or when the workflow is currently running anywhere in this process.`
 
 	workflowDeleteToolDescription = `Delete a workflow.
 
-When the name exists in both scopes you must pass scope to pick which copy to delete. Errors when the workflow doesn't exist, the name is ambiguous, or the workflow is currently running.`
+When the name exists in multiple scopes you must pass scope to pick which copy to delete. Errors when the workflow doesn't exist, the name is ambiguous, or the workflow is currently running.`
 
 	workflowCopyToolDescription = `Copy a workflow between scopes (or duplicate it within one).
 
-'to' is the destination scope: 'repo' makes a workflow repo-local (a committed JSON file under <project root>/.ask/workflows/ that the whole team can use), 'user' copies it into the machine-local ask.json. The source is untouched — to move, copy then workflow_delete the original.
+'to' is the destination scope: 'repo' makes a workflow repo-local (a committed JSON file under <project root>/.ask/workflows/ that the whole team can use), 'user' copies it into the machine-local ask.json, 'global' copies it into ~/.config/ask/workflows/ (machine-local, visible from every project). The source is untouched — to move, copy then workflow_delete the original.
 
 Naming conflicts: when the destination scope already has a workflow by that name, the call errors and you must pass new_name. new_name is also how you duplicate within the same scope.
 
@@ -226,7 +226,7 @@ Errors when the source doesn't exist, the source name is ambiguous across scopes
 
 	workflowRunToolDescription = `Dispatch a workflow run in the background.
 
-Fire-and-forget: returns immediately with the session key. The workflow runs in a fresh tab; the user can switch to it with the tab bar to watch progress. When the name exists in both scopes pass scope to pick which copy runs.
+Fire-and-forget: returns immediately with the session key. The workflow runs in a fresh tab; the user can switch to it with the tab bar to watch progress. When the name exists in multiple scopes pass scope ('user', 'repo', or 'global') to pick which copy runs.
 
 CRITICAL — the workflow starts in a brand-new session with NO access to this conversation. Its message history, the files you have read, and your tool results DO NOT carry over. The append parameter is the ONLY channel of context into the run: its text is threaded into step 1's prompt as a "Reference:" block, and that is everything the workflow gets.
 
@@ -477,16 +477,16 @@ func workflowDefToView(w workflowDef) workflowDefView {
 	}
 }
 
-// workflowItemsForCwd returns the merged repo+user workflow list,
-// propagating an unreadable ask.json as an error (the tool layer
-// reports it; pure-UI paths use listAllWorkflows and degrade
+// workflowItemsForCwd returns the merged global+repo+user workflow
+// list, propagating an unreadable ask.json as an error (the tool
+// layer reports it; pure-UI paths use listAllWorkflows and degrade
 // silently instead).
 func workflowItemsForCwd(cwd string) ([]workflowDef, error) {
 	user, err := loadUserWorkflows(cwd)
 	if err != nil {
 		return nil, err
 	}
-	return append(loadRepoWorkflows(cwd), user...), nil
+	return append(append(loadGlobalWorkflows(), loadRepoWorkflows(cwd)...), user...), nil
 }
 
 // resolveWorkflowResult adapts resolveWorkflowByName's error shapes
@@ -543,7 +543,7 @@ func workflowGetCore(cwd string, in workflowGetInput) (*mcp.CallToolResult, work
 		return errResult("name is required"), workflowGetOutput{}, nil
 	}
 	// Reads are forgiving on ambiguity: with no explicit scope the
-	// repo copy wins (project-wins, same as the picker / runner).
+	// global copy wins (personal-wins, same as the picker / runner).
 	scope := in.Scope
 	if scope != "" {
 		if _, err := normalizeWorkflowScope(scope); err != nil {
@@ -749,7 +749,7 @@ func workflowCopyCore(cwd string, in workflowCopyInput) (*mcp.CallToolResult, wo
 		return errResult("name is required"), workflowCopyOutput{}, nil
 	}
 	if strings.TrimSpace(in.To) == "" {
-		return errResult("to is required: pass 'user' or 'repo'"), workflowCopyOutput{}, nil
+		return errResult("to is required: pass 'user', 'repo', or 'global'"), workflowCopyOutput{}, nil
 	}
 	dup, err := copyWorkflowDef(cwd, name, in.Scope, in.To, in.NewName)
 	if err != nil {

--- a/mcp_workflows_test.go
+++ b/mcp_workflows_test.go
@@ -1169,12 +1169,12 @@ func TestWorkflowTools_ScopedLifecycle(t *testing.T) {
 		t.Error("same-scope duplicate create must error")
 	}
 	// Unknown scope rejected.
-	res, _, _ = b.workflowCreateTool(ctx, newCallToolReq(), workflowCreateInput{Name: "x", Scope: "global"})
+	res, _, _ = b.workflowCreateTool(ctx, newCallToolReq(), workflowCreateInput{Name: "x", Scope: "global-only"})
 	if res == nil || !res.IsError {
 		t.Error("unknown scope must error")
 	}
 
-	// List shows both with scope tags, repo first.
+	// List shows both with scope tags, repo before user.
 	_, listOut, err := b.workflowListTool(ctx, newCallToolReq(), workflowListInput{})
 	if err != nil {
 		t.Fatal(err)
@@ -1277,5 +1277,217 @@ func TestWorkflowRun_RepoScopedWorkflowDispatches(t *testing.T) {
 	}
 	if out.Workflow != "shared" || len(*captured) != 1 || (*captured)[0].Workflow.Name != "shared" {
 		t.Errorf("dispatch wrong: out=%+v captured=%+v", out, *captured)
+	}
+}
+
+// ----- three-scope: global -----
+
+// TestWorkflowListCore_GlobalIncluded asserts globals appear in
+// workflow_list output with scope: "global" alongside user/repo.
+func TestWorkflowListCore_GlobalIncluded(t *testing.T) {
+	b, cwd := newWorkflowMCPTestBridge(t, 1)
+	resetWorkflowTrackerForTest()
+	if err := saveAllWorkflows(cwd, []workflowDef{
+		{Name: "u-wf", Scope: workflowScopeUser, Steps: []workflowStep{{Name: "u", Provider: "fake"}}},
+		{Name: "r-wf", Scope: workflowScopeRepo, Steps: []workflowStep{{Name: "r", Provider: "fake"}}},
+		{Name: "g-wf", Scope: workflowScopeGlobal, Steps: []workflowStep{{Name: "g", Provider: "fake"}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, out, err := b.workflowListTool(context.Background(), newCallToolReq(), workflowListInput{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(out.Workflows) != 3 {
+		t.Fatalf("expected 3 workflows, got %d: %+v", len(out.Workflows), out.Workflows)
+	}
+	// Order is global → repo → user.
+	wantOrder := []struct{ name, scope string }{
+		{"g-wf", "global"},
+		{"r-wf", "repo"},
+		{"u-wf", "user"},
+	}
+	for i, want := range wantOrder {
+		if out.Workflows[i].Name != want.name || out.Workflows[i].Scope != want.scope {
+			t.Errorf("row %d: got (%q,%q) want (%q,%q)", i, out.Workflows[i].Name, out.Workflows[i].Scope, want.name, want.scope)
+		}
+	}
+}
+
+// TestWorkflowCreateCore_GlobalScope: workflow_create with
+// scope: "global" writes the file at ~/.config/ask/workflows/, and
+// listAllWorkflows returns it tagged Scope=global.
+func TestWorkflowCreateCore_GlobalScope(t *testing.T) {
+	b, cwd := newWorkflowMCPTestBridge(t, 1)
+	resetWorkflowTrackerForTest()
+	res, out, err := b.workflowCreateTool(context.Background(), newCallToolReq(), workflowCreateInput{
+		Name:        "personal",
+		Scope:       "global",
+		Description: "My personal toolbox",
+		Steps:       []workflowStepView{{Name: "s1", Provider: "fake"}},
+	})
+	if err != nil || res.IsError {
+		t.Fatalf("create: err=%v res=%v", err, mcpResultText(res))
+	}
+	if out.Workflow.Scope != "global" || out.Workflow.Name != "personal" {
+		t.Errorf("output wrong: %+v", out.Workflow)
+	}
+	// On disk at ~/.config/ask/workflows/personal.json.
+	globalPath := filepath.Join(os.Getenv("HOME"), ".config", "ask", "workflows", "personal.json")
+	if _, err := os.Stat(globalPath); err != nil {
+		t.Fatalf("global file missing: %v", err)
+	}
+	// listAllWorkflows returns it tagged global.
+	if w, ok := findWorkflow(cwd, "personal", workflowScopeGlobal); !ok || w.Description != "My personal toolbox" {
+		t.Errorf("global not in merged list: %+v ok=%v", w, ok)
+	}
+}
+
+// TestWorkflowEditCore_GlobalScope: workflow_edit with scope:
+// "global" updates the global file and the wire response carries the
+// updated scope.
+func TestWorkflowEditCore_GlobalScope(t *testing.T) {
+	b, cwd := newWorkflowMCPTestBridge(t, 1)
+	resetWorkflowTrackerForTest()
+	if err := saveAllWorkflows(cwd, []workflowDef{
+		{Name: "p", Scope: workflowScopeGlobal, Steps: []workflowStep{{Name: "s", Provider: "fake"}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	desc := "Updated"
+	res, out, err := b.workflowEditTool(context.Background(), newCallToolReq(), workflowEditInput{
+		Name:        "p",
+		Scope:       "global",
+		Description: &desc,
+	})
+	if err != nil || res.IsError {
+		t.Fatalf("edit: err=%v res=%v", err, mcpResultText(res))
+	}
+	if out.Workflow.Scope != "global" || out.Workflow.Description != "Updated" {
+		t.Errorf("edit output wrong: %+v", out.Workflow)
+	}
+	// File on disk has the new description.
+	globalPath := filepath.Join(os.Getenv("HOME"), ".config", "ask", "workflows", "p.json")
+	data, _ := os.ReadFile(globalPath)
+	if !strings.Contains(string(data), "Updated") {
+		t.Errorf("global file not updated: %s", data)
+	}
+}
+
+// TestWorkflowDeleteCore_GlobalScope: workflow_delete with scope:
+// "global" removes the file and confirms via the wire response.
+func TestWorkflowDeleteCore_GlobalScope(t *testing.T) {
+	b, cwd := newWorkflowMCPTestBridge(t, 1)
+	resetWorkflowTrackerForTest()
+	if err := saveAllWorkflows(cwd, []workflowDef{
+		{Name: "p", Scope: workflowScopeGlobal, Steps: []workflowStep{{Name: "s", Provider: "fake"}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	globalPath := filepath.Join(os.Getenv("HOME"), ".config", "ask", "workflows", "p.json")
+	if _, err := os.Stat(globalPath); err != nil {
+		t.Fatalf("global file missing pre-delete: %v", err)
+	}
+	res, out, err := b.workflowDeleteTool(context.Background(), newCallToolReq(), workflowDeleteInput{
+		Name:  "p",
+		Scope: "global",
+	})
+	if err != nil || res.IsError || !out.Deleted {
+		t.Fatalf("delete: err=%v res=%v out=%+v", err, mcpResultText(res), out)
+	}
+	if _, err := os.Stat(globalPath); !os.IsNotExist(err) {
+		t.Errorf("global file should be gone: %v", err)
+	}
+}
+
+// TestWorkflowCopyCore_GlobalTarget: workflow_copy with to: "global"
+// lands a copy at ~/.config/ask/workflows/.
+func TestWorkflowCopyCore_GlobalTarget(t *testing.T) {
+	b, cwd := newWorkflowMCPTestBridge(t, 1)
+	resetWorkflowTrackerForTest()
+	if err := saveAllWorkflows(cwd, []workflowDef{
+		{Name: "src", Scope: workflowScopeUser, Steps: []workflowStep{{Name: "s", Provider: "fake", Prompt: "p"}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	res, out, err := b.workflowCopyTool(context.Background(), newCallToolReq(), workflowCopyInput{
+		Name: "src",
+		To:   "global",
+	})
+	if err != nil || res.IsError {
+		t.Fatalf("copy: err=%v res=%v", err, mcpResultText(res))
+	}
+	if out.Workflow.Scope != "global" || out.Workflow.Name != "src" {
+		t.Errorf("copy output wrong: %+v", out.Workflow)
+	}
+	globalPath := filepath.Join(os.Getenv("HOME"), ".config", "ask", "workflows", "src.json")
+	if _, err := os.Stat(globalPath); err != nil {
+		t.Errorf("global copy not on disk: %v", err)
+	}
+	// Source survives.
+	if _, ok := findWorkflow(cwd, "src", workflowScopeUser); !ok {
+		t.Error("source must survive a copy")
+	}
+}
+
+// TestWorkflowRunCore_GlobalScope: workflow_run with scope: "global"
+// dispatches a global-scope workflow via spawnWorkflowTabMsg.
+func TestWorkflowRunCore_GlobalScope(t *testing.T) {
+	b, cwd := newWorkflowMCPTestBridge(t, 11)
+	resetWorkflowTrackerForTest()
+	captured := installSpawnCaptor(t)
+	if err := saveAllWorkflows(cwd, []workflowDef{
+		{Name: "global-wf", Scope: workflowScopeGlobal, Steps: []workflowStep{{Name: "s", Provider: "fake"}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	res, out, err := b.workflowRunTool(context.Background(), newCallToolReq(), workflowRunInput{
+		Name:   "global-wf",
+		Scope:  "global",
+		Append: "plan",
+	})
+	if err != nil || res.IsError {
+		t.Fatalf("run: err=%v res=%v", err, mcpResultText(res))
+	}
+	if out.Workflow != "global-wf" {
+		t.Errorf("output workflow: got %q want global-wf", out.Workflow)
+	}
+	if len(*captured) != 1 {
+		t.Fatalf("expected 1 dispatch, got %d", len(*captured))
+	}
+	msg := (*captured)[0]
+	if msg.Workflow.Name != "global-wf" || msg.Workflow.Scope != workflowScopeGlobal {
+		t.Errorf("dispatched wrong: %+v", msg.Workflow)
+	}
+	if msg.Cwd != cwd {
+		t.Errorf("dispatched cwd: got %q want %q", msg.Cwd, cwd)
+	}
+}
+
+// TestWorkflowCopyCore_AmbiguousAcrossAllThreeScopes: a name in
+// user + repo + global without a scope errors with the new "multiple
+// scopes" message.
+func TestWorkflowCopyCore_AmbiguousAcrossAllThreeScopes(t *testing.T) {
+	b, cwd := newWorkflowMCPTestBridge(t, 1)
+	resetWorkflowTrackerForTest()
+	if err := saveAllWorkflows(cwd, []workflowDef{
+		{Name: "amb", Scope: workflowScopeUser, Steps: []workflowStep{{Name: "u", Provider: "fake"}}},
+		{Name: "amb", Scope: workflowScopeRepo, Steps: []workflowStep{{Name: "r", Provider: "fake"}}},
+		{Name: "amb", Scope: workflowScopeGlobal, Steps: []workflowStep{{Name: "g", Provider: "fake"}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	res, _, err := b.workflowCopyTool(context.Background(), newCallToolReq(), workflowCopyInput{
+		Name: "amb",
+		To:   "user",
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if res == nil || !res.IsError {
+		t.Fatalf("ambiguous copy without scope must error; got %+v", res)
+	}
+	if !strings.Contains(mcpResultText(res), "multiple scopes") {
+		t.Errorf("ambiguity error should say 'multiple scopes'; got %q", mcpResultText(res))
 	}
 }

--- a/workflow_store.go
+++ b/workflow_store.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-// workflow_store.go is the two-scope persistence layer for workflow
+// workflow_store.go is the three-scope persistence layer for workflow
 // definitions:
 //
 //   - user scope: projectConfig.Workflows.Items inside
@@ -18,22 +18,32 @@ import (
 //   - repo scope: one JSON file per workflow under
 //     <projectRoot>/.ask/workflows/, committed to the repo so the
 //     whole team shares them.
+//   - global scope: one JSON file per workflow under
+//     ~/.config/ask/workflows/ (machine-local, visible from every
+//     project — a personal toolbox that follows the user between
+//     checkout roots).
 //
-// Every read merges the two scopes (repo first — the "project wins"
-// convention skills and subagents already follow); every write routes
-// by the def's Scope tag. Names are unique within a scope; the same
-// name MAY exist in both scopes, in which case name-only resolution
-// prefers repo and the mutating tool surface demands an explicit
-// scope (resolveWorkflowByName).
+// Every read merges the three scopes (global first — personal-wins, then
+// repo project-wins, then user); every write routes by the def's Scope
+// tag. Names are unique within a scope; the same name MAY exist in
+// multiple scopes, in which case name-only resolution prefers global
+// (the most personal option) and the mutating tool surface demands an
+// explicit scope (resolveWorkflowByName).
 //
 // All mutations serialise through withConfigLock — the user scope
 // needs it for the load → mutate → save cycle on ask.json, and
-// running the repo-dir sync under the same lock means a concurrent
-// builder commit and MCP workflow_edit can't interleave file writes.
+// running the repo-dir + global-dir syncs under the same lock means a
+// concurrent builder commit and MCP workflow_edit can't interleave
+// file writes.
 
 // workflowsRepoDirName is the repo-local directory, relative to the
 // project root.
 const workflowsRepoDirName = ".ask/workflows"
+
+// workflowsGlobalDirName is the machine-local "global" directory name,
+// relative to the user's config root (~/.config/ask). Same basename as
+// the repo dir, different parent — the parent location IS the scope.
+const workflowsGlobalDirName = "workflows"
 
 // workflowsRepoDir returns the absolute repo-local workflows dir for
 // cwd. Empty when cwd is empty.
@@ -45,6 +55,18 @@ func workflowsRepoDir(cwd string) string {
 	return filepath.Join(root, filepath.FromSlash(workflowsRepoDirName))
 }
 
+// workflowsGlobalDir returns the absolute global workflows dir, under
+// ~/.config/ask/workflows/. Empty when home is empty so test fixtures
+// that pin HOME still degrade cleanly (load/sync become no-ops on the
+// same pattern as the repo dir under an empty cwd).
+func workflowsGlobalDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".config", "ask", workflowsGlobalDirName)
+}
+
 // normalizeWorkflowScope maps "" to user (the pre-scope default) and
 // validates the rest. Returns an error for anything else so tool
 // callers get a clear message instead of a silent fallback.
@@ -54,8 +76,10 @@ func normalizeWorkflowScope(scope string) (string, error) {
 		return workflowScopeUser, nil
 	case workflowScopeRepo:
 		return workflowScopeRepo, nil
+	case workflowScopeGlobal:
+		return workflowScopeGlobal, nil
 	}
-	return "", fmt.Errorf("unknown scope %q (use %q or %q)", scope, workflowScopeUser, workflowScopeRepo)
+	return "", fmt.Errorf("unknown scope %q (use %q, %q, or %q)", scope, workflowScopeUser, workflowScopeRepo, workflowScopeGlobal)
 }
 
 // workflowFileName maps a workflow name onto a filesystem-safe
@@ -137,6 +161,60 @@ func loadRepoWorkflows(cwd string) []workflowDef {
 	return out
 }
 
+// loadGlobalWorkflows reads every *.json under ~/.config/ask/workflows/,
+// skipping files that don't parse or carry an empty name. Mirrors
+// loadRepoWorkflows: a malformed or hand-edited file is debugLog'd and
+// skipped, never fatal. Duplicate names within the dir keep the first
+// (filename order) and skip the rest. Results are tagged Scope=global
+// and sorted by name.
+func loadGlobalWorkflows() []workflowDef {
+	dir := workflowsGlobalDir()
+	if dir == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+	seen := map[string]bool{}
+	var out []workflowDef
+	for _, fname := range names {
+		path := filepath.Join(dir, fname)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			debugLog("global workflow %s: read: %v", path, err)
+			continue
+		}
+		var def workflowDef
+		if err := json.Unmarshal(data, &def); err != nil {
+			debugLog("global workflow %s: parse: %v", path, err)
+			continue
+		}
+		def.Name = strings.TrimSpace(def.Name)
+		if def.Name == "" {
+			debugLog("global workflow %s: skipped, name is required", path)
+			continue
+		}
+		if seen[def.Name] {
+			debugLog("global workflow %s: skipped, duplicate name %q", path, def.Name)
+			continue
+		}
+		seen[def.Name] = true
+		def.Scope = workflowScopeGlobal
+		out = append(out, def)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
 // loadUserWorkflows reads the user-scope list from ask.json, tagged
 // Scope=user, in config order. The error surfaces a broken ask.json
 // to the tool layer; UI listing paths drop it (an unreadable config
@@ -155,15 +233,21 @@ func loadUserWorkflows(cwd string) ([]workflowDef, error) {
 	return out, nil
 }
 
-// listAllWorkflows merges the two scopes: repo first (project wins),
-// then user, each in their scope-stable order.
+// listAllWorkflows merges the three scopes: global first (the most
+// personal option leads), then repo (project-wins, same as the
+// pre-global convention), then user. Each scope keeps its own
+// scope-stable order; resolveWorkflowByName / findWorkflow walk the
+// merged list in this order so a name present in multiple scopes
+// resolves to global on a name-only lookup.
 func listAllWorkflows(cwd string) []workflowDef {
 	user, _ := loadUserWorkflows(cwd)
-	return append(loadRepoWorkflows(cwd), user...)
+	return append(append(loadGlobalWorkflows(), loadRepoWorkflows(cwd)...), user...)
 }
 
 // findWorkflow returns the named workflow in the given scope.
-// scope "" searches repo first, then user (project-wins resolution).
+// scope "" searches global first, then repo, then user (the same
+// personal-wins order listAllWorkflows uses; global beats repo on
+// ambiguity because the global copy is the user's explicit pick).
 func findWorkflow(cwd, name, scope string) (workflowDef, bool) {
 	for _, w := range listAllWorkflows(cwd) {
 		if w.Name != name {
@@ -177,13 +261,13 @@ func findWorkflow(cwd, name, scope string) (workflowDef, bool) {
 }
 
 // errWorkflowAmbiguous is returned by resolveWorkflowByName when the
-// name exists in both scopes and the caller didn't pick one.
-var errWorkflowAmbiguous = errors.New("workflow exists in both scopes; pass scope to pick one")
+// name exists in multiple scopes and the caller didn't pick one.
+var errWorkflowAmbiguous = errors.New("workflow exists in multiple scopes; pass scope to pick one")
 
 // resolveWorkflowByName resolves name (+ optional scope) to exactly
 // one workflow. With an explicit scope it's a plain scoped lookup.
-// Without one, a name living in both scopes is an error — mutating
-// surfaces must never guess which copy to touch.
+// Without one, a name living in more than one scope is an error —
+// mutating surfaces must never guess which copy to touch.
 func resolveWorkflowByName(cwd, name, scope string) (workflowDef, error) {
 	if scope != "" {
 		norm, err := normalizeWorkflowScope(scope)
@@ -213,10 +297,11 @@ func resolveWorkflowByName(cwd, name, scope string) (workflowDef, error) {
 
 // saveAllWorkflows persists the full merged list: user-scope defs
 // replace projectConfig.Workflows.Items (in list order), repo-scope
-// defs are synced onto <root>/.ask/workflows/ (write each def to
-// <sanitized-name>.json, remove files no longer claimed by any def).
-// Defs with an empty Scope count as user. Files whose content is
-// already current are left untouched so VCS mtimes don't churn.
+// defs are synced onto <root>/.ask/workflows/, global-scope defs are
+// synced onto ~/.config/ask/workflows/ — one file per def named after
+// the workflow, files no longer claimed by any def removed. Defs
+// with an empty Scope count as user. Files whose content is already
+// current are left untouched so VCS mtimes don't churn.
 //
 // This is the single write path for the builder UI and the
 // scope-mutation helpers below — both build the desired end state in
@@ -246,12 +331,20 @@ func mutateWorkflows(cwd string, fn func(items []workflowDef) ([]workflowDef, er
 
 // saveAllWorkflowsLocked is saveAllWorkflows without the lock; the
 // caller must hold configFileMu (withConfigLock is not reentrant).
+// Splits the merged list into three scope slices and persists each:
+// user → projectConfig.Workflows.Items in ask.json; repo →
+// <root>/.ask/workflows/; global → ~/.config/ask/workflows/. Defs
+// with an empty Scope count as user. Files whose content is already
+// current are left untouched so VCS mtimes don't churn.
 func saveAllWorkflowsLocked(cwd string, items []workflowDef) error {
-	var user, repo []workflowDef
+	var user, repo, global []workflowDef
 	for _, w := range items {
-		if w.Scope == workflowScopeRepo {
+		switch w.Scope {
+		case workflowScopeRepo:
 			repo = append(repo, w)
-		} else {
+		case workflowScopeGlobal:
+			global = append(global, w)
+		default:
 			user = append(user, w)
 		}
 	}
@@ -274,7 +367,10 @@ func saveAllWorkflowsLocked(cwd string, items []workflowDef) error {
 	if err := saveConfig(cfg); err != nil {
 		return err
 	}
-	return syncRepoWorkflowFiles(cwd, repo)
+	if err := syncRepoWorkflowFiles(cwd, repo); err != nil {
+		return err
+	}
+	return syncGlobalWorkflowFiles(global)
 }
 
 // syncRepoWorkflowFiles makes the repo-local dir contain exactly
@@ -290,6 +386,32 @@ func syncRepoWorkflowFiles(cwd string, defs []workflowDef) error {
 		}
 		return nil
 	}
+	return syncWorkflowFiles(dir, defs, "repo")
+}
+
+// syncGlobalWorkflowFiles mirrors syncRepoWorkflowFiles for the
+// machine-local global dir at ~/.config/ask/workflows/. The dir is
+// created on first write and removed when it empties out, so a user
+// who never creates a global workflow never grows a workflows/ tree.
+func syncGlobalWorkflowFiles(defs []workflowDef) error {
+	dir := workflowsGlobalDir()
+	if dir == "" {
+		if len(defs) > 0 {
+			return errors.New("no home directory to store global workflows under")
+		}
+		return nil
+	}
+	return syncWorkflowFiles(dir, defs, "global")
+}
+
+// syncWorkflowFiles is the shared "make `dir` contain exactly `defs`"
+// body used by both syncRepoWorkflowFiles and syncGlobalWorkflowFiles.
+// `label` is the human-readable scope name used in debugLog only —
+// file paths come from `dir` directly. One file per def named after
+// the workflow (suffixed -2, -3… when two names sanitize identically);
+// stale files removed. The dir is created on first write and removed
+// when it empties out.
+func syncWorkflowFiles(dir string, defs []workflowDef, label string) error {
 	claimed := map[string]bool{}
 	if len(defs) > 0 {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -341,6 +463,7 @@ func syncRepoWorkflowFiles(cwd string, defs []workflowDef) error {
 	if remaining == 0 && len(claimed) == 0 {
 		_ = os.Remove(dir) // best-effort tidy; fails when non-empty
 	}
+	_ = label // reserved for future debugLog enrichment
 	return nil
 }
 
@@ -399,11 +522,15 @@ func cloneWorkflowSteps(in []workflowStep) []workflowStep {
 	return out
 }
 
-// workflowScopeTag is the short UI label for a scope ("repo"/"user").
-// Defs that predate scoping (empty Scope) read as user.
+// workflowScopeTag is the short UI label for a scope
+// ("user"/"repo"/"global"). Defs that predate scoping (empty Scope)
+// read as user.
 func workflowScopeTag(scope string) string {
-	if scope == workflowScopeRepo {
+	switch scope {
+	case workflowScopeRepo:
 		return workflowScopeRepo
+	case workflowScopeGlobal:
+		return workflowScopeGlobal
 	}
 	return workflowScopeUser
 }

--- a/workflow_store_test.go
+++ b/workflow_store_test.go
@@ -114,7 +114,7 @@ func TestWorkflowStore_TwoScopeRoundTrip(t *testing.T) {
 		t.Errorf("Scope must never persist (location IS the scope): %s", data)
 	}
 
-	// Merged listing: repo first, scopes tagged, loop tree intact.
+	// Merged listing: repo before user within the merged list, scopes tagged, loop tree intact.
 	got := listAllWorkflows(cwd)
 	if len(got) != 2 || got[0].Name != "shared" || got[0].Scope != workflowScopeRepo ||
 		got[1].Name != "local-only" || got[1].Scope != workflowScopeUser {
@@ -197,7 +197,7 @@ func TestResolveWorkflowByName(t *testing.T) {
 		t.Errorf("solo: %+v err=%v", w, err)
 	}
 	// Ambiguous name without a scope errors.
-	if _, err := resolveWorkflowByName(cwd, "both", ""); err == nil || !strings.Contains(err.Error(), "both scopes") {
+	if _, err := resolveWorkflowByName(cwd, "both", ""); err == nil || !strings.Contains(err.Error(), "multiple scopes") {
 		t.Errorf("ambiguous resolve should error; got %v", err)
 	}
 	// Explicit scope picks the right copy.
@@ -306,5 +306,326 @@ func TestWorkflowsRepoDir_GitRootResolution(t *testing.T) {
 	}
 	if got := workflowsRepoDir(sub); got != filepath.Join(root, ".ask", "workflows") {
 		t.Errorf("subdir should resolve to checkout root; got %q", got)
+	}
+}
+
+// ----- three-scope: global -----
+
+// TestWorkflowStore_GlobalRoundTrip writes a global-scope def, asserts
+// the file lands at ~/.config/ask/workflows/<name>.json, that the
+// on-disk bytes are byte-identical to a repo file (no `"scope"` /
+// `"Scope"` keys), and that a re-read returns the def tagged
+// Scope=global. Description and loop steps round-trip the same way as
+// user/repo.
+func TestWorkflowStore_GlobalRoundTrip(t *testing.T) {
+	cwd := isolateHome(t)
+	const desc = "Personal toolbox entry — available from every project."
+	items := []workflowDef{
+		{Name: "toolbox", Scope: workflowScopeGlobal, Description: desc,
+			Steps: []workflowStep{
+				{Name: "s1", Provider: "fake", Prompt: "first"},
+				{Name: "loop1", Kind: workflowStepKindLoop, MaxIterations: 2, ExitCondition: "done",
+					Steps: []workflowStep{{Name: "inner", Provider: "fake", Prompt: "go"}}},
+			}},
+	}
+	if err := saveAllWorkflows(cwd, items); err != nil {
+		t.Fatalf("saveAllWorkflows: %v", err)
+	}
+
+	// File landed at ~/.config/ask/workflows/toolbox.json.
+	path := filepath.Join(os.Getenv("HOME"), ".config", "ask", "workflows", "toolbox.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("global workflow file missing at %s: %v", path, err)
+	}
+	// Same byte-shape as a repo file: no scope key, on-disk def intact.
+	if strings.Contains(string(data), `"Scope"`) || strings.Contains(string(data), `"scope"`) {
+		t.Errorf("Scope must never persist on global files: %s", data)
+	}
+	var onDisk workflowDef
+	if err := json.Unmarshal(data, &onDisk); err != nil {
+		t.Fatalf("global file unparseable: %v", err)
+	}
+	if onDisk.Name != "toolbox" || len(onDisk.Steps) != 2 || !onDisk.Steps[1].isLoop() {
+		t.Errorf("global file content wrong: %+v", onDisk)
+	}
+	if onDisk.Steps[1].MaxIterations != 2 || onDisk.Steps[1].ExitCondition != "done" {
+		t.Errorf("loop config lost on round trip: %+v", onDisk.Steps[1])
+	}
+	if onDisk.Steps[1].Steps[0].Name != "inner" {
+		t.Errorf("loop inner step lost: %+v", onDisk.Steps[1].Steps)
+	}
+	if !strings.Contains(string(data), `"description"`) {
+		t.Errorf("description should persist under the json:description key: %s", data)
+	}
+
+	// Re-read returns the def tagged Scope=global.
+	got := listAllWorkflows(cwd)
+	var read workflowDef
+	for _, w := range got {
+		if w.Name == "toolbox" {
+			read = w
+		}
+	}
+	if read.Scope != workflowScopeGlobal {
+		t.Errorf("Scope tag lost: got %q want %q", read.Scope, workflowScopeGlobal)
+	}
+	if read.Description != desc {
+		t.Errorf("description lost: got %q want %q", read.Description, desc)
+	}
+}
+
+// TestLoadGlobalWorkflows_SkipsJunk mirrors TestLoadRepoWorkflows_SkipsJunk
+// for the global dir: malformed JSON, missing name, duplicate name,
+// and non-JSON files are debugLog'd and skipped, never fatal.
+func TestLoadGlobalWorkflows_SkipsJunk(t *testing.T) {
+	isolateHome(t)
+	dir := filepath.Join(os.Getenv("HOME"), ".config", "ask", "workflows")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("good.json", `{"name":"good","steps":[{"name":"s","provider":"fake"}]}`)
+	write("broken.json", `{not json`)
+	write("nameless.json", `{"steps":[]}`)
+	write("z-dup.json", `{"name":"good"}`)
+	write("notes.txt", `not a workflow`)
+	got := loadGlobalWorkflows()
+	if len(got) != 1 || got[0].Name != "good" || len(got[0].Steps) != 1 {
+		t.Errorf("expected exactly the one good workflow; got %+v", got)
+	}
+	if got[0].Scope != workflowScopeGlobal {
+		t.Errorf("expected Scope=global; got %q", got[0].Scope)
+	}
+}
+
+// TestWorkflowStore_GlobalSyncRenamesAndDeletes pins the global
+// dir's sync behaviour: rename → file replaced; delete → file gone;
+// emptying the dir → dir removed (same tidy pattern as the repo
+// dir). All under the config lock.
+func TestWorkflowStore_GlobalSyncRenamesAndDeletes(t *testing.T) {
+	cwd := isolateHome(t)
+	dir := filepath.Join(os.Getenv("HOME"), ".config", "ask", "workflows")
+
+	seed := []workflowDef{{Name: "alpha", Scope: workflowScopeGlobal}}
+	if err := saveAllWorkflows(cwd, seed); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "alpha.json")); err != nil {
+		t.Fatalf("alpha.json missing: %v", err)
+	}
+
+	// Rename: alpha → beta removes the stale file and writes the new.
+	if err := saveAllWorkflows(cwd, []workflowDef{{Name: "beta", Scope: workflowScopeGlobal}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "alpha.json")); !os.IsNotExist(err) {
+		t.Errorf("stale alpha.json should be removed after rename")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "beta.json")); err != nil {
+		t.Errorf("beta.json missing after rename: %v", err)
+	}
+
+	// Deleting every global def empties (and tidies) the dir.
+	if err := saveAllWorkflows(cwd, nil); err != nil {
+		t.Fatal(err)
+	}
+	if entries, err := os.ReadDir(dir); err == nil && len(entries) > 0 {
+		t.Errorf("global dir should be empty after deleting all: %v", entries)
+	}
+}
+
+// TestWorkflowsGlobalDir_NonHome pins the empty-home fallback: when
+// $HOME is empty the function returns "" (mirroring workflowsRepoDir's
+// empty-cwd fallback). Keeps test fixtures that pin HOME safe and
+// makes the load/sync paths a clean no-op.
+func TestWorkflowsGlobalDir_NonHome(t *testing.T) {
+	// Empty env: temporarily set HOME="" so the call returns "".
+	t.Setenv("HOME", "")
+	if got := workflowsGlobalDir(); got != "" {
+		t.Errorf("empty HOME should yield empty dir; got %q", got)
+	}
+	// loadGlobalWorkflows/syncGlobalWorkflowFiles degrade cleanly
+	// when the dir is empty.
+	if got := loadGlobalWorkflows(); got != nil {
+		t.Errorf("loadGlobalWorkflows on empty dir should return nil; got %+v", got)
+	}
+	if err := syncGlobalWorkflowFiles([]workflowDef{{Name: "x", Scope: workflowScopeGlobal}}); err == nil {
+		t.Error("syncGlobalWorkflowFiles with defs but empty dir should error")
+	}
+	if err := syncGlobalWorkflowFiles(nil); err != nil {
+		t.Errorf("syncGlobalWorkflowFiles with no defs and empty dir should be a no-op; got %v", err)
+	}
+}
+
+// TestResolveWorkflowByName_Global pins the explicit-scope path and
+// the multi-scope ambiguity error for the third scope.
+func TestResolveWorkflowByName_Global(t *testing.T) {
+	cwd := isolateHome(t)
+	if err := saveAllWorkflows(cwd, []workflowDef{
+		{Name: "g", Scope: workflowScopeGlobal, Steps: []workflowStep{{Name: "g-step", Provider: "fake"}}},
+		{Name: "r", Scope: workflowScopeRepo, Steps: []workflowStep{{Name: "r-step", Provider: "fake"}}},
+		{Name: "u", Scope: workflowScopeUser, Steps: []workflowStep{{Name: "u-step", Provider: "fake"}}},
+		{Name: "all-three", Scope: workflowScopeUser},
+		{Name: "all-three", Scope: workflowScopeRepo, Steps: []workflowStep{{Name: "r", Provider: "fake"}}},
+		{Name: "all-three", Scope: workflowScopeGlobal, Steps: []workflowStep{{Name: "g", Provider: "fake"}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Explicit scope: global resolves uniquely.
+	w, err := resolveWorkflowByName(cwd, "g", workflowScopeGlobal)
+	if err != nil || w.Steps[0].Name != "g-step" {
+		t.Errorf("global explicit lookup: %+v err=%v", w, err)
+	}
+	// A name in all three scopes without a scope errors with the
+	// multi-scope ambiguity message.
+	if _, err := resolveWorkflowByName(cwd, "all-three", ""); err == nil ||
+		!strings.Contains(err.Error(), "multiple scopes") {
+		t.Errorf("three-scope ambiguity should error with 'multiple scopes'; got %v", err)
+	}
+	// Unknown scope rejected.
+	if _, err := resolveWorkflowByName(cwd, "g", "local"); err == nil {
+		t.Error("unknown scope should error")
+	}
+}
+
+// TestFindWorkflow_GlobalWins pins the personal-wins rule: when a name
+// exists in all three scopes, findWorkflow(cwd, name, "") returns the
+// global copy. Same convention skills/subagents follow (project-wins
+// for repo, but for the new global-wins).
+func TestFindWorkflow_GlobalWins(t *testing.T) {
+	cwd := isolateHome(t)
+	if err := saveAllWorkflows(cwd, []workflowDef{
+		{Name: "shared", Scope: workflowScopeUser, Steps: []workflowStep{{Name: "u", Provider: "fake"}}},
+		{Name: "shared", Scope: workflowScopeRepo, Steps: []workflowStep{{Name: "r", Provider: "fake"}}},
+		{Name: "shared", Scope: workflowScopeGlobal, Steps: []workflowStep{{Name: "g", Provider: "fake"}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	w, ok := findWorkflow(cwd, "shared", "")
+	if !ok || w.Scope != workflowScopeGlobal {
+		t.Errorf("findWorkflow should prefer global; got %+v ok=%v", w, ok)
+	}
+	if w.Steps[0].Name != "g" {
+		t.Errorf("global copy should have its own step; got %+v", w.Steps)
+	}
+}
+
+// TestCopyWorkflowDef_Global covers the cross-scope copy paths into
+// and out of the global dir, plus the conflict-on-name semantics.
+func TestCopyWorkflowDef_Global(t *testing.T) {
+	cwd := isolateHome(t)
+	dir := filepath.Join(os.Getenv("HOME"), ".config", "ask", "workflows")
+
+	// Seed: one user workflow to copy.
+	if err := saveAllWorkflows(cwd, []workflowDef{
+		{Name: "u-only", Scope: workflowScopeUser, Steps: []workflowStep{{Name: "s", Provider: "fake", Prompt: "p"}}},
+		{Name: "in-global", Scope: workflowScopeGlobal, Steps: []workflowStep{{Name: "g", Provider: "fake"}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// user → global: copy lands at the global dir.
+	dup, err := copyWorkflowDef(cwd, "u-only", "", workflowScopeGlobal, "")
+	if err != nil {
+		t.Fatalf("user→global copy: %v", err)
+	}
+	if dup.Scope != workflowScopeGlobal || dup.Name != "u-only" {
+		t.Errorf("copy shape wrong: %+v", dup)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "u-only.json")); err != nil {
+		t.Errorf("global copy not on disk: %v", err)
+	}
+
+	// global → repo: copy lands at <root>/.ask/workflows/.
+	dup, err = copyWorkflowDef(cwd, "in-global", workflowScopeGlobal, workflowScopeRepo, "")
+	if err != nil {
+		t.Fatalf("global→repo copy: %v", err)
+	}
+	if dup.Scope != workflowScopeRepo || dup.Name != "in-global" {
+		t.Errorf("global→repo copy shape wrong: %+v", dup)
+	}
+	if _, err := os.Stat(filepath.Join(cwd, ".ask", "workflows", "in-global.json")); err != nil {
+		t.Errorf("repo copy not on disk: %v", err)
+	}
+
+	// repo → global (with rename to avoid collision).
+	if err := saveAllWorkflows(cwd, []workflowDef{
+		{Name: "u-only", Scope: workflowScopeUser},
+		{Name: "u-only", Scope: workflowScopeGlobal},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	dup, err = copyWorkflowDef(cwd, "u-only", workflowScopeUser, workflowScopeGlobal, "u-only-fork")
+	if err != nil {
+		t.Fatalf("user→global with rename: %v", err)
+	}
+	if dup.Name != "u-only-fork" || dup.Scope != workflowScopeGlobal {
+		t.Errorf("forked copy shape wrong: %+v", dup)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "u-only-fork.json")); err != nil {
+		t.Errorf("forked global copy not on disk: %v", err)
+	}
+
+	// Conflict without new_name errors.
+	if _, err := copyWorkflowDef(cwd, "u-only", workflowScopeUser, workflowScopeGlobal, ""); err == nil ||
+		!strings.Contains(err.Error(), "new_name") {
+		t.Errorf("conflicting global copy should demand new_name; got %v", err)
+	}
+}
+
+// TestListAllWorkflows_Order pins the merged-list order: global first
+// (the most personal option), then repo (project-wins), then user.
+// Repo and global sort alphabetically on load (stable listing
+// regardless of directory iteration order); the user list preserves
+// ask.json config order — same convention the pre-global code
+// followed.
+func TestListAllWorkflows_Order(t *testing.T) {
+	cwd := isolateHome(t)
+	items := []workflowDef{
+		{Name: "a-global", Scope: workflowScopeGlobal},
+		{Name: "z-global", Scope: workflowScopeGlobal},
+		{Name: "a-repo", Scope: workflowScopeRepo},
+		{Name: "z-repo", Scope: workflowScopeRepo},
+		{Name: "a-user", Scope: workflowScopeUser},
+		{Name: "z-user", Scope: workflowScopeUser},
+	}
+	if err := saveAllWorkflows(cwd, items); err != nil {
+		t.Fatal(err)
+	}
+	got := listAllWorkflows(cwd)
+	wantScopes := []string{
+		workflowScopeGlobal, workflowScopeGlobal,
+		workflowScopeRepo, workflowScopeRepo,
+		workflowScopeUser, workflowScopeUser,
+	}
+	wantNames := []string{"a-global", "z-global", "a-repo", "z-repo", "a-user", "z-user"}
+	if len(got) != len(wantScopes) {
+		t.Fatalf("merged list length: got %d want %d (%+v)", len(got), len(wantScopes), got)
+	}
+	for i := range wantScopes {
+		if got[i].Scope != wantScopes[i] || got[i].Name != wantNames[i] {
+			t.Errorf("row %d: got (%q,%q) want (%q,%q)", i, got[i].Name, got[i].Scope, wantNames[i], wantScopes[i])
+		}
+	}
+	// Reverse the user order in ask.json — the merged list's user
+	// group must reflect the new config order, not alphabetical.
+	if err := saveAllWorkflows(cwd, []workflowDef{
+		{Name: "a-global", Scope: workflowScopeGlobal},
+		{Name: "z-global", Scope: workflowScopeGlobal},
+		{Name: "z-user", Scope: workflowScopeUser},
+		{Name: "a-user", Scope: workflowScopeUser},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got = listAllWorkflows(cwd)
+	if got[2].Name != "z-user" || got[3].Name != "a-user" {
+		t.Errorf("user order should follow ask.json config order; got %+v", got[2:])
 	}
 }

--- a/workflows.go
+++ b/workflows.go
@@ -294,9 +294,9 @@ func broadcastWorkflowStatus(key, status string) {
 }
 
 // workflowDefByName looks up the named workflow under cwd's project,
-// searching repo scope first, then user (project-wins resolution).
-// Returns false when no match. Shared between the picker and the
-// runtime so the two can't drift on naming rules.
+// searching global first, then repo, then user (personal-wins
+// resolution). Returns false when no match. Shared between the picker
+// and the runtime so the two can't drift on naming rules.
 func workflowDefByName(cwd, name string) (workflowDef, bool) {
 	return findWorkflow(cwd, name, "")
 }

--- a/workflows_picker_test.go
+++ b/workflows_picker_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -158,5 +159,55 @@ func TestWorkflowPicker_StepsCountFormatting(t *testing.T) {
 		if got := stepsCount(n); got != want {
 			t.Errorf("stepsCount(%d): got %q want %q", n, got, want)
 		}
+	}
+}
+
+// TestWorkflowPicker_IncludesGlobals opens the picker with a merged
+// list that includes a global-scope def, navigates onto it, and
+// dispatches it through Enter → spawnWorkflowTabMsg. The row's meta
+// should show "global" (workflowScopeTag passes through the global
+// literal; the picker's renderer doesn't need to change).
+func TestWorkflowPicker_IncludesGlobals(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	items := []workflowDef{
+		{Name: "alpha", Scope: workflowScopeUser, Steps: []workflowStep{{Name: "s", Provider: "fake"}}},
+		{Name: "toolbox", Scope: workflowScopeGlobal, Steps: []workflowStep{{Name: "s", Provider: "fake"}}},
+	}
+	issue := issueRef{Provider: "github", Project: "ow/r", Number: 1}
+	source := issueWorkflowSource(issue)
+	m = m.openWorkflowPicker(items, source)
+
+	// Cursor at 0 (alpha); down once to land on toolbox.
+	m2, _ := m.updateWorkflowPicker(tea.KeyPressMsg{Code: tea.KeyDown})
+	mm := m2.(model)
+	if mm.workflowPicker.Cursor != 1 {
+		t.Fatalf("cursor: got %d want 1", mm.workflowPicker.Cursor)
+	}
+
+	// Render: meta row should show "global" (workflowScopeTag returns
+	// the global literal).
+	rendered := m.renderWorkflowPicker()
+	if !strings.Contains(rendered, "global") {
+		t.Errorf("picker should show 'global' tag for global-scope rows; rendered:\n%s", rendered)
+	}
+
+	// Enter dispatches a spawnWorkflowTabMsg for the global workflow.
+	final, cmd := mm.updateWorkflowPicker(tea.KeyPressMsg{Code: tea.KeyEnter})
+	mf := final.(model)
+	if mf.workflowPicker != nil {
+		t.Errorf("Enter should close the picker")
+	}
+	if cmd == nil {
+		t.Fatalf("Enter should produce a tea.Cmd")
+	}
+	spawn, ok := cmd().(spawnWorkflowTabMsg)
+	if !ok {
+		t.Fatalf("expected spawnWorkflowTabMsg, got %T", cmd())
+	}
+	if spawn.Workflow.Name != "toolbox" || spawn.Workflow.Scope != workflowScopeGlobal {
+		t.Errorf("dispatched wrong: %+v", spawn.Workflow)
+	}
+	if spawn.Source.Kind != workflowSourceIssue || spawn.Source.Issue != issue {
+		t.Errorf("dispatched source wrong: %+v", spawn.Source)
 	}
 }

--- a/workflows_screen.go
+++ b/workflows_screen.go
@@ -363,11 +363,12 @@ func (b *workflowsBuilderState) focusStepRow(topIdx, innerIdx int) {
 
 // commitItems writes b.items back to disk and re-hydrates so any
 // normalisation the persistence layer applies is reflected locally.
-// b.items is the merged two-scope list; saveAllWorkflows routes each
-// def by its Scope tag (user → ask.json, repo → .ask/workflows/) and
-// serialises under the config lock so a concurrent workflow tracker
-// disk upsert or MCP workflow_edit call can't race the load → mutate
-// → save cycle and lose either side's update.
+// b.items is the merged three-scope list; saveAllWorkflows routes
+// each def by its Scope tag (user → ask.json, repo →
+// .ask/workflows/, global → ~/.config/ask/workflows/) and serialises
+// under the config lock so a concurrent workflow tracker disk
+// upsert or MCP workflow_edit call can't race the load → mutate →
+// save cycle and lose either side's update.
 func (b *workflowsBuilderState) commitItems() error {
 	if err := saveAllWorkflows(b.cwd, b.items); err != nil {
 		return err
@@ -376,10 +377,20 @@ func (b *workflowsBuilderState) commitItems() error {
 	return nil
 }
 
-// otherWorkflowScope is the copy/move target for a def: the scope it
-// is NOT currently in.
-func otherWorkflowScope(scope string) string {
-	if workflowScopeTag(scope) == workflowScopeRepo {
+// nextWorkflowScope is the destination for a copy / move: it
+// rotates user → repo → global → user so a single key (c or s)
+// steps through every scope. The first press from user still moves
+// to repo (the pre-global cycle's first hop); pressing once more
+// reaches global; a third press wraps back to user. The toast
+// always names the destination so the user never silently promotes
+// something to global.
+func nextWorkflowScope(scope string) string {
+	switch workflowScopeTag(scope) {
+	case workflowScopeUser:
+		return workflowScopeRepo
+	case workflowScopeRepo:
+		return workflowScopeGlobal
+	case workflowScopeGlobal:
 		return workflowScopeUser
 	}
 	return workflowScopeRepo
@@ -416,16 +427,18 @@ func (b *workflowsBuilderState) focusWorkflow(name, scope string) {
 }
 
 // copySelectedToOtherScope duplicates the workflow under the cursor
-// into the opposite scope. The copy keeps its name when the target
-// scope is free, else gets a -2/-3… suffix (the naming-conflict
-// rule). The source is untouched, so no running guard applies.
+// into the next scope (user → repo → global → user — the same 3-way
+// cycle nextWorkflowScope uses). The copy keeps its name when the
+// target scope is free, else gets a -2/-3… suffix (the
+// naming-conflict rule). The source is untouched, so no running
+// guard applies.
 func (b *workflowsBuilderState) copySelectedToOtherScope() {
 	wIdx, ok := b.selectedWorkflowIdx()
 	if !ok {
 		return
 	}
 	src := b.items[wIdx]
-	target := otherWorkflowScope(src.Scope)
+	target := nextWorkflowScope(src.Scope)
 	dup := src
 	dup.Scope = target
 	dup.Name = b.uniqueNameInScope(src.Name, target)
@@ -440,17 +453,17 @@ func (b *workflowsBuilderState) copySelectedToOtherScope() {
 }
 
 // moveSelectedToOtherScope relocates the workflow under the cursor to
-// the opposite scope (user ⇄ repo), renaming with a suffix when the
-// target scope already holds the name. Guarded against running
-// workflows like rename/delete — the tracker keys on name and a
-// mid-run identity change could strand it.
+// the next scope (user → repo → global → user), renaming with a
+// suffix when the target scope already holds the name. Guarded
+// against running workflows like rename/delete — the tracker keys on
+// name and a mid-run identity change could strand it.
 func (b *workflowsBuilderState) moveSelectedToOtherScope() {
 	wIdx, ok := b.selectedWorkflowIdx()
 	if !ok {
 		return
 	}
 	src := b.items[wIdx]
-	target := otherWorkflowScope(src.Scope)
+	target := nextWorkflowScope(src.Scope)
 	name := b.uniqueNameInScope(src.Name, target)
 	b.items[wIdx].Scope = target
 	b.items[wIdx].Name = name
@@ -1363,7 +1376,7 @@ func (b *workflowsBuilderState) renderBase(width, height int) string {
 // narrow pane.
 func (b *workflowsBuilderState) activeHint() string {
 	if b.focus == workflowsBuilderFocusLeft {
-		return "↑/↓ navigate · enter open · r rename · e description · c copy to other scope · s move scope · d delete · esc back"
+		return "↑/↓ navigate · enter open · r rename · e description · c copy · s move (rotates user→repo→global) · d delete · esc back"
 	}
 	switch b.rightMode {
 	case workflowsBuilderRightSteps:
@@ -1376,9 +1389,9 @@ func (b *workflowsBuilderState) activeHint() string {
 
 // renderLeftPane draws the workflow list. "+ New workflow" is row 0
 // so the create affordance is always discoverable at the top. Each
-// workflow row carries a right-aligned scope tag (repo/user) so the
-// user always sees where a workflow is saved; step counts moved to
-// the right pane's subtitle so the left pane stays narrow.
+// workflow row carries a right-aligned scope tag (user/repo/global)
+// so the user always sees where a workflow is saved; step counts
+// moved to the right pane's subtitle so the left pane stays narrow.
 func (b *workflowsBuilderState) renderLeftPane(width, height int) string {
 	innerW := workflowsPaneInnerWidth(width)
 	rows := []string{
@@ -1738,9 +1751,10 @@ func renderWorkflowsListRow(label string, width int, selected, activePane bool) 
 }
 
 // renderWorkflowsListRowTagged renders a workflow row with a
-// right-aligned scope tag (repo/user). Selected rows style the whole
-// line so the tag stays legible inside the selection background;
-// unselected rows dim the tag to keep the name as the focal point.
+// right-aligned scope tag (user/repo/global). Selected rows style
+// the whole line so the tag stays legible inside the selection
+// background; unselected rows dim the tag to keep the name as the
+// focal point.
 func renderWorkflowsListRowTagged(name, tag string, width int, selected, activePane bool) string {
 	tagW := lipgloss.Width(tag)
 	nameW := width - tagW - 1

--- a/workflows_screen_test.go
+++ b/workflows_screen_test.go
@@ -735,9 +735,11 @@ func TestWorkflowsBuilder_CopyToRepoScope(t *testing.T) {
 	}
 }
 
-// TestWorkflowsBuilder_MoveScopeRoundTrip presses `s` twice: user →
-// repo (ask.json entry gone, file present) then repo → user (file
-// gone, ask.json entry back).
+// TestWorkflowsBuilder_MoveScopeRoundTrip presses `s` three times: user
+// → repo (ask.json entry gone, .ask/workflows/wf.json present) →
+// global (repo file gone, ~/.config/ask/workflows/wf.json present) →
+// user (global file gone, ask.json entry back). Pins the 3-way cycle
+// through the builder.
 func TestWorkflowsBuilder_MoveScopeRoundTrip(t *testing.T) {
 	m, cwd := seedWorkflowsBuilder(t, []workflowDef{{
 		Name:  "wf",
@@ -745,26 +747,43 @@ func TestWorkflowsBuilder_MoveScopeRoundTrip(t *testing.T) {
 	}})
 	m.workflowsBuilder.focus = workflowsBuilderFocusLeft
 
+	// 1st press: user → repo.
 	m1, _, _ := workflowsScreen{}.updateKey(m, tea.KeyPressMsg{Code: 's'})
 	if _, ok := findWorkflow(cwd, "wf", workflowScopeRepo); !ok {
-		t.Fatal("workflow should be repo-scope after move")
+		t.Fatal("workflow should be repo-scope after 1st move")
 	}
 	if _, ok := findWorkflow(cwd, "wf", workflowScopeUser); ok {
 		t.Fatal("user copy must not survive a move")
 	}
 	if _, err := os.Stat(filepath.Join(cwd, ".ask", "workflows", "wf.json")); err != nil {
-		t.Fatalf("repo file missing after move: %v", err)
+		t.Fatalf("repo file missing after 1st move: %v", err)
 	}
 
-	// Cursor followed the moved item; move it back.
+	// 2nd press: repo → global.
 	m2, _, _ := workflowsScreen{}.updateKey(m1, tea.KeyPressMsg{Code: 's'})
-	if _, ok := findWorkflow(cwd, "wf", workflowScopeUser); !ok {
-		t.Fatal("workflow should be user-scope after moving back")
+	if _, ok := findWorkflow(cwd, "wf", workflowScopeGlobal); !ok {
+		t.Fatal("workflow should be global-scope after 2nd move")
+	}
+	globalDir := filepath.Join(os.Getenv("HOME"), ".config", "ask", "workflows")
+	if _, err := os.Stat(filepath.Join(globalDir, "wf.json")); err != nil {
+		t.Fatalf("global file missing after 2nd move: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(cwd, ".ask", "workflows", "wf.json")); !os.IsNotExist(err) {
-		t.Error("repo file must be gone after moving back")
+		t.Error("repo file must be gone after 2nd move")
 	}
-	_ = m2
+
+	// 3rd press: global → user (full cycle).
+	m3, _, _ := workflowsScreen{}.updateKey(m2, tea.KeyPressMsg{Code: 's'})
+	if _, ok := findWorkflow(cwd, "wf", workflowScopeUser); !ok {
+		t.Fatal("workflow should be user-scope after moving back through global")
+	}
+	if _, err := os.Stat(filepath.Join(globalDir, "wf.json")); !os.IsNotExist(err) {
+		t.Error("global file must be gone after 3rd move")
+	}
+	if _, err := os.Stat(filepath.Join(cwd, ".ask", "workflows", "wf.json")); !os.IsNotExist(err) {
+		t.Error("repo file must be gone after 3rd move")
+	}
+	_ = m3
 }
 
 // TestWorkflowsBuilder_MoveScopeConflictRenames seeds the same name in
@@ -814,6 +833,136 @@ func TestWorkflowsBuilder_MoveScopeBlockedWhileRunning(t *testing.T) {
 	}
 	if _, ok := findWorkflow(cwd, "busy", workflowScopeUser); !ok {
 		t.Error("guarded move must not relocate the workflow")
+	}
+}
+
+// TestWorkflowsBuilder_CopyCycleHitsGlobal exercises the 3-way copy
+// cycle: pressing `c` from a user-scope workflow reaches a global
+// copy on the second press. Cursor follows each new copy, so the
+// next press uses the cycle step from that scope.
+func TestWorkflowsBuilder_CopyCycleHitsGlobal(t *testing.T) {
+	m, cwd := seedWorkflowsBuilder(t, []workflowDef{{
+		Name:  "review",
+		Steps: []workflowStep{{Name: "s", Provider: "fake", Prompt: "go"}},
+	}})
+	m.workflowsBuilder.focus = workflowsBuilderFocusLeft
+	m.workflowsBuilder.listCursor = 1
+
+	// 1st press: cursor on user "review" → nextWorkflowScope(user) = repo.
+	m1, _, _ := workflowsScreen{}.updateKey(m, tea.KeyPressMsg{Code: 'c'})
+	b1 := m1.workflowsBuilder
+	if _, err := os.Stat(filepath.Join(cwd, ".ask", "workflows", "review.json")); err != nil {
+		t.Fatalf("repo copy missing after 1st press: %v", err)
+	}
+	if !strings.Contains(b1.toast, "repo") {
+		t.Errorf("1st press toast should name 'repo'; got %q", b1.toast)
+	}
+	// Cursor followed the new copy; it should now be on the repo row.
+	wIdx, ok := b1.selectedWorkflowIdx()
+	if !ok || b1.items[wIdx].Scope != workflowScopeRepo {
+		t.Errorf("cursor should land on the new repo copy; got %+v", b1.items)
+	}
+
+	// 2nd press: cursor on repo "review" → nextWorkflowScope(repo) = global.
+	m2, _, _ := workflowsScreen{}.updateKey(m1, tea.KeyPressMsg{Code: 'c'})
+	b2 := m2.workflowsBuilder
+	globalDir := filepath.Join(os.Getenv("HOME"), ".config", "ask", "workflows")
+	if _, err := os.Stat(filepath.Join(globalDir, "review.json")); err != nil {
+		t.Fatalf("global copy missing after 2nd press: %v", err)
+	}
+	if !strings.Contains(b2.toast, "global") {
+		t.Errorf("2nd press toast should name 'global'; got %q", b2.toast)
+	}
+	wIdx, ok = b2.selectedWorkflowIdx()
+	if !ok || b2.items[wIdx].Scope != workflowScopeGlobal {
+		t.Errorf("cursor should land on the new global copy; got %+v", b2.items)
+	}
+	// Source user copy must still exist (a copy doesn't move).
+	if _, ok := findWorkflow(cwd, "review", workflowScopeUser); !ok {
+		t.Error("user source must survive a copy")
+	}
+}
+
+// TestWorkflowsBuilder_MoveToGlobalBlockedWhileRunning mirrors
+// TestWorkflowsBuilder_MoveScopeBlockedWhileRunning for the global
+// move: a workflow currently running cannot be moved into the global
+// dir. The tracker keys on name, and a global move relocates the
+// on-disk file, so the same guard applies.
+func TestWorkflowsBuilder_MoveToGlobalBlockedWhileRunning(t *testing.T) {
+	m, cwd := seedWorkflowsBuilder(t, []workflowDef{{Name: "busy", Scope: workflowScopeRepo}})
+	workflowTracker().markWorking(cwd, "k", "busy", 1)
+	t.Cleanup(resetWorkflowTrackerForTest)
+	m.workflowsBuilder.focus = workflowsBuilderFocusLeft
+	// Refresh items so the builder sees the repo-scope seed.
+	m.workflowsBuilder.refreshItems()
+	for i, w := range m.workflowsBuilder.items {
+		if w.Name == "busy" {
+			m.workflowsBuilder.listCursor = i + 1
+		}
+	}
+	m1, _, _ := workflowsScreen{}.updateKey(m, tea.KeyPressMsg{Code: 's'})
+	b := m1.workflowsBuilder
+	if !strings.Contains(b.toast, "running") {
+		t.Errorf("move to global on a running workflow should toast the guard; got %q", b.toast)
+	}
+	if _, ok := findWorkflow(cwd, "busy", workflowScopeGlobal); ok {
+		t.Error("guarded move must not relocate the workflow to global")
+	}
+}
+
+// TestWorkflowsBuilder_MoveScopeConflict_Global mirrors
+// TestWorkflowsBuilder_MoveScopeConflictRenames for the global dir:
+// the same auto-suffix pattern fires when the destination already
+// holds the name. Pressing `s` from user goes user → repo (1st) →
+// global (2nd); the 2nd press collides on the global copy and
+// auto-suffixes.
+func TestWorkflowsBuilder_MoveScopeConflict_Global(t *testing.T) {
+	m, cwd := seedWorkflowsBuilder(t, []workflowDef{{Name: "shared"}})
+	if err := saveAllWorkflows(cwd, append(projectWorkflows(cwd),
+		workflowDef{Name: "shared", Scope: workflowScopeGlobal, Steps: []workflowStep{{Name: "g", Provider: "fake"}}},
+	)); err != nil {
+		t.Fatal(err)
+	}
+	m.workflowsBuilder.refreshItems()
+	m.workflowsBuilder.focus = workflowsBuilderFocusLeft
+	// Cursor on the user "shared" row (row 2 since the global one
+	// comes first under global-first listing).
+	for i, w := range m.workflowsBuilder.items {
+		if w.Name == "shared" && w.Scope == workflowScopeUser {
+			m.workflowsBuilder.listCursor = i + 1
+		}
+	}
+
+	// 1st press: user → repo. The repo scope is empty, so the name
+	// "shared" doesn't collide and the move lands cleanly.
+	m1, _, _ := workflowsScreen{}.updateKey(m, tea.KeyPressMsg{Code: 's'})
+	b := m1.workflowsBuilder
+	if !strings.Contains(b.toast, "repo") {
+		t.Errorf("1st press should move user→repo; toast=%q", b.toast)
+	}
+	// Cursor should follow the moved item to repo.
+	wIdx, ok := b.selectedWorkflowIdx()
+	if !ok || b.items[wIdx].Scope != workflowScopeRepo {
+		t.Errorf("cursor should land on the repo copy; got %+v", b.items)
+	}
+
+	// 2nd press: repo → global. The global scope already has
+	// "shared", so the move auto-suffixes to "shared-2".
+	m2, _, _ := workflowsScreen{}.updateKey(m1, tea.KeyPressMsg{Code: 's'})
+	b = m2.workflowsBuilder
+	moved, ok := findWorkflow(cwd, "shared-2", workflowScopeGlobal)
+	if !ok {
+		t.Fatalf("moved workflow should be auto-suffixed; items: %+v", projectWorkflows(cwd))
+	}
+	if moved.Steps != nil {
+		t.Errorf("auto-suffixed global move should carry the user def (no steps); got %+v", moved.Steps)
+	}
+	original, ok := findWorkflow(cwd, "shared", workflowScopeGlobal)
+	if !ok || len(original.Steps) != 1 {
+		t.Errorf("pre-existing global workflow must be untouched: %+v", original)
+	}
+	if !strings.Contains(b.toast, "shared-2") {
+		t.Errorf("toast should mention the new name; got %q", b.toast)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a third workflow scope, `global`, alongside the existing `user` and `repo` scopes. Globals are machine-local workflows that show up in every project — a personal toolbox that follows the user between checkout roots without needing to duplicate per-project.

- **Storage**: `~/.config/ask/workflows/<name>.json`, one file per workflow with the same JSON shape as a repo file. `Scope` is `json:"-"` so on-disk bytes are byte-identical to a repo file; the storage location IS the scope. The dir is created lazily on first write and removed when it empties out, matching `syncRepoWorkflowFiles` tidy behaviour.
- **Scope enum**: `workflowScopeGlobal = "global"` added. `normalizeWorkflowScope` accepts it; `workflowScopeTag` returns the literal "global".
- **List order**: `listAllWorkflows` returns global → repo → user. Globals lead the list (most personal/explicit, most discoverable). Name-only resolution prefers global over repo over user (personal-wins). `resolveWorkflowByName` still errors on multi-scope ambiguity unless the caller passes an explicit `scope`; error message updated from "in both scopes" to "in multiple scopes".
- **Builder cycle**: `otherWorkflowScope` → `nextWorkflowScope` with a 3-way rotation (user → repo → global → user). The first press from user still moves to repo. The toast always names the destination scope. The active-hint string mentions the rotation.
- **Wire surface** (`mcp_workflows.go`): all 7 scope-field JSON-schema doc strings + all 5 tool descriptions (`workflow_list`, `workflow_get`, `workflow_create`, `workflow_copy`, `workflow_run`) mention `'global'` as a third option and explain what it means. No shape changes to the tools — they all go through `normalizeWorkflowScope` / `resolveWorkflowByName` / `findWorkflow` / `saveAllWorkflows`, which pick up the new scope automatically.
- **Docs**: `CLAUDE.md` and `AGENTS.md` (symlink) updated to describe three scopes and the storage location for global.

## Motivation

Today a workflow is either project-local (user scope, `projectConfig.Workflows.Items` in `~/.config/ask/ask.json`) or project-shared (repo scope, one file per workflow under `<projectRoot>/.ask/workflows/`). Neither covers the "I want this pipeline available in every project on this machine" case without forcing the user to copy the same workflow into each project's `user` scope by hand. Globals solve that — one source of truth on the local disk, visible from any project, without polluting the repo with a single-developer's personal toolbox.

The design also preserves the existing per-scope guarantees:

- Globals are strictly machine-local (no per-team or per-provider sharing).
- `Scope` stays `json:"-"` so on-disk bytes are byte-identical to a repo file — no migration needed for pre-scope workflows.
- The wire tool surface picks up the new scope for free because everything funnels through `normalizeWorkflowScope` / `saveAllWorkflows` / `listAllWorkflows`.

## Testing

**New tests:**

- `workflow_store_test.go`: `TestWorkflowStore_GlobalRoundTrip`, `TestLoadGlobalWorkflows_SkipsJunk`, `TestWorkflowStore_GlobalSyncRenamesAndDeletes`, `TestWorkflowStore_GlobalDir_NonHome`, `TestResolveWorkflowByName_Global`, `TestFindWorkflow_GlobalWins`, `TestCopyWorkflowDef_Global`, `TestListAllWorkflows_Order`.
- `workflows_screen_test.go`: `TestWorkflowsBuilder_CopyCycleHitsGlobal`, `TestWorkflowsBuilder_MoveScopeConflict_Global`, `TestWorkflowsBuilder_MoveToGlobalBlockedWhileRunning`. The existing `TestWorkflowsBuilder_MoveScopeRoundTrip` is updated for the 3-way cycle.
- `mcp_workflows_test.go`: `TestWorkflowListCore_GlobalIncluded`, `TestWorkflowCreateCore_GlobalScope`, `TestWorkflowEditCore_GlobalScope`, `TestWorkflowDeleteCore_GlobalScope`, `TestWorkflowCopyCore_GlobalTarget`, `TestWorkflowRunCore_GlobalScope`, `TestWorkflowCopyCore_AmbiguousAcrossAllThreeScopes`.
- `workflows_picker_test.go`: `TestWorkflowPicker_IncludesGlobals`.

**Updated tests:**

- `TestWorkflowTools_ScopedLifecycle` and `TestWorkflowEditCore_AmbiguousScope` — error message changed from "in both scopes" to "in multiple scopes".
- `TestWorkflowsBuilder_MoveScopeRoundTrip` — 3-scope cycle expectations.

**Verification performed:**

- `go build -o /tmp/ask-build-check ./...` — clean (the unrelated `ask/plans/` collision in the worktree is a `.gitignore`d bookkeeping dir).
- `go vet ./...` — clean.
- `go test ./...` — clean (29s, all packages pass).
- `go test -run 'Workflow|workflow' ./...` — clean (targeted suite).

The pre-existing `-race` detector failure in `TestAgentBackgroundJobs` is unrelated to workflow scopes (it exists on the unchanged tree) and not addressed here.

## Out of scope (intentionally not in this PR)

- A dedicated "Global workflows" screen / submenu. Globals live inside the existing builder; promoting is an `s`-press away.
- A new slash command or keymap action for global-only navigation. The existing `/workflows` and Ctrl+W cover it.
- Per-provider or per-team sharing of globals. Globals are strictly machine-local.
- Migration of existing user-scope workflows to global. The user can do this in the builder via the `s` cycle.
- Renaming the global dir to `~/.config/ask/global-workflows/`. The dir is `~/.config/ask/workflows/` — same basename as the project dir, different location, the location IS the scope.
