### PR TITLE
feat(providers): add Google AI Studio and Vertex AI providers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,8 @@ ALL OF THE ABOVE IS NOT OPTIONAL. YOU MUST ALWAYS USE THE ABOVE REFERENCES.
 
 `ask` is a Bubble Tea v2 TUI coding agent. The agent loop runs
 in-process on `charm.land/fantasy` against provider APIs (anthropic,
-openai, deepseek) — there are NO CLI subprocesses and NO loopback MCP
+openai, deepseek, kimi, minimax, googleai, vertex) — there are NO CLI
+subprocesses and NO loopback MCP
 server; every tool (coding core, linear/workflow bridge twins,
 question modal, external MCP clients) is native Go. The tool surface
 is two-tier: a small fixed CORE rides the wire tool definitions,
@@ -61,6 +62,9 @@ One `package main`, one file per concern.
 | `deepseek.go`          | DeepSeek spec: model/effort options, `$DEEPSEEK_API_KEY` resolution, effort→wire mapping (thinking off / reasoning_effort), images rejected. |
 | `anthropic.go`         | Anthropic spec: catwalk model list, effort→`output_config.effort` with catalog clamping, manual prompt-cache breakpoints (`anthropicPrepareStep`: system + last 2 messages; `anthropicDecorateTools`: last tool) — without these the API bills uncached every turn. |
 | `openai.go`            | OpenAI spec: Responses API (prefix predicate `openaiUseResponsesAPI` so new gpt-5.x/codex ids never fall back to chat completions), reasoning summaries + encrypted reasoning content (stateless resume), effort clamping. |
+| `googleai.go`         | Google AI Studio spec: API-key auth (`google.New(google.WithGeminiAPIKey)`), effort→`google.ThinkingLevel` (catalog-clamped), catwalk-driven Gemini model list. |
+| `vertex.go`           | Vertex AI spec: project + location + ADC auth (`google.New(google.WithVertex)`), filters Claude ids out of the catwalk model list, `vertexPrepareCredentials` env-mutation seam for the optional SA-key path. |
+| `config_vertex.go`    | `/config → Vertex AI...` sub-picker. Three free-text rows (Project, Location, Service Account Key path) with regex validation + `expandTilde` for the SA-key row. |
 | `catalog.go`           | catwalk embedded-catalog lookups: model ids (default first), context windows, image capability, effort-level clamping. No network — the snapshot ships with the module. |
 | `agent_run.go`         | The in-process agent runtime: session goroutine, fantasy agent loop ↔ provider-protocol msgs, per-spec PrepareStep, image file parts, interrupt, loop detection, auto-compaction, dangling-tool-call repair. `refreshToolset` splits the surface: core → wire tool definitions, bridge twins + MCP → the deferred registry; the live-emit callbacks unwrap `invoke_tool` so the transcript shows the real registry tool. |
 | `agent_prompt.go`      | Coder system prompt assembly: static head, env snapshot, CLAUDE.md/AGENTS.md inclusion, `askSteeringPrompt` tail. Byte-stable per session for DeepSeek's prefix cache. |
@@ -165,6 +169,9 @@ exercised by the user; code alone won't catch layout regressions.
 | `model_picker_test.go`     | Ctrl+M picker — open/seed (incl. busy gate), header-skipping nav + wrap, fuzzy filter (provider name + friendly name + id), apply semantics (cross-provider clears session, same-provider keeps, no SaveSettings, tab-local), recents (record/cap/dedupe/resurface incl. synthesized custom ids), API-key gate (prompt/save/esc/env-or-config skip), custom-id editor, paste routing, friendly-name + fuzzy helpers, `missingAPIKeyError`. |
 | `anthropic_test.go`        | Anthropic spec — metadata/registry, effort→wire incl. clamping, cache-breakpoint placement (`anthropicPrepareStep` marks system + last 2, strips stale, never mutates caller; `anthropicDecorateTools` marks last tool), native `web_search` provider tool, no-key fail-fast, lifecycle w/ image attachment → wire FilePart, persisted transcript free of cache markers, context windows. |
 | `openai_test.go`           | OpenAI spec — metadata/registry, Responses-API prefix predicate, encrypted-reasoning + summary options, effort mapping, native `web_search` provider tool, no-key fail-fast, lifecycle (images accepted), context windows. |
+| `googleai_test.go`         | Google AI Studio spec — metadata/registry, effort→`google.ThinkingLevel` incl. `catalogClampEffort` (Gemini 3.1 Pro rejects "minimal" → "low"), no-key fail-fast, full session lifecycle against `fakeLM`, Materialize, store root, max output tokens (catalog-driven), image support, `modelContextLimit`. |
+| `vertex_test.go`           | Vertex AI spec — metadata/registry (incl. Claude-filtered picker + no key-prompt), effort mapping, no-key fail-fast (no project), SA-key auth via `vertexPrepareCredentials` seam (path validation, env mutation, env fallback, ADC discovery), full session lifecycle, Materialize, store root, `vertexModelOptions_FiltersClaude`. |
+| `config_vertex_test.go`    | `/config → Vertex AI` picker — global row presence, project/location regex validation, SA-key tilde + readable-file validation, persistence, paste accumulation, invalid input keeps editor open, summary state ("off" / "<project>/global"). |
 | `catalog_test.go`          | catwalk lookups — model hit/miss, default-first id list, window/image fallbacks, effort clamping (down to nearest, up from below-range). |
 | `cost_test.go`             | Session cost meter — `stepCostUSD` catalog pricing math + unpriceable fallbacks, `formatUSD`, usageMsg/costMsg/tabTitleMsg accumulation + foreign-proc/tab gating, resets (/new, /clear, cross-provider swap keeps same-provider), task-tool sub-agent cost emission, sidebar cost row derivation. |
 | `util_test.go` / `paths_test.go` | Pure helpers, path completion, frontmatter parsing.       |
@@ -690,6 +697,32 @@ so gpt-5.x/codex/o-series ids always take the Responses API even when
 fantasy's exact-id list lags. Reasoning summaries on; encrypted
 reasoning content always requested (Store defaults false → stateless
 replay needs the blobs round-tripped in persisted messages).
+
+**Google AI Studio** rides fantasy's `google` provider via
+`google.New(google.WithGeminiAPIKey(key))`. Auth is the API key
+(`$GOOGLE_API_KEY` env or `cfg.GoogleAI.APIKey`). Effort maps to
+`google.ThinkingLevel` with `catalogClampEffort` de-grading a pick
+the chosen model doesn't support (Gemini 3.1 Pro rejects "minimal"
+→ "low", Gemini 2.5 Pro rejects everything). Default model
+`gemini-3.1-pro-preview-customtools`. Brave-backed core
+`web_search` (no native Google Search grounding in fantasy yet).
+
+**Vertex AI** rides the same `google` provider via
+`google.New(google.WithVertex(project, location))`. Auth uses
+Google Cloud ADC: explicit `cfg.Vertex.ServiceAccountKey` (or
+`$GOOGLE_APPLICATION_CREDENTIALS` env) → `gcloud auth
+application-default login` creds → GCE metadata. The
+`vertexPrepareCredentials` helper validates the SA-key path and
+calls `vertexApplyEnv` (swappable) to set the env so
+`credentials.DetectDefault` finds the bytes. Project is required
+(fail-fast at session start); Location defaults to `global`. The
+catwalk model list includes five Claude ids that fantasy
+transparently routes through `anthropic.WithVertex` — those are
+filtered out of `vertexModelOptions` because their reasoning
+enum ([low/medium/high/max]) is incompatible with Gemini's
+[minimal/low/medium/high]. Users wanting Claude-on-Vertex use the
+regular Anthropic provider. Same Brave-backed `web_search` as
+Google AI Studio. Default model `gemini-3.1-pro-preview`.
 
 Model metadata (context windows, image capability, reasoning levels)
 comes from `charm.land/catwalk`'s embedded catalog (catalog.go) with

--- a/config.go
+++ b/config.go
@@ -53,6 +53,8 @@ type askConfig struct {
 	Anthropic apiProviderConfig `json:"anthropic,omitempty"`
 	OpenAI    apiProviderConfig `json:"openai,omitempty"`
 	MiniMax   apiProviderConfig `json:"minimax,omitempty"`
+	GoogleAI  apiProviderConfig `json:"googleai,omitempty"`
+	Vertex    vertexConfig      `json:"vertex,omitempty"`
 	UI        uiConfig          `json:"ui,omitempty"`
 	Memory    memoryConfig      `json:"memory,omitempty"`
 	WebSearch webSearchConfig   `json:"webSearch,omitempty"`
@@ -614,6 +616,7 @@ const (
 	openaiEnvAPIKey    = "OPENAI_API_KEY"
 	braveEnvAPIKey     = "BRAVE_API_KEY"
 	minimaxEnvAPIKey   = "MINIMAX_API_KEY"
+	googleaiEnvAPIKey  = "GOOGLE_API_KEY"
 )
 
 // resolveAPIProviderKey returns the API key to use: an explicit config
@@ -645,6 +648,24 @@ func resolveOpenAIAPIKey(c apiProviderConfig) string {
 
 func resolveMiniMaxAPIKey(c apiProviderConfig) string {
 	return resolveAPIProviderKey(c, minimaxEnvAPIKey)
+}
+
+func resolveGoogleAIAPIKey(c apiProviderConfig) string {
+	return resolveAPIProviderKey(c, googleaiEnvAPIKey)
+}
+
+// vertexConfig holds the per-provider settings for the Vertex AI
+// backend. Vertex uses Google Cloud Application Default Credentials
+// (env-var SA key → gcloud login → GCE metadata) plus a project +
+// location, so it does NOT use apiProviderConfig — there's no API key
+// to store. The apiProviderConfig embed carries the model / effort /
+// slash-commands settings the spec's loadSettings/saveSettings
+// accessors need without duplicating JSON tags.
+type vertexConfig struct {
+	Project           string `json:"project,omitempty"`
+	Location          string `json:"location,omitempty"`
+	ServiceAccountKey string `json:"serviceAccountKey,omitempty"`
+	apiProviderConfig
 }
 
 // webSearchConfig holds the generic web-search settings. Today the only

--- a/config_modal.go
+++ b/config_modal.go
@@ -95,6 +95,7 @@ func (m model) globalConfigItems() []configItem {
 		{"Default Provider", provName, "provider"},
 		{"Memory...", mem, "memory"},
 		{"Web Search...", webSearch, "webSearch"},
+		{"Vertex AI...", vertexSummary(), "vertex"},
 		{"Keybindings...", "", "keybindings"},
 	}
 	return items
@@ -110,6 +111,22 @@ func (m model) refreshHistoryCmd() tea.Cmd {
 			ToolOutput:  m.toolOutputMode,
 			QuietMode:   m.quietMode,
 		}, true)
+}
+
+// vertexSummary reports the user-facing Vertex row key for the
+// /config menu: "off" when neither project nor location is set, a
+// "<project>/<location>" pair when both are. Mirrors the live-state
+// pattern used for memory ("on" vs "off (open failed)").
+func vertexSummary() string {
+	cfg, _ := loadConfig()
+	if cfg.Vertex.Project == "" {
+		return "off"
+	}
+	loc := vertexResolveLocation(cfg.Vertex)
+	if loc == vertexDefaultLocation {
+		return cfg.Vertex.Project + "/global"
+	}
+	return cfg.Vertex.Project + "/" + loc
 }
 
 func (m model) startConfigModal() model {
@@ -157,6 +174,9 @@ func (m model) updateConfigModal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 	if m.configWebSearchPickerActive {
 		return m.updateConfigWebSearchPicker(msg)
+	}
+	if m.configVertexPickerActive {
+		return m.updateConfigVertexPicker(msg)
 	}
 	if m.configKeybindingsPickerActive {
 		return m.updateConfigKeybindingsPicker(msg)
@@ -393,6 +413,9 @@ func (m model) handleGlobalConfigEnter(itemID string) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "webSearch":
 		m = m.openConfigWebSearchPicker()
+		return m, nil
+	case "vertex":
+		m = m.openConfigVertexPicker()
 		return m, nil
 	case "keybindings":
 		m = m.openConfigKeybindingsPicker()

--- a/config_vertex.go
+++ b/config_vertex.go
@@ -1,0 +1,305 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	lipgloss "charm.land/lipgloss/v2"
+)
+
+// vertexPickerRow is one row in the /config → Vertex AI submenu.
+// Three editable fields: project, location, and the optional
+// service-account key path. Echoes the typed value (no masking —
+// the SA key is a path on disk, not a secret).
+type vertexPickerRow struct {
+	name string
+	key  string
+	id   string
+}
+
+func (m model) vertexPickerItems() []vertexPickerRow {
+	cfg, _ := loadConfig()
+	rows := []vertexPickerRow{
+		{"Project", plainSummary(cfg.Vertex.Project), "project"},
+		{"Location", plainSummary(vertexResolveLocation(cfg.Vertex)), "location"},
+		{"Service Account Key", plainSummary(cfg.Vertex.ServiceAccountKey), "serviceAccountKey"},
+	}
+	return rows
+}
+
+// vertexFieldSpec describes one editable row in the picker — the
+// validation, load, and save logic. Centralised so the input
+// handler doesn't grow a switch per field.
+type vertexFieldSpec struct {
+	id       string
+	title    string
+	helpHint string
+	validate func(string) error
+	load     func(askConfig) string
+	save     func(*askConfig, string)
+}
+
+// vertexFieldSpecs is the registry, keyed by the row id. Order
+// doesn't matter; row order comes from vertexPickerItems.
+var vertexFieldSpecs = map[string]vertexFieldSpec{
+	"project": {
+		id:       "project",
+		title:    "Project",
+		helpHint: "Google Cloud project id; enter to save",
+		validate: validateVertexProject,
+		load:     func(c askConfig) string { return c.Vertex.Project },
+		save:     func(c *askConfig, v string) { c.Vertex.Project = v },
+	},
+	"location": {
+		id:       "location",
+		title:    "Location",
+		helpHint: "Vertex region (e.g. us-central1) or 'global'; enter to save",
+		validate: validateVertexLocation,
+		load:     func(c askConfig) string { return vertexResolveLocation(c.Vertex) },
+		save:     func(c *askConfig, v string) { c.Vertex.Location = v },
+	},
+	"serviceAccountKey": {
+		id:       "serviceAccountKey",
+		title:    "Service Account Key",
+		helpHint: "path to a service-account JSON; blank to use ADC; enter to save",
+		validate: validateVertexServiceAccountKey,
+		load:     func(c askConfig) string { return c.Vertex.ServiceAccountKey },
+		save:     func(c *askConfig, v string) { c.Vertex.ServiceAccountKey = v },
+	},
+}
+
+// validateVertexProject screens the picker input. GCP project ids
+// are 6-30 chars, lowercase letters / digits / hyphens, must start
+// with a letter. Empty is invalid (the picker would surface a
+// "project is required" error at session start — better to block
+// it here so the field visibly requires a value).
+func validateVertexProject(s string) error {
+	t := strings.TrimSpace(s)
+	if t == "" {
+		return errors.New("project is required")
+	}
+	if len(t) < 6 || len(t) > 30 {
+		return errors.New("project id must be 6-30 characters")
+	}
+	if !vertexProjectIDPattern.MatchString(t) {
+		return errors.New("project id must start with a lowercase letter and contain only lowercase letters, digits, or hyphens")
+	}
+	return nil
+}
+
+// vertexProjectIDPattern matches a valid GCP project id: starts
+// with a lowercase letter, followed by 5-29 lowercase letters,
+// digits, or hyphens.
+var vertexProjectIDPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{5,29}$`)
+
+// validateVertexLocation accepts either the literal "global" or a
+// region id matching the canonical GCP shape ([a-z]+-[a-z]+[0-9],
+// e.g. "us-central1", "europe-west4"). Empty is invalid.
+func validateVertexLocation(s string) error {
+	t := strings.TrimSpace(s)
+	if t == "" {
+		return errors.New("location is required")
+	}
+	if t == "global" {
+		return nil
+	}
+	if !vertexLocationPattern.MatchString(t) {
+		return errors.New("location must be 'global' or match shape like 'us-central1'")
+	}
+	return nil
+}
+
+var vertexLocationPattern = regexp.MustCompile(`^[a-z]+-[a-z]+[0-9]$`)
+
+// validateVertexServiceAccountKey accepts an empty string (clears
+// the field, falls back to ADC) or a path to a readable file. The
+// path is tilde-expanded so a user can paste `~/keys/vertex.json`.
+func validateVertexServiceAccountKey(s string) error {
+	t := strings.TrimSpace(s)
+	if t == "" {
+		return nil
+	}
+	expanded, _ := expandTilde(t)
+	info, err := os.Stat(expanded)
+	if err != nil {
+		return fmt.Errorf("cannot read %s: %w", expanded, err)
+	}
+	if info.IsDir() {
+		return errors.New("path is a directory, expected a JSON file")
+	}
+	return nil
+}
+
+func (m model) openConfigVertexPicker() model {
+	m.configVertexPickerActive = true
+	m.configVertexCursor = 0
+	m.configVertexFieldEditing = ""
+	m.configVertexFieldDraft = ""
+	return m
+}
+
+func (m model) closeConfigVertexPicker() model {
+	m.configVertexPickerActive = false
+	m.configVertexCursor = 0
+	m.configVertexFieldEditing = ""
+	m.configVertexFieldDraft = ""
+	return m
+}
+
+func (m model) openConfigVertexFieldEditor(id string) model {
+	if _, ok := vertexFieldSpecs[id]; !ok {
+		return m
+	}
+	cfg, _ := loadConfig()
+	m.configVertexFieldEditing = id
+	m.configVertexFieldDraft = vertexFieldSpecs[id].load(cfg)
+	return m
+}
+
+func (m model) closeConfigVertexFieldEditor() model {
+	m.configVertexFieldEditing = ""
+	m.configVertexFieldDraft = ""
+	return m
+}
+
+func (m model) updateConfigVertexPicker(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if m.configVertexFieldEditing != "" {
+		return m.updateConfigVertexFieldInput(msg)
+	}
+	rows := m.vertexPickerItems()
+	switch {
+	case msg.Mod == tea.ModCtrl && msg.Code == 'c', msg.Code == tea.KeyEsc:
+		m = m.closeConfigVertexPicker()
+		return m, nil
+	case listNavPrev(msg):
+		m.configVertexCursor = listNavWrap(m.configVertexCursor, -1, len(rows))
+		return m, nil
+	case listNavNext(msg):
+		m.configVertexCursor = listNavWrap(m.configVertexCursor, +1, len(rows))
+		return m, nil
+	case msg.Code == tea.KeyEnter:
+		if m.configVertexCursor < 0 || m.configVertexCursor >= len(rows) {
+			return m, nil
+		}
+		m = m.openConfigVertexFieldEditor(rows[m.configVertexCursor].id)
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m model) updateConfigVertexFieldInput(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch {
+	case msg.Mod == tea.ModCtrl && msg.Code == 'c', msg.Code == tea.KeyEsc:
+		m = m.closeConfigVertexFieldEditor()
+		return m, nil
+	case msg.Code == tea.KeyEnter:
+		return m.commitConfigVertexField()
+	case msg.Code == tea.KeyBackspace:
+		if r := []rune(m.configVertexFieldDraft); len(r) > 0 {
+			m.configVertexFieldDraft = string(r[:len(r)-1])
+		}
+		return m, nil
+	}
+	if configTextInputKey(msg) {
+		m.configVertexFieldDraft += msg.Text
+		return m, nil
+	}
+	return m, nil
+}
+
+// applyConfigVertexPaste appends pasted text to the field draft.
+// Called from the top-level update.go PasteMsg dispatcher.
+func (m model) applyConfigVertexPaste(text string) (tea.Model, tea.Cmd) {
+	m.configVertexFieldDraft += text
+	return m, nil
+}
+
+// commitConfigVertexField validates, persists, and closes the
+// inline editor. Validation failure keeps the editor open so the
+// user can correct without retyping; success emits a toast.
+func (m model) commitConfigVertexField() (tea.Model, tea.Cmd) {
+	id := m.configVertexFieldEditing
+	spec, ok := vertexFieldSpecs[id]
+	if !ok {
+		m = m.closeConfigVertexFieldEditor()
+		return m, nil
+	}
+	draft := strings.TrimSpace(m.configVertexFieldDraft)
+	if spec.validate != nil {
+		if err := spec.validate(draft); err != nil {
+			return m, m.toast.show("vertex: "+spec.title+": "+err.Error())
+		}
+	}
+	if err := withConfigLock(func() error {
+		cfg, _ := loadConfig()
+		spec.save(&cfg, draft)
+		return saveConfig(cfg)
+	}); err != nil {
+		debugLog("vertex %s saveConfig: %v", id, err)
+		m = m.closeConfigVertexFieldEditor()
+		return m, m.toast.show("vertex: save: "+err.Error())
+	}
+	m = m.closeConfigVertexFieldEditor()
+	if draft == "" {
+		return m, m.toast.show("vertex: " + spec.title + " cleared")
+	}
+	return m, m.toast.show("vertex: " + spec.title + " saved")
+}
+
+func (m model) viewConfigVertexPicker() string {
+	if m.configVertexFieldEditing != "" {
+		return m.viewConfigVertexFieldInput()
+	}
+	rows := m.vertexPickerItems()
+	innerW := 0
+	for _, r := range rows {
+		w := lipgloss.Width(r.name) + lipgloss.Width(r.key) + 4
+		if w > innerW {
+			innerW = w
+		}
+	}
+	if innerW < 40 {
+		innerW = 40
+	}
+	title := themePickerTitleStyle.Render("Vertex AI")
+	body := make([]string, 0, len(rows)+4)
+	body = append(body, title, "")
+	for i, r := range rows {
+		body = append(body, renderMemoryPickerRow(memoryPickerRow(r), innerW, i == m.configVertexCursor))
+	}
+	body = append(body,
+		"",
+		configHelpStyle.Render("Project + Location are required. Service Account Key is optional; blank falls back to ADC."),
+		"",
+		themePickerHelpStyle.Render("enter edit · esc close"),
+	)
+	return themePickerBoxStyle.Render(strings.Join(body, "\n"))
+}
+
+func (m model) viewConfigVertexFieldInput() string {
+	spec, ok := vertexFieldSpecs[m.configVertexFieldEditing]
+	if !ok {
+		return ""
+	}
+	innerW := 60
+	title := themePickerTitleStyle.Render(spec.title)
+	body := []string{
+		title,
+		"",
+		configHelpStyle.Render(spec.helpHint),
+		"",
+		configPromptStyle.Render("> ") + m.configVertexFieldDraft + configCaretStyle.Render("▏"),
+		"",
+		themePickerHelpStyle.Render("enter save · esc cancel"),
+	}
+	for _, line := range body {
+		if w := lipgloss.Width(line); w > innerW {
+			innerW = w
+		}
+	}
+	return themePickerBoxStyle.Render(strings.Join(body, "\n"))
+}

--- a/config_vertex_test.go
+++ b/config_vertex_test.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// TestConfigVertexPicker covers the /config → Vertex AI submenu:
+// opening it, entering the editor for each of the three fields,
+// validation failures, persistence to disk, paste accumulation, and
+// Esc / Ctrl+C close.
+func TestConfigVertexPicker(t *testing.T) {
+	isolateHome(t)
+	m := newTestModel(t, newFakeProvider())
+	m.toast = NewToastModel(40, 0)
+
+	// The global config list must surface the Vertex row.
+	var hasRow bool
+	for _, it := range m.globalConfigItems() {
+		if it.id == "vertex" {
+			hasRow = true
+		}
+	}
+	if !hasRow {
+		t.Fatal("globalConfigItems missing the Vertex row")
+	}
+
+	// Unconfigured summary is "off".
+	if got := vertexSummary(); got != "off" {
+		t.Errorf("unconfigured summary = %q want off", got)
+	}
+
+	m = m.openConfigVertexPicker()
+	if !m.configVertexPickerActive || m.configVertexFieldEditing != "" {
+		t.Fatalf("open: active=%v editing=%v", m.configVertexPickerActive, m.configVertexFieldEditing)
+	}
+
+	// Three rows; first is "project".
+	rows := m.vertexPickerItems()
+	if len(rows) != 3 {
+		t.Fatalf("rows=%d want 3", len(rows))
+	}
+	if rows[0].id != "project" || rows[1].id != "location" || rows[2].id != "serviceAccountKey" {
+		t.Errorf("row order wrong: %+v", rows)
+	}
+
+	// Enter on Project row opens the inline editor.
+	mm, _ := m.updateConfigVertexPicker(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = mm.(model)
+	if m.configVertexFieldEditing != "project" {
+		t.Fatalf("Enter on project row should open the editor, got editing=%q", m.configVertexFieldEditing)
+	}
+
+	// Editor pre-fills with the on-disk value (empty here).
+	if m.configVertexFieldDraft != "" {
+		t.Errorf("editor draft should start empty, got %q", m.configVertexFieldDraft)
+	}
+
+	// Type a valid project id.
+	mm, _ = m.updateConfigVertexFieldInput(tea.KeyPressMsg{Code: 'm', Text: "m"})
+	m = mm.(model)
+	mm, _ = m.updateConfigVertexFieldInput(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	m = mm.(model)
+	mm, _ = m.applyConfigVertexPaste("-proj")
+	m = mm.(model)
+	if m.configVertexFieldDraft != "my-proj" {
+		t.Fatalf("draft = %q, want my-proj", m.configVertexFieldDraft)
+	}
+
+	// Enter commits and closes the editor; value lands on disk.
+	mm, _ = m.updateConfigVertexFieldInput(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = mm.(model)
+	if m.configVertexFieldEditing != "" {
+		t.Error("commit should close the editor")
+	}
+	cfg, _ := loadConfig()
+	if cfg.Vertex.Project != "my-proj" {
+		t.Fatalf("persisted project = %q, want my-proj", cfg.Vertex.Project)
+	}
+
+	// Row summary now reflects the saved value.
+	rows = m.vertexPickerItems()
+	if rows[0].key != "my-proj" {
+		t.Errorf("project row key = %q, want my-proj", rows[0].key)
+	}
+
+	// Vertex summary now mentions the project.
+	if got := vertexSummary(); got != "my-proj/global" {
+		t.Errorf("configured summary = %q want my-proj/global", got)
+	}
+}
+
+func TestConfigVertexPicker_LocationValidation(t *testing.T) {
+	isolateHome(t)
+	if err := withConfigLock(func() error {
+		cfg, _ := loadConfig()
+		cfg.Vertex.Project = "my-proj"
+		return saveConfig(cfg)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Valid: "global".
+	if err := validateVertexLocation("global"); err != nil {
+		t.Errorf("global must validate: %v", err)
+	}
+	// Valid: "us-central1".
+	if err := validateVertexLocation("us-central1"); err != nil {
+		t.Errorf("us-central1 must validate: %v", err)
+	}
+	// Invalid: empty.
+	if err := validateVertexLocation(""); err == nil {
+		t.Error("empty location must fail")
+	}
+	// Invalid: weird shape.
+	if err := validateVertexLocation("blah"); err == nil {
+		t.Error("non-shape location must fail")
+	}
+
+	// Drive the picker: invalid draft → toast + editor stays open.
+	m := newTestModel(t, newFakeProvider())
+	m.toast = NewToastModel(40, 0)
+	m = m.openConfigVertexPicker()
+	// Cursor down to Location.
+	mm, _ := m.updateConfigVertexPicker(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = mm.(model)
+	// Open the location editor.
+	mm, _ = m.updateConfigVertexPicker(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = mm.(model)
+	if m.configVertexFieldEditing != "location" {
+		t.Fatalf("expected location editor, got %q", m.configVertexFieldEditing)
+	}
+	// Type an invalid value.
+	for _, r := range "blah" {
+		mm, _ = m.updateConfigVertexFieldInput(tea.KeyPressMsg{Code: r, Text: string(r)})
+		m = mm.(model)
+	}
+	mm, _ = m.updateConfigVertexFieldInput(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = mm.(model)
+	// Editor stays open on validation failure.
+	if m.configVertexFieldEditing != "location" {
+		t.Error("invalid location should keep the editor open")
+	}
+	cfg, _ := loadConfig()
+	if cfg.Vertex.Location != "" {
+		t.Errorf("invalid location must not be persisted, got %q", cfg.Vertex.Location)
+	}
+}
+
+func TestConfigVertexPicker_ServiceAccountKeyValidation(t *testing.T) {
+	isolateHome(t)
+
+	// Valid: empty (clears the field).
+	if err := validateVertexServiceAccountKey(""); err != nil {
+		t.Errorf("empty SA key must validate: %v", err)
+	}
+
+	// Valid: a path to a real file.
+	dir := t.TempDir()
+	realPath := filepath.Join(dir, "sa.json")
+	if err := os.WriteFile(realPath, []byte(`{"type":"service_account"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateVertexServiceAccountKey(realPath); err != nil {
+		t.Errorf("real SA key path must validate: %v", err)
+	}
+
+	// Valid: tilde expansion.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	tildeDir := filepath.Join(home, "keys")
+	if err := os.MkdirAll(tildeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tildePath := filepath.Join(tildeDir, "sa.json")
+	if err := os.WriteFile(tildePath, []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateVertexServiceAccountKey("~/keys/sa.json"); err != nil {
+		t.Errorf("tilde-expanded SA key must validate: %v", err)
+	}
+
+	// Invalid: non-existent file.
+	if err := validateVertexServiceAccountKey("/nonexistent/path/sa.json"); err == nil {
+		t.Error("non-existent SA key must fail validation")
+	}
+
+	// Invalid: a directory.
+	if err := validateVertexServiceAccountKey(dir); err == nil {
+		t.Errorf("directory must fail SA key validation, got nil")
+	}
+}
+
+func TestConfigVertexPicker_ServiceAccountKeyPersists(t *testing.T) {
+	isolateHome(t)
+	dir := t.TempDir()
+	saPath := filepath.Join(dir, "sa.json")
+	if err := os.WriteFile(saPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newTestModel(t, newFakeProvider())
+	m.toast = NewToastModel(40, 0)
+	if err := withConfigLock(func() error {
+		cfg, _ := loadConfig()
+		cfg.Vertex.Project = "my-proj"
+		return saveConfig(cfg)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	m = m.openConfigVertexPicker()
+	// Cursor to SA key row (3rd).
+	mm, _ := m.updateConfigVertexPicker(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = mm.(model)
+	mm, _ = m.updateConfigVertexPicker(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = mm.(model)
+	mm, _ = m.updateConfigVertexPicker(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = mm.(model)
+	if m.configVertexFieldEditing != "serviceAccountKey" {
+		t.Fatalf("expected SA key editor, got %q", m.configVertexFieldEditing)
+	}
+	// Type + paste.
+	for _, r := range saPath {
+		mm, _ = m.updateConfigVertexFieldInput(tea.KeyPressMsg{Code: r, Text: string(r)})
+		m = mm.(model)
+	}
+	mm, _ = m.updateConfigVertexFieldInput(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = mm.(model)
+	cfg, _ := loadConfig()
+	if cfg.Vertex.ServiceAccountKey != saPath {
+		t.Errorf("persisted SA key = %q, want %q", cfg.Vertex.ServiceAccountKey, saPath)
+	}
+}
+
+func TestConfigVertexPicker_ProjectValidation(t *testing.T) {
+	// Valid: 6-30 lowercase chars starting with a letter.
+	for _, p := range []string{"myproj", "my-proj", "abc123", "a12345"} {
+		if err := validateVertexProject(p); err != nil {
+			t.Errorf("%q must validate: %v", p, err)
+		}
+	}
+	// Invalid: empty / too short / too long / uppercase / starts with digit.
+	for _, p := range []string{"", "abc", "ABCdef", "1abcde", "a-very-long-project-name-that-is-too-long"} {
+		if err := validateVertexProject(p); err == nil {
+			t.Errorf("%q must fail validation", p)
+		}
+	}
+}
+
+func TestConfigVertexPicker_EscClose(t *testing.T) {
+	isolateHome(t)
+	m := newTestModel(t, newFakeProvider())
+	m = m.openConfigVertexPicker()
+	mm, _ := m.updateConfigVertexPicker(tea.KeyPressMsg{Code: tea.KeyEsc})
+	m = mm.(model)
+	if m.configVertexPickerActive {
+		t.Error("Esc should close the Vertex picker")
+	}
+}

--- a/googleai.go
+++ b/googleai.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"strings"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"charm.land/fantasy"
+	"charm.land/fantasy/providers/google"
+)
+
+const (
+	googleaiProviderID              = "googleai"
+	googleaiDefaultModel            = "gemini-3.1-pro-preview-customtools"
+	googleaiContextWindow           = 1_048_576
+	googleaiFallbackMaxOutputTokens = 32_000
+)
+
+// googleaiEffortOptions is the picker surface for reasoning effort.
+// catalogClampEffort degrades a pick the chosen model doesn't offer
+// (e.g. "minimal" on a gemini-3.1-pro — which only supports
+// [low, medium, high] — drops to "low").
+var googleaiEffortOptions = []string{"minimal", "low", "medium", "high"}
+
+// googleaiLanguageModel builds the fantasy LanguageModel for one
+// session. Swappable in tests so StartSession can run against a fake
+// model with zero network.
+var googleaiLanguageModel = func(cfg apiProviderConfig, modelID string) (fantasy.LanguageModel, error) {
+	key := resolveGoogleAIAPIKey(cfg)
+	if key == "" {
+		return nil, missingAPIKeyError(googleaiEnvAPIKey)
+	}
+	provider, err := google.New(google.WithGeminiAPIKey(key))
+	if err != nil {
+		return nil, err
+	}
+	return provider.LanguageModel(context.Background(), modelID)
+}
+
+// googleaiProviderOptions translates ask's effort picker onto the
+// Gemini wire controls. effort="low"/"medium"/"high" map onto
+// google.ThinkingLevel; "minimal" maps to ThinkingLevelMinimal;
+// anything unmapped (including the empty string) is a no-op so
+// the API default kicks in. catalogClampEffort de-grades a pick
+// the chosen model doesn't support (Gemini 3.1 Pro rejects
+// "minimal", Gemini 2.5 Pro rejects everything).
+func googleaiProviderOptions(modelID, effort string) (fantasy.ProviderOptions, *float64) {
+	if effort == "" {
+		return nil, nil
+	}
+	clamped := catalogClampEffort(catwalk.InferenceProviderGemini, modelID, effort)
+	level := google.ThinkingLevel(strings.ToUpper(clamped))
+	opts := &google.ProviderOptions{
+		ThinkingConfig: &google.ThinkingConfig{ThinkingLevel: &level},
+	}
+	return fantasy.ProviderOptions{google.Name: opts}, nil
+}
+
+var googleaiSpec = agentProviderSpec{
+	id:            googleaiProviderID,
+	displayName:   "Google AI Studio",
+	defaultModel:  googleaiDefaultModel,
+	modelOptions:  catalogModelIDs(catwalk.InferenceProviderGemini),
+	effortOptions: googleaiEffortOptions,
+	buildModel: func(cfg askConfig, modelID string) (fantasy.LanguageModel, error) {
+		return googleaiLanguageModel(cfg.GoogleAI, modelID)
+	},
+	callOptions: googleaiProviderOptions,
+	// Every Gemini model in catwalk supports image attachments
+	// (supports_attachments=true). Unknown ids default to true —
+	// the alternative is silently dropping a paste which is worse
+	// than saying so.
+	supportsImages: func(modelID string) bool {
+		return catalogSupportsImages(catwalk.InferenceProviderGemini, modelID, true)
+	},
+	contextWindow: func(modelID string) int64 {
+		return catalogContextWindow(catwalk.InferenceProviderGemini, modelID, googleaiContextWindow)
+	},
+	maxOutputTokens: func(modelID string) int64 {
+		return catalogDefaultMaxTokens(catwalk.InferenceProviderGemini, modelID, googleaiFallbackMaxOutputTokens)
+	},
+	loadSettings: func(cfg askConfig) ProviderSettings {
+		return ProviderSettings{
+			Model:         cfg.GoogleAI.Model,
+			Effort:        cfg.GoogleAI.Effort,
+			SlashCommands: cfg.GoogleAI.SlashCommands,
+		}
+	},
+	saveSettings: func(cfg *askConfig, s ProviderSettings) {
+		cfg.GoogleAI.Model = s.Model
+		cfg.GoogleAI.Effort = s.Effort
+		cfg.GoogleAI.SlashCommands = s.SlashCommands
+	},
+}
+
+func googleaiAgentProvider() agentAPIProvider { return agentAPIProvider{spec: &googleaiSpec} }
+
+func googleaiStore() *agentSessionStore {
+	return &agentSessionStore{provider: googleaiProviderID}
+}

--- a/googleai_test.go
+++ b/googleai_test.go
@@ -1,0 +1,299 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/fantasy"
+	"charm.land/fantasy/providers/google"
+)
+
+func swapGoogleAILM(t *testing.T, lm fantasy.LanguageModel) {
+	t.Helper()
+	prev := googleaiLanguageModel
+	googleaiLanguageModel = func(apiProviderConfig, string) (fantasy.LanguageModel, error) {
+		return lm, nil
+	}
+	t.Cleanup(func() { googleaiLanguageModel = prev })
+}
+
+func TestGoogleAIProvider_Metadata(t *testing.T) {
+	p := googleaiAgentProvider()
+	if p.ID() != "googleai" || p.DisplayName() != "Google AI Studio" {
+		t.Errorf("identity wrong: %q %q", p.ID(), p.DisplayName())
+	}
+	caps := p.Capabilities()
+	if !caps.Resume || !caps.ModelPicker || !caps.EffortPicker {
+		t.Errorf("capabilities wrong: %+v", caps)
+	}
+	if caps.AskUserQuestionMCP || caps.PermissionPromptMCP {
+		t.Errorf("MCP redirect capabilities must be off (native tools): %+v", caps)
+	}
+	picker := p.ModelPicker()
+	if len(picker.Options) == 0 || picker.Options[0] != googleaiDefaultModel || !picker.AllowCustom {
+		t.Errorf("model picker wrong: %+v", picker)
+	}
+	if efforts := p.EffortOptions(); len(efforts) != 4 || efforts[0] != "minimal" {
+		t.Errorf("effort options wrong: %v", efforts)
+	}
+	if id := p.PreMintSessionID(ProviderSessionArgs{}); id == "" {
+		t.Error("googleai must pre-mint session ids")
+	}
+
+	got, ok := providerByIDStrict("googleai")
+	if !ok || got.ID() != "googleai" {
+		t.Fatal("googleai must be in the provider registry")
+	}
+	if err := validateProviderID("googleai"); err != nil {
+		t.Errorf("workflow provider validation must accept googleai: %v", err)
+	}
+}
+
+func TestGoogleAIProvider_SettingsRoundTrip(t *testing.T) {
+	isolateHome(t)
+	p := googleaiAgentProvider()
+	if s := p.LoadSettings(); s.Model != "" || s.Effort != "" {
+		t.Errorf("fresh settings must be zero: %+v", s)
+	}
+	want := ProviderSettings{Model: "gemini-3.1-pro-preview", Effort: "low",
+		SlashCommands: []providerSlashEntry{{Name: "x", Description: "y"}}}
+	if err := p.SaveSettings(want); err != nil {
+		t.Fatalf("SaveSettings: %v", err)
+	}
+	got := p.LoadSettings()
+	if got.Model != want.Model || got.Effort != want.Effort || len(got.SlashCommands) != 1 {
+		t.Errorf("settings lost: %+v", got)
+	}
+}
+
+func TestGoogleAIProviderOptions(t *testing.T) {
+	opts, temp := googleaiProviderOptions(googleaiDefaultModel, "low")
+	if temp != nil {
+		t.Errorf("googleai must not set temperature: %v", temp)
+	}
+	goo, ok := opts["google"].(*google.ProviderOptions)
+	if !ok || goo.ThinkingConfig == nil || goo.ThinkingConfig.ThinkingLevel == nil {
+		t.Fatalf("low must produce ThinkingLevel=LOW: %+v", goo)
+	}
+	if *goo.ThinkingConfig.ThinkingLevel != "LOW" {
+		t.Errorf("level=%q want LOW", *goo.ThinkingConfig.ThinkingLevel)
+	}
+
+	// "minimal" clamps to "low" on gemini-3.1-pro (no minimal in catwalk).
+	opts, _ = googleaiProviderOptions(googleaiDefaultModel, "minimal")
+	goo = opts["google"].(*google.ProviderOptions)
+	if *goo.ThinkingConfig.ThinkingLevel != "LOW" {
+		t.Errorf("minimal should clamp to LOW on 3.1 Pro, got %q", *goo.ThinkingConfig.ThinkingLevel)
+	}
+
+	// "high" passes through.
+	opts, _ = googleaiProviderOptions(googleaiDefaultModel, "high")
+	goo = opts["google"].(*google.ProviderOptions)
+	if *goo.ThinkingConfig.ThinkingLevel != "HIGH" {
+		t.Errorf("high should pass through, got %q", *goo.ThinkingConfig.ThinkingLevel)
+	}
+
+	// Empty effort is a no-op (no provider options returned).
+	opts, _ = googleaiProviderOptions(googleaiDefaultModel, "")
+	if opts != nil {
+		t.Errorf("empty effort must return nil options, got %+v", opts)
+	}
+}
+
+func TestGoogleAIProvider_NoAPIKeyFailsFast(t *testing.T) {
+	isolateHome(t)
+	t.Setenv(googleaiEnvAPIKey, "")
+	p := googleaiAgentProvider()
+	_, _, err := p.StartSession(ProviderSessionArgs{Cwd: t.TempDir(), NewSessionID: "s1"})
+	if err == nil {
+		t.Fatal("StartSession without a key must fail")
+	}
+	if !strings.Contains(err.Error(), "model picker") || !strings.Contains(err.Error(), googleaiEnvAPIKey) {
+		t.Errorf("error must point at both config and env: %v", err)
+	}
+}
+
+func TestGoogleAIProvider_SessionLifecycle(t *testing.T) {
+	isolateHome(t)
+	stubGitStatus(t, "")
+	lm := &fakeLM{turns: [][]fantasy.StreamPart{
+		textTurn("answer one", fantasy.Usage{InputTokens: 10}),
+	}}
+	swapGoogleAILM(t, lm)
+
+	p := googleaiAgentProvider()
+	cwd := t.TempDir()
+	args := ProviderSessionArgs{Cwd: cwd, TabID: 4, NewSessionID: "ses-gai", SkipAllPermissions: true}
+	proc, ch, err := p.StartSession(args)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	if proc.cmd != nil {
+		t.Error("in-process provider must not carry an exec.Cmd")
+	}
+	if p.NativeSessionID(proc) != "" {
+		t.Error("pre-minting provider must return empty NativeSessionID")
+	}
+
+	if err := p.Send(proc, "question", nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	msgs := readSessionMsgs(t, ch, isTurnComplete)
+	var done providerDoneMsg
+	var usage *usageMsg
+	for _, m := range msgs {
+		switch v := m.(type) {
+		case providerDoneMsg:
+			done = v
+		case usageMsg:
+			u := v
+			usage = &u
+		}
+	}
+	if done.res.SessionID != "ses-gai" || done.res.Result != "answer one" {
+		t.Errorf("done msg wrong: %+v", done.res)
+	}
+	// Gemini models have catalog pricing → costKnown + dollar amount.
+	if usage == nil || !usage.costKnown {
+		t.Errorf("usageMsg must exist and be cost-known: %+v", usage)
+	}
+
+	calls := lm.streamCalls()
+	if len(calls) == 0 || calls[0].Prompt[0].Role != fantasy.MessageRoleSystem {
+		t.Fatal("first wire message must be the system prompt")
+	}
+	if sys := messageText(calls[0].Prompt[0]); !strings.Contains(sys, "<critical_rules>") ||
+		!strings.Contains(sys, "super human speeds") {
+		t.Error("system prompt must include coder rules and ask steering")
+	}
+	if want := googleaiSpec.maxOutputTokens(googleaiDefaultModel); calls[0].MaxOutputTokens == nil ||
+		*calls[0].MaxOutputTokens != want {
+		t.Errorf("wire MaxOutputTokens = %v want %d", calls[0].MaxOutputTokens, want)
+	}
+
+	if handled, _ := p.Interrupt(proc); handled {
+		t.Error("idle interrupt must report handled=false")
+	}
+
+	sessions, err := p.ListSessions(cwd)
+	if err != nil || len(sessions) != 1 || sessions[0].id != "ses-gai" {
+		t.Fatalf("ListSessions: %v %+v", err, sessions)
+	}
+	if sessions[0].preview != "question" {
+		t.Errorf("preview %q", sessions[0].preview)
+	}
+	entries, err := p.LoadHistory("ses-gai", HistoryOpts{ToolOutput: toolOutputFull})
+	if err != nil || len(entries) != 2 {
+		t.Fatalf("LoadHistory: %v %+v", err, entries)
+	}
+
+	proc.kill()
+	sawExit := false
+	for m := range ch {
+		if _, ok := m.(providerExitedMsg); ok {
+			sawExit = true
+		}
+	}
+	if !sawExit {
+		t.Error("kill must produce providerExitedMsg")
+	}
+
+	lm2 := &fakeLM{turns: [][]fantasy.StreamPart{
+		textTurn("answer two", fantasy.Usage{}),
+	}}
+	swapGoogleAILM(t, lm2)
+	proc2, ch2, err := p.StartSession(ProviderSessionArgs{
+		Cwd: cwd, TabID: 4, SessionID: "ses-gai", SkipAllPermissions: true,
+	})
+	if err != nil {
+		t.Fatalf("resume StartSession: %v", err)
+	}
+	defer func() { proc2.kill(); drainProviderStream(ch2) }()
+	if err := p.Send(proc2, "follow-up", nil); err != nil {
+		t.Fatal(err)
+	}
+	readSessionMsgs(t, ch2, isTurnComplete)
+	wire := lm2.streamCalls()[0].Prompt
+	var sawPriorTurn bool
+	for _, m := range wire {
+		if m.Role == fantasy.MessageRoleUser && strings.Contains(messageText(m), "question") {
+			sawPriorTurn = true
+		}
+	}
+	if !sawPriorTurn {
+		t.Error("resumed session must replay prior turns on the wire")
+	}
+}
+
+func TestGoogleAIProvider_ResumeUnknownSessionErrors(t *testing.T) {
+	isolateHome(t)
+	swapGoogleAILM(t, &fakeLM{})
+	p := googleaiAgentProvider()
+	if _, _, err := p.StartSession(ProviderSessionArgs{Cwd: t.TempDir(), SessionID: "missing"}); err == nil {
+		t.Fatal("resuming an unknown session must fail")
+	}
+}
+
+func TestGoogleAIProvider_MaterializeRoundTrip(t *testing.T) {
+	isolateHome(t)
+	p := googleaiAgentProvider()
+	workspace := t.TempDir()
+	id, cwd, err := p.Materialize(workspace, []NeutralTurn{
+		{Role: "user", Text: "ported question"},
+		{Role: "assistant", Text: "ported answer"},
+	})
+	if err != nil || id == "" || cwd != workspace {
+		t.Fatalf("Materialize: id=%q cwd=%q err=%v", id, cwd, err)
+	}
+	entries, err := p.LoadHistory(id, HistoryOpts{})
+	if err != nil || len(entries) != 2 {
+		t.Fatalf("materialized history: %v %+v", err, entries)
+	}
+	if entries[0].kind != histUser || entries[1].kind != histResponse {
+		t.Errorf("materialized entry kinds wrong: %+v", entries)
+	}
+}
+
+func TestGoogleAIStoreUsesHome(t *testing.T) {
+	home := isolateHome(t)
+	st := googleaiStore()
+	root, err := st.root()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(root, home) {
+		t.Errorf("store root %q must live under isolated home %q", root, home)
+	}
+}
+
+func TestGoogleAIMaxOutputTokens(t *testing.T) {
+	// The default model is in the catwalk catalog; the published
+	// default_max_tokens (64000) wins over the fallback.
+	if got := googleaiSpec.maxOutputTokens(googleaiDefaultModel); got == googleaiFallbackMaxOutputTokens {
+		t.Errorf("default model should use the catwalk value, not the fallback: got %d", got)
+	}
+	// Unknown models fall back to the conservative default.
+	if got := googleaiSpec.maxOutputTokens("custom-unknown"); got != googleaiFallbackMaxOutputTokens {
+		t.Errorf("unknown model must use the fallback budget: %d", got)
+	}
+}
+
+func TestGoogleAISupportsImages(t *testing.T) {
+	// gemini-3.1-pro-preview-customtools supports images.
+	if !googleaiSpec.supportsImages(googleaiDefaultModel) {
+		t.Error("default model must support images")
+	}
+	// Unknown models fall back to true.
+	if !googleaiSpec.supportsImages("unknown-model") {
+		t.Error("unknown model should default to image-capable")
+	}
+}
+
+func TestModelContextLimit_GoogleAI(t *testing.T) {
+	if got := modelContextLimit(googleaiDefaultModel); got != googleaiContextWindow {
+		t.Errorf("googleai default limit = %d want %d", got, googleaiContextWindow)
+	}
+	if got := modelContextLimit("gemini-3-flash-preview"); got != googleaiContextWindow {
+		t.Errorf("gemini-3-flash-preview limit = %d want %d", got, googleaiContextWindow)
+	}
+}

--- a/model_picker.go
+++ b/model_picker.go
@@ -45,6 +45,8 @@ var providerKeySpecs = []providerKeySpec{
 		func(c *askConfig) *apiProviderConfig { return &c.Moonshot }},
 	{minimaxProviderID, "MiniMax", minimaxEnvAPIKey,
 		func(c *askConfig) *apiProviderConfig { return &c.MiniMax }},
+	{googleaiProviderID, "Google AI Studio", googleaiEnvAPIKey,
+		func(c *askConfig) *apiProviderConfig { return &c.GoogleAI }},
 }
 
 func providerKeySpecByID(id string) (providerKeySpec, bool) {
@@ -85,6 +87,8 @@ var catwalkProviderIDs = map[string]catwalk.InferenceProvider{
 	openaiProviderID:    catwalk.InferenceProviderOpenAI,
 	deepseekProviderID:  catwalk.InferenceProviderDeepSeek,
 	minimaxProviderID:   catwalk.InferenceProviderMiniMax,
+	googleaiProviderID:  catwalk.InferenceProviderGemini,
+	vertexProviderID:    catwalk.InferenceProviderVertexAI,
 }
 
 // friendlyModelName resolves a model id to a human-friendly display

--- a/model_picker_test.go
+++ b/model_picker_test.go
@@ -664,3 +664,101 @@ func TestModelPicker_CtrlDClosesTab(t *testing.T) {
 	}
 	_ = mi
 }
+
+// newProviderRegistryFixture seeds the model picker with the real
+// googleai + vertex providers (alongside the kimi fake from the
+// existing fixture) so the picker headers + groups cover the new
+// providers end-to-end.
+func newProviderRegistryFixture(t *testing.T) model {
+	t.Helper()
+	isolateHome(t)
+	setKeyMapForTesting(DefaultKeyMap())
+	t.Cleanup(invalidateKeyMapCache)
+	// Ensure the kimi fake doesn't gate on a key for the picker test
+	// (it would surface as "no API key" notes on the header).
+	t.Setenv(moonshotEnvAPIKey, "fake-kimi-key")
+	t.Setenv(googleaiEnvAPIKey, "fake-googleai-key")
+	pKimi := newFakeProvider()
+	pKimi.id = kimiProviderID
+	pKimi.displayName = "Kimi (Moonshot)"
+	pKimi.modelPicker = ProviderPicker{Options: []string{"kimi-k2.7-code"}}
+	withRegisteredProviders(t, googleaiAgentProvider(), vertexAgentProvider(), pKimi)
+	m := newTestModel(t, pKimi)
+	return m
+}
+
+func TestModelPicker_GoogleAIAppearsAsSection(t *testing.T) {
+	m := newProviderRegistryFixture(t)
+	m = m.openModelPicker()
+	rows := m.modelPicker.rows()
+	var hasHeader, hasEntry bool
+	for _, r := range rows {
+		if r.kind == modelPickerRowHeader && r.title == "Google AI Studio" {
+			hasHeader = true
+		}
+		if r.kind == modelPickerRowEntry && r.entry.providerID == googleaiProviderID &&
+			r.entry.modelID == googleaiDefaultModel {
+			hasEntry = true
+		}
+	}
+	if !hasHeader {
+		t.Error("model picker must surface a Google AI Studio section header")
+	}
+	if !hasEntry {
+		t.Error("model picker must surface the googleai default model entry")
+	}
+}
+
+func TestModelPicker_VertexAppearsAsSection(t *testing.T) {
+	m := newProviderRegistryFixture(t)
+	m = m.openModelPicker()
+	rows := m.modelPicker.rows()
+	var hasHeader, hasEntry bool
+	for _, r := range rows {
+		if r.kind == modelPickerRowHeader && r.title == "Vertex AI" {
+			hasHeader = true
+		}
+		if r.kind == modelPickerRowEntry && r.entry.providerID == vertexProviderID &&
+			r.entry.modelID == vertexDefaultModel {
+			hasEntry = true
+		}
+	}
+	if !hasHeader {
+		t.Error("model picker must surface a Vertex AI section header")
+	}
+	if !hasEntry {
+		t.Error("model picker must surface the vertex default model entry")
+	}
+}
+
+func TestModelPicker_VertexNoKeyPrompt(t *testing.T) {
+	// Vertex auth is configured in the /config → Vertex AI submenu,
+	// not via the inline API-key prompt. Picking a Vertex model
+	// without a configured project should apply directly (and surface
+	// a "project is required" error on session start, not on the pick).
+	m := newProviderRegistryFixture(t)
+	if err := withConfigLock(func() error {
+		cfg, _ := loadConfig()
+		cfg.Vertex.Project = "" // explicit empty
+		return saveConfig(cfg)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	m = m.openModelPicker()
+	// Walk to the Vertex section (Google AI Studio is registered first
+	// in the fixture, then Vertex, then Kimi).
+	for {
+		row := selectedRow(t, m)
+		if row.kind == modelPickerRowEntry && row.entry.providerID == vertexProviderID {
+			break
+		}
+		m = stepKey(t, m, pressSpecial(tea.KeyDown))
+	}
+	m = stepKey(t, m, pressSpecial(tea.KeyEnter))
+	if m.modelPicker != nil && m.modelPicker.keyEntry != nil {
+		t.Error("Vertex must not open an inline API-key prompt")
+	}
+	if m.mode != modeInput {
+		t.Errorf("Vertex pick should apply directly; mode=%v", m.mode)
+	}
+}

--- a/provider.go
+++ b/provider.go
@@ -359,6 +359,8 @@ func init() {
 	registerProvider(deepseekAgentProvider())
 	registerProvider(kimiAgentProvider())
 	registerProvider(minimaxAgentProvider())
+	registerProvider(googleaiAgentProvider())
+	registerProvider(vertexAgentProvider())
 }
 
 // providerByID returns the provider with the given ID, or the first

--- a/tabs.go
+++ b/tabs.go
@@ -411,6 +411,7 @@ func (a app) supplantWorkflow(req spawnWorkflowTabMsg) (tea.Model, tea.Cmd) {
 	t.configProviderPickerActive = false
 	t.configMemoryPickerActive = false
 	t.configWebSearchPickerActive = false
+	t.configVertexPickerActive = false
 	t.configKeybindingsPickerActive = false
 	t.lastContentFP = ""
 	if t.fc != nil {

--- a/types.go
+++ b/types.go
@@ -530,6 +530,18 @@ type model struct {
 	configWebSearchEditing      bool
 	configWebSearchDraft        string
 
+	// configVertexPickerActive toggles the /config → Vertex AI
+	// sub-picker. Three rows: Project, Location, Service Account
+	// Key path. Pressing Enter on a row opens the inline editor
+	// (configVertexFieldEditing flips to the row id); the draft
+	// accumulates keystrokes/pastes and Enter validates + persists
+	// to cfg.Vertex.* via the matching vertexFieldSpec. Mirrors
+	// the memory picker's multi-field shape.
+	configVertexPickerActive bool
+	configVertexCursor       int
+	configVertexFieldEditing string
+	configVertexFieldDraft   string
+
 	// /config now layers into Global Options (existing knobs) vs
 	// Project Options (per-cwd issue provider). configGlobalPicker-
 	// Active is the gate for the Global submenu — it carries the

--- a/update.go
+++ b/update.go
@@ -1019,6 +1019,9 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 		if m.mode == modeConfig && m.configWebSearchPickerActive && m.configWebSearchEditing {
 			return m.applyConfigWebSearchPaste(msg.Content)
 		}
+		if m.mode == modeConfig && m.configVertexPickerActive && m.configVertexFieldEditing != "" {
+			return m.applyConfigVertexPaste(msg.Content)
+		}
 		if m.mode == modeModelPicker {
 			return m.applyModelPickerPaste(msg.Content)
 		}

--- a/usage.go
+++ b/usage.go
@@ -23,6 +23,12 @@ func modelContextLimit(model string) int {
 	if strings.HasPrefix(lower, "minimax") {
 		return int(catalogContextWindow(catwalk.InferenceProviderMiniMax, model, 200_000))
 	}
+	if m, ok := catalogModel(catwalk.InferenceProviderGemini, model); ok && m.ContextWindow > 0 {
+		return int(m.ContextWindow)
+	}
+	if m, ok := catalogModel(catwalk.InferenceProviderVertexAI, model); ok && m.ContextWindow > 0 {
+		return int(m.ContextWindow)
+	}
 	if m, ok := catalogModel(catwalk.InferenceProviderAnthropic, model); ok && m.ContextWindow > 0 {
 		return int(m.ContextWindow)
 	}

--- a/vertex.go
+++ b/vertex.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"charm.land/fantasy"
+	"charm.land/fantasy/providers/google"
+)
+
+const (
+	vertexProviderID              = "vertex"
+	vertexDefaultModel            = "gemini-3.1-pro-preview"
+	vertexDefaultLocation         = "global"
+	vertexContextWindow           = 1_048_576
+	vertexFallbackMaxOutputTokens = 32_000
+
+	// vertexEnvApplicationCredentials is the env var the genai
+	// library consults via credentials.DetectDefault to find a
+	// service-account JSON. Set in vertexApplyEnv when the user
+	// has configured cfg.Vertex.ServiceAccountKey (or wants the
+	// existing env value promoted); otherwise the same detection
+	// path falls through to gcloud / GCE metadata.
+	vertexEnvApplicationCredentials = "GOOGLE_APPLICATION_CREDENTIALS"
+
+	// vertexEnvCloudProject is the env-var fallback for the project
+	// id, mirroring `gcloud config get-value project` behavior.
+	vertexEnvCloudProject = "GOOGLE_CLOUD_PROJECT"
+)
+
+// vertexEffortOptions is the picker surface for reasoning effort.
+// Same shape as googleai: catalogClampEffort de-grades a pick the
+// chosen model doesn't support (Vertex's Gemini 3.1 Pro rejects
+// "minimal" — it drops to "low").
+var vertexEffortOptions = []string{"minimal", "low", "medium", "high"}
+
+// vertexModelOptions filters the catalog's Vertex model list: the
+// Vertex catwalk bundle ships five Claude models alongside the
+// Gemini line, but fantasy's google provider transparently routes
+// those through anthropic.WithVertex (different wire, different
+// reasoning enums). They are out of scope for v1 — users wanting
+// Claude-on-Vertex use the regular Anthropic provider.
+var vertexModelOptions = filterVertexModelOptions(catalogModelIDs(catwalk.InferenceProviderVertexAI))
+
+// filterVertexModelOptions strips Claude / Anthropic ids from the
+// Vertex catwalk list. The substring match covers the catwalk
+// naming patterns we see today (claude-sonnet-4-6, claude-opus-4-5-
+// 20251101, …); an "anthropic" guard catches any future ids the
+// provider would also auto-route to anthropic.WithVertex.
+func filterVertexModelOptions(all []string) []string {
+	out := make([]string, 0, len(all))
+	for _, id := range all {
+		low := strings.ToLower(id)
+		if strings.Contains(low, "claude") || strings.Contains(low, "anthropic") {
+			continue
+		}
+		out = append(out, id)
+	}
+	return out
+}
+
+// vertexResolveProject: config value wins, then GOOGLE_CLOUD_PROJECT.
+// Empty result is the fail-fast signal at session start.
+func vertexResolveProject(vc vertexConfig) string {
+	if vc.Project != "" {
+		return vc.Project
+	}
+	return os.Getenv(vertexEnvCloudProject)
+}
+
+// vertexResolveLocation: config value wins, then the documented
+// Vertex "global" default (broadest availability for current Gemini
+// 3.x models).
+func vertexResolveLocation(vc vertexConfig) string {
+	if vc.Location != "" {
+		return vc.Location
+	}
+	return vertexDefaultLocation
+}
+
+// vertexApplyEnv is the testable seam for the SA-key env-mutation
+// strategy. The real implementation calls os.Setenv so the genai
+// library's credentials.DetectDefault finds the SA key bytes on
+// the next call. Tests swap this var to assert the path is being
+// propagated without actually mutating the process env.
+//
+// Note: the env var is process-wide. Two Vertex sessions with
+// different SA key paths in the same process would race; the last
+// Setenv wins. v1 limitation — "one Vertex project per process" —
+// documented in the spec comment.
+var vertexApplyEnv = func(path string) {
+	_ = os.Setenv(vertexEnvApplicationCredentials, path)
+}
+
+// vertexPrepareCredentials resolves the SA key path, validates it
+// is readable, and applies the env var so the genai library's
+// credentials.DetectDefault finds the bytes on the next call.
+// Returns the path in use, or "" when no SA key is configured
+// (ADC discovery via gcloud / GCE metadata is then the fallback).
+// Extracted from vertexLanguageModel so the SA-key resolution
+// chain (config > env > ADC) is unit-testable without spinning up
+// a real google.New.
+//
+// Tests swap vertexApplyEnv to assert the env mutation without
+// polluting the process env.
+var vertexPrepareCredentials = func(vc vertexConfig) (string, error) {
+	saKeyPath := vc.ServiceAccountKey
+	if saKeyPath == "" {
+		saKeyPath = os.Getenv(vertexEnvApplicationCredentials)
+	}
+	if saKeyPath == "" {
+		return "", nil
+	}
+	if _, err := os.Stat(saKeyPath); err != nil {
+		return "", fmt.Errorf("vertex: read service account key %s: %w", saKeyPath, err)
+	}
+	vertexApplyEnv(saKeyPath)
+	return saKeyPath, nil
+}
+
+// vertexLanguageModel builds the fantasy LanguageModel for one
+// session. Swappable in tests so StartSession can run against a
+// fake model with zero network.
+var vertexLanguageModel = func(vc vertexConfig, modelID string) (fantasy.LanguageModel, error) {
+	project := vertexResolveProject(vc)
+	if project == "" {
+		return nil, errors.New("vertex: project is required — set it in /config → Vertex AI, or via " + vertexEnvCloudProject)
+	}
+	location := vertexResolveLocation(vc)
+	opts := []google.Option{google.WithVertex(project, location)}
+
+	// Service-account key resolution: explicit config wins, then the
+	// env var, then ADC discovery (gcloud / GCE metadata). When we
+	// have a path, set the env so credentials.DetectDefault — which
+	// fantasy's UseDefaultCredentials calls into — finds it.
+	if _, err := vertexPrepareCredentials(vc); err != nil {
+		return nil, err
+	}
+	provider, err := google.New(opts...)
+	if err != nil {
+		return nil, err
+	}
+	return provider.LanguageModel(context.Background(), modelID)
+}
+
+// vertexProviderOptions translates ask's effort picker onto Gemini's
+// thinking controls. Same shape as googleaiProviderOptions — both
+// providers share the ThinkingConfig + ThinkingLevel wire surface.
+func vertexProviderOptions(modelID, effort string) (fantasy.ProviderOptions, *float64) {
+	if effort == "" {
+		return nil, nil
+	}
+	clamped := catalogClampEffort(catwalk.InferenceProviderVertexAI, modelID, effort)
+	level := google.ThinkingLevel(strings.ToUpper(clamped))
+	opts := &google.ProviderOptions{
+		ThinkingConfig: &google.ThinkingConfig{ThinkingLevel: &level},
+	}
+	return fantasy.ProviderOptions{google.Name: opts}, nil
+}
+
+var vertexSpec = agentProviderSpec{
+	id:            vertexProviderID,
+	displayName:   "Vertex AI",
+	defaultModel:  vertexDefaultModel,
+	modelOptions:  vertexModelOptions,
+	effortOptions: vertexEffortOptions,
+	buildModel: func(cfg askConfig, modelID string) (fantasy.LanguageModel, error) {
+		return vertexLanguageModel(cfg.Vertex, modelID)
+	},
+	callOptions: vertexProviderOptions,
+	// Every Gemini model in the Vertex catalog supports image
+	// attachments; unknown ids default to true (the same reasoning
+	// as googleai — silent drops are worse than a clear error).
+	supportsImages: func(modelID string) bool {
+		return catalogSupportsImages(catwalk.InferenceProviderVertexAI, modelID, true)
+	},
+	contextWindow: func(modelID string) int64 {
+		return catalogContextWindow(catwalk.InferenceProviderVertexAI, modelID, vertexContextWindow)
+	},
+	maxOutputTokens: func(modelID string) int64 {
+		return catalogDefaultMaxTokens(catwalk.InferenceProviderVertexAI, modelID, vertexFallbackMaxOutputTokens)
+	},
+	loadSettings: func(cfg askConfig) ProviderSettings {
+		return ProviderSettings{
+			Model:         cfg.Vertex.Model,
+			Effort:        cfg.Vertex.Effort,
+			SlashCommands: cfg.Vertex.SlashCommands,
+		}
+	},
+	saveSettings: func(cfg *askConfig, s ProviderSettings) {
+		cfg.Vertex.Model = s.Model
+		cfg.Vertex.Effort = s.Effort
+		cfg.Vertex.SlashCommands = s.SlashCommands
+	},
+}
+
+func vertexAgentProvider() agentAPIProvider { return agentAPIProvider{spec: &vertexSpec} }
+
+func vertexStore() *agentSessionStore {
+	return &agentSessionStore{provider: vertexProviderID}
+}

--- a/vertex_test.go
+++ b/vertex_test.go
@@ -1,0 +1,512 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"charm.land/fantasy"
+	"charm.land/fantasy/providers/google"
+)
+
+func swapVertexLM(t *testing.T, lm fantasy.LanguageModel) {
+	t.Helper()
+	prev := vertexLanguageModel
+	vertexLanguageModel = func(vertexConfig, string) (fantasy.LanguageModel, error) {
+		return lm, nil
+	}
+	t.Cleanup(func() { vertexLanguageModel = prev })
+}
+
+func TestVertexProvider_Metadata(t *testing.T) {
+	p := vertexAgentProvider()
+	if p.ID() != "vertex" || p.DisplayName() != "Vertex AI" {
+		t.Errorf("identity wrong: %q %q", p.ID(), p.DisplayName())
+	}
+	caps := p.Capabilities()
+	if !caps.Resume || !caps.ModelPicker || !caps.EffortPicker {
+		t.Errorf("capabilities wrong: %+v", caps)
+	}
+	if caps.AskUserQuestionMCP || caps.PermissionPromptMCP {
+		t.Errorf("MCP redirect capabilities must be off (native tools): %+v", caps)
+	}
+	picker := p.ModelPicker()
+	if len(picker.Options) == 0 || picker.Options[0] != vertexDefaultModel || !picker.AllowCustom {
+		t.Errorf("model picker wrong: %+v", picker)
+	}
+	// The Vertex catwalk lists Claude models alongside Gemini; the
+	// spec filters them out so the picker shows only the Gemini line.
+	for _, id := range picker.Options {
+		low := strings.ToLower(id)
+		if strings.Contains(low, "claude") || strings.Contains(low, "anthropic") {
+			t.Errorf("picker must filter Claude / anthropic ids, got %q", id)
+		}
+	}
+	if efforts := p.EffortOptions(); len(efforts) != 4 || efforts[0] != "minimal" {
+		t.Errorf("effort options wrong: %v", efforts)
+	}
+	if id := p.PreMintSessionID(ProviderSessionArgs{}); id == "" {
+		t.Error("vertex must pre-mint session ids")
+	}
+
+	got, ok := providerByIDStrict("vertex")
+	if !ok || got.ID() != "vertex" {
+		t.Fatal("vertex must be in the provider registry")
+	}
+	if err := validateProviderID("vertex"); err != nil {
+		t.Errorf("workflow provider validation must accept vertex: %v", err)
+	}
+
+	// Vertex is NOT in providerKeySpecs: its auth is configured via
+	// the /config → Vertex AI submenu, not via the model picker's
+	// inline API-key prompt. The picker therefore never gates on a
+	// key for vertex.
+	if _, ok := providerKeySpecByID("vertex"); ok {
+		t.Error("vertex must NOT be in providerKeySpecs (auth via submenu)")
+	}
+}
+
+func TestVertexProvider_SettingsRoundTrip(t *testing.T) {
+	isolateHome(t)
+	p := vertexAgentProvider()
+	if s := p.LoadSettings(); s.Model != "" || s.Effort != "" {
+		t.Errorf("fresh settings must be zero: %+v", s)
+	}
+	want := ProviderSettings{Model: "gemini-3-flash-preview", Effort: "high",
+		SlashCommands: []providerSlashEntry{{Name: "x", Description: "y"}}}
+	if err := p.SaveSettings(want); err != nil {
+		t.Fatalf("SaveSettings: %v", err)
+	}
+	got := p.LoadSettings()
+	if got.Model != want.Model || got.Effort != want.Effort || len(got.SlashCommands) != 1 {
+		t.Errorf("settings lost: %+v", got)
+	}
+}
+
+func TestVertexProviderOptions(t *testing.T) {
+	opts, temp := vertexProviderOptions(vertexDefaultModel, "low")
+	if temp != nil {
+		t.Errorf("vertex must not set temperature: %v", temp)
+	}
+	goo, ok := opts["google"].(*google.ProviderOptions)
+	if !ok || goo.ThinkingConfig == nil || goo.ThinkingConfig.ThinkingLevel == nil {
+		t.Fatalf("low must produce ThinkingLevel=LOW: %+v", goo)
+	}
+	if *goo.ThinkingConfig.ThinkingLevel != "LOW" {
+		t.Errorf("level=%q want LOW", *goo.ThinkingConfig.ThinkingLevel)
+	}
+
+	// "minimal" clamps to "low" on gemini-3.1-pro (no minimal in catwalk).
+	opts, _ = vertexProviderOptions(vertexDefaultModel, "minimal")
+	goo = opts["google"].(*google.ProviderOptions)
+	if *goo.ThinkingConfig.ThinkingLevel != "LOW" {
+		t.Errorf("minimal should clamp to LOW on 3.1 Pro, got %q", *goo.ThinkingConfig.ThinkingLevel)
+	}
+
+	// "high" passes through.
+	opts, _ = vertexProviderOptions(vertexDefaultModel, "high")
+	goo = opts["google"].(*google.ProviderOptions)
+	if *goo.ThinkingConfig.ThinkingLevel != "HIGH" {
+		t.Errorf("high should pass through, got %q", *goo.ThinkingConfig.ThinkingLevel)
+	}
+
+	// Empty effort is a no-op.
+	opts, _ = vertexProviderOptions(vertexDefaultModel, "")
+	if opts != nil {
+		t.Errorf("empty effort must return nil options, got %+v", opts)
+	}
+}
+
+func TestVertexResolveLocation(t *testing.T) {
+	// Configured location wins.
+	if got := vertexResolveLocation(vertexConfig{Location: "us-central1"}); got != "us-central1" {
+		t.Errorf("configured location = %q want us-central1", got)
+	}
+	// Empty → global default.
+	if got := vertexResolveLocation(vertexConfig{}); got != vertexDefaultLocation {
+		t.Errorf("default location = %q want %q", got, vertexDefaultLocation)
+	}
+}
+
+func TestVertexResolveProject(t *testing.T) {
+	// Configured project wins.
+	t.Setenv(vertexEnvCloudProject, "env-proj")
+	if got := vertexResolveProject(vertexConfig{Project: "cfg-proj"}); got != "cfg-proj" {
+		t.Errorf("configured project = %q want cfg-proj", got)
+	}
+	// Empty config → env fallback.
+	if got := vertexResolveProject(vertexConfig{}); got != "env-proj" {
+		t.Errorf("env fallback = %q want env-proj", got)
+	}
+	// Both empty → empty (session start will fail-fast with a pointed error).
+	t.Setenv(vertexEnvCloudProject, "")
+	if got := vertexResolveProject(vertexConfig{}); got != "" {
+		t.Errorf("both empty = %q want \"\"", got)
+	}
+}
+
+func TestVertexLanguageModel_MissingProjectErrors(t *testing.T) {
+	isolateHome(t)
+	t.Setenv(vertexEnvCloudProject, "")
+	t.Setenv(vertexEnvApplicationCredentials, "")
+	p := vertexAgentProvider()
+	_, _, err := p.StartSession(ProviderSessionArgs{Cwd: t.TempDir(), NewSessionID: "s1"})
+	if err == nil {
+		t.Fatal("StartSession without a project must fail")
+	}
+	if !strings.Contains(err.Error(), "vertex") || !strings.Contains(err.Error(), "project is required") {
+		t.Errorf("error must point at vertex + project: %v", err)
+	}
+	if !strings.Contains(err.Error(), vertexEnvCloudProject) {
+		t.Errorf("error must mention the env fallback: %v", err)
+	}
+}
+
+func TestVertexLanguageModel_ServiceAccountKeyNotFound(t *testing.T) {
+	isolateHome(t)
+	// Don't swap vertexLanguageModel — we want the real SA-key
+	// resolution to fire. The validation runs BEFORE google.New,
+	// so we never reach a real network call.
+	missing := "/nonexistent/path/that/does/not/exist.json"
+	calls := []string{}
+	prevApply := vertexApplyEnv
+	vertexApplyEnv = func(p string) { calls = append(calls, p) }
+	t.Cleanup(func() { vertexApplyEnv = prevApply })
+
+	_, err := vertexPrepareCredentials(vertexConfig{ServiceAccountKey: missing})
+	if err == nil {
+		t.Fatal("missing SA key path must fail")
+	}
+	if !strings.Contains(err.Error(), "vertex") || !strings.Contains(err.Error(), missing) {
+		t.Errorf("error must wrap the path: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Errorf("env must NOT be touched when the path is invalid: got %v", calls)
+	}
+}
+
+func TestVertexLanguageModel_ServiceAccountKeyParsed(t *testing.T) {
+	isolateHome(t)
+	// Stand up a minimal valid SA key JSON. The simplest shape that
+	// would pass credentials.DetectDefault is enough — we just want
+	// to verify the path is propagated to vertexApplyEnv.
+	dir := t.TempDir()
+	saPath := filepath.Join(dir, "sa.json")
+	saContent := `{
+  "type": "service_account",
+  "project_id": "test-proj",
+  "private_key_id": "abc123",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIBVgIBADANBgkqhkiG9w0BAQEFAASCAUAwggE8AgEAAkEAuFvwGm9Q+a7VxMvA\n-----END PRIVATE KEY-----\n",
+  "client_email": "test@test-proj.iam.gserviceaccount.com",
+  "client_id": "100000000000000000000",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token"
+}`
+	if err := os.WriteFile(saPath, []byte(saContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Capture the env-mutation calls.
+	calls := []string{}
+	prevApply := vertexApplyEnv
+	vertexApplyEnv = func(p string) { calls = append(calls, p) }
+	t.Cleanup(func() { vertexApplyEnv = prevApply })
+
+	// Drive the SA-key resolution directly — no need to invoke
+	// vertexLanguageModel (which would call google.New and require
+	// a real Vertex client).
+	got, err := vertexPrepareCredentials(vertexConfig{ServiceAccountKey: saPath})
+	if err != nil {
+		t.Fatalf("vertexPrepareCredentials: %v", err)
+	}
+	if got != saPath {
+		t.Errorf("returned path = %q, want %q", got, saPath)
+	}
+	if len(calls) != 1 || calls[0] != saPath {
+		t.Errorf("vertexApplyEnv must be called with the SA key path once, got %v", calls)
+	}
+}
+
+func TestVertexPrepareCredentials_SetsRealEnv(t *testing.T) {
+	isolateHome(t)
+	// No swap: the real vertexApplyEnv must mutate the process env
+	// so the genai library's credentials.DetectDefault finds the
+	// bytes on the next call.
+	dir := t.TempDir()
+	saPath := filepath.Join(dir, "sa.json")
+	if err := os.WriteFile(saPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := vertexPrepareCredentials(vertexConfig{ServiceAccountKey: saPath}); err != nil {
+		t.Fatal(err)
+	}
+	if env := os.Getenv(vertexEnvApplicationCredentials); env != saPath {
+		t.Errorf("GOOGLE_APPLICATION_CREDENTIALS = %q want %q", env, saPath)
+	}
+}
+
+func TestVertexPrepareCredentials_EnvFallback(t *testing.T) {
+	isolateHome(t)
+	// When the config has no SA key, the function falls back to the
+	// env var (already exported) and applies it through the same seam.
+	dir := t.TempDir()
+	saPath := filepath.Join(dir, "sa.json")
+	if err := os.WriteFile(saPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(vertexEnvApplicationCredentials, saPath)
+	calls := []string{}
+	prevApply := vertexApplyEnv
+	vertexApplyEnv = func(p string) { calls = append(calls, p) }
+	t.Cleanup(func() { vertexApplyEnv = prevApply })
+
+	got, err := vertexPrepareCredentials(vertexConfig{})
+	if err != nil {
+		t.Fatalf("vertexPrepareCredentials: %v", err)
+	}
+	if got != saPath {
+		t.Errorf("path = %q want %q", got, saPath)
+	}
+	if len(calls) != 1 || calls[0] != saPath {
+		t.Errorf("vertexApplyEnv must be called with the env-var path once, got %v", calls)
+	}
+}
+
+func TestVertexPrepareCredentials_ADCDiscovery(t *testing.T) {
+	isolateHome(t)
+	// When neither the config nor the env has a SA key, the function
+	// returns ("", nil) and lets the genai library do ADC discovery
+	// (gcloud / GCE metadata). vertexApplyEnv must NOT be called.
+	t.Setenv(vertexEnvApplicationCredentials, "")
+	calls := []string{}
+	prevApply := vertexApplyEnv
+	vertexApplyEnv = func(p string) { calls = append(calls, p) }
+	t.Cleanup(func() { vertexApplyEnv = prevApply })
+
+	got, err := vertexPrepareCredentials(vertexConfig{})
+	if err != nil {
+		t.Fatalf("vertexPrepareCredentials: %v", err)
+	}
+	if got != "" {
+		t.Errorf("path = %q want \"\"", got)
+	}
+	if len(calls) != 0 {
+		t.Errorf("vertexApplyEnv must NOT be called when no SA key is set: got %v", calls)
+	}
+}
+
+func TestVertexProvider_SessionLifecycle(t *testing.T) {
+	isolateHome(t)
+	stubGitStatus(t, "")
+	lm := &fakeLM{turns: [][]fantasy.StreamPart{
+		textTurn("answer one", fantasy.Usage{InputTokens: 10}),
+	}}
+	swapVertexLM(t, lm)
+
+	// Project + location configured.
+	if err := withConfigLock(func() error {
+		cfg, _ := loadConfig()
+		cfg.Vertex.Project = "test-proj"
+		cfg.Vertex.Location = "us-central1"
+		return saveConfig(cfg)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	p := vertexAgentProvider()
+	cwd := t.TempDir()
+	args := ProviderSessionArgs{Cwd: cwd, TabID: 4, NewSessionID: "ses-vtx", SkipAllPermissions: true}
+	proc, ch, err := p.StartSession(args)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	if proc.cmd != nil {
+		t.Error("in-process provider must not carry an exec.Cmd")
+	}
+
+	if err := p.Send(proc, "question", nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	msgs := readSessionMsgs(t, ch, isTurnComplete)
+	var done providerDoneMsg
+	var usage *usageMsg
+	for _, m := range msgs {
+		switch v := m.(type) {
+		case providerDoneMsg:
+			done = v
+		case usageMsg:
+			u := v
+			usage = &u
+		}
+	}
+	if done.res.SessionID != "ses-vtx" || done.res.Result != "answer one" {
+		t.Errorf("done msg wrong: %+v", done.res)
+	}
+	if usage == nil || !usage.costKnown {
+		t.Errorf("usageMsg must exist and be cost-known: %+v", usage)
+	}
+
+	calls := lm.streamCalls()
+	if len(calls) == 0 || calls[0].Prompt[0].Role != fantasy.MessageRoleSystem {
+		t.Fatal("first wire message must be the system prompt")
+	}
+	if want := vertexSpec.maxOutputTokens(vertexDefaultModel); calls[0].MaxOutputTokens == nil ||
+		*calls[0].MaxOutputTokens != want {
+		t.Errorf("wire MaxOutputTokens = %v want %d", calls[0].MaxOutputTokens, want)
+	}
+
+	if handled, _ := p.Interrupt(proc); handled {
+		t.Error("idle interrupt must report handled=false")
+	}
+
+	sessions, err := p.ListSessions(cwd)
+	if err != nil || len(sessions) != 1 || sessions[0].id != "ses-vtx" {
+		t.Fatalf("ListSessions: %v %+v", err, sessions)
+	}
+	if sessions[0].preview != "question" {
+		t.Errorf("preview %q", sessions[0].preview)
+	}
+	entries, err := p.LoadHistory("ses-vtx", HistoryOpts{ToolOutput: toolOutputFull})
+	if err != nil || len(entries) != 2 {
+		t.Fatalf("LoadHistory: %v %+v", err, entries)
+	}
+
+	proc.kill()
+	sawExit := false
+	for m := range ch {
+		if _, ok := m.(providerExitedMsg); ok {
+			sawExit = true
+		}
+	}
+	if !sawExit {
+		t.Error("kill must produce providerExitedMsg")
+	}
+
+	lm2 := &fakeLM{turns: [][]fantasy.StreamPart{
+		textTurn("answer two", fantasy.Usage{}),
+	}}
+	swapVertexLM(t, lm2)
+	proc2, ch2, err := p.StartSession(ProviderSessionArgs{
+		Cwd: cwd, TabID: 4, SessionID: "ses-vtx", SkipAllPermissions: true,
+	})
+	if err != nil {
+		t.Fatalf("resume StartSession: %v", err)
+	}
+	defer func() { proc2.kill(); drainProviderStream(ch2) }()
+	if err := p.Send(proc2, "follow-up", nil); err != nil {
+		t.Fatal(err)
+	}
+	readSessionMsgs(t, ch2, isTurnComplete)
+	wire := lm2.streamCalls()[0].Prompt
+	var sawPriorTurn bool
+	for _, m := range wire {
+		if m.Role == fantasy.MessageRoleUser && strings.Contains(messageText(m), "question") {
+			sawPriorTurn = true
+		}
+	}
+	if !sawPriorTurn {
+		t.Error("resumed session must replay prior turns on the wire")
+	}
+}
+
+func TestVertexProvider_ResumeUnknownSessionErrors(t *testing.T) {
+	isolateHome(t)
+	swapVertexLM(t, &fakeLM{})
+	if err := withConfigLock(func() error {
+		cfg, _ := loadConfig()
+		cfg.Vertex.Project = "test-proj"
+		return saveConfig(cfg)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	p := vertexAgentProvider()
+	if _, _, err := p.StartSession(ProviderSessionArgs{Cwd: t.TempDir(), SessionID: "missing"}); err == nil {
+		t.Fatal("resuming an unknown session must fail")
+	}
+}
+
+func TestVertexProvider_MaterializeRoundTrip(t *testing.T) {
+	isolateHome(t)
+	p := vertexAgentProvider()
+	workspace := t.TempDir()
+	id, cwd, err := p.Materialize(workspace, []NeutralTurn{
+		{Role: "user", Text: "ported question"},
+		{Role: "assistant", Text: "ported answer"},
+	})
+	if err != nil || id == "" || cwd != workspace {
+		t.Fatalf("Materialize: id=%q cwd=%q err=%v", id, cwd, err)
+	}
+	entries, err := p.LoadHistory(id, HistoryOpts{})
+	if err != nil || len(entries) != 2 {
+		t.Fatalf("materialized history: %v %+v", err, entries)
+	}
+	if entries[0].kind != histUser || entries[1].kind != histResponse {
+		t.Errorf("materialized entry kinds wrong: %+v", entries)
+	}
+}
+
+func TestVertexStoreUsesHome(t *testing.T) {
+	home := isolateHome(t)
+	st := vertexStore()
+	root, err := st.root()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(root, home) {
+		t.Errorf("store root %q must live under isolated home %q", root, home)
+	}
+}
+
+func TestVertexMaxOutputTokens(t *testing.T) {
+	// The default model is in the catwalk catalog; the published
+	// default_max_tokens (64000) wins over the fallback.
+	if got := vertexSpec.maxOutputTokens(vertexDefaultModel); got == vertexFallbackMaxOutputTokens {
+		t.Errorf("default model should use the catwalk value, not the fallback: got %d", got)
+	}
+	// Unknown models fall back to the conservative default.
+	if got := vertexSpec.maxOutputTokens("custom-unknown"); got != vertexFallbackMaxOutputTokens {
+		t.Errorf("unknown model must use the fallback budget: %d", got)
+	}
+}
+
+func TestVertexSupportsImages(t *testing.T) {
+	if !vertexSpec.supportsImages(vertexDefaultModel) {
+		t.Error("default model must support images")
+	}
+	if !vertexSpec.supportsImages("unknown-model") {
+		t.Error("unknown model should default to image-capable")
+	}
+}
+
+func TestModelContextLimit_Vertex(t *testing.T) {
+	if got := modelContextLimit(vertexDefaultModel); got != vertexContextWindow {
+		t.Errorf("vertex default limit = %d want %d", got, vertexContextWindow)
+	}
+	if got := modelContextLimit("gemini-3-flash-preview"); got != vertexContextWindow {
+		t.Errorf("gemini-3-flash-preview limit = %d want %d", got, vertexContextWindow)
+	}
+}
+
+func TestVertexModelOptions_FiltersClaude(t *testing.T) {
+	// The Vertex catwalk ships Claude models; the spec must filter
+	// them out so the picker doesn't offer ids with the wrong
+	// reasoning enum.
+	for _, id := range vertexModelOptions {
+		low := strings.ToLower(id)
+		if strings.Contains(low, "claude") || strings.Contains(low, "anthropic") {
+			t.Errorf("vertexModelOptions must filter Claude / anthropic ids, got %q", id)
+		}
+	}
+	// And the Gemini default must still be there.
+	var found bool
+	for _, id := range vertexModelOptions {
+		if id == vertexDefaultModel {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("vertexModelOptions missing default %q: %v", vertexDefaultModel, vertexModelOptions)
+	}
+}

--- a/view.go
+++ b/view.go
@@ -794,6 +794,23 @@ func (m model) View() tea.View {
 					Max: image.Pt(pX+pW, pY+pH),
 				})
 			}
+			if m.configVertexPickerActive {
+				picker := m.viewConfigVertexPicker()
+				pW := lipgloss.Width(picker)
+				pH := lipgloss.Height(picker)
+				pX := (m.width - pW) / 2
+				pY := (m.height - pH) / 2
+				if pX < 0 {
+					pX = 0
+				}
+				if pY < 0 {
+					pY = 0
+				}
+				uv.NewStyledString(picker).Draw(canvas, image.Rectangle{
+					Min: image.Pt(pX, pY),
+					Max: image.Pt(pX+pW, pY+pH),
+				})
+			}
 			if m.configKeybindingsPickerActive {
 				picker := m.viewConfigKeybindingsPicker()
 				pW := lipgloss.Width(picker)


### PR DESCRIPTION
## Summary

Adds two new in-process LLM providers to ask as first-class `agentAPIProvider` specs alongside the existing five (`anthropic`, `openai`, `deepseek`, `kimi`, `minimax`):

- **Google AI Studio** (`googleai`) — API-key auth via `$GOOGLE_API_KEY`, hits the Gemini API (`generativelanguage.googleapis.com`). Default model: `gemini-3.1-pro-preview-customtools` (catwalk default).
- **Vertex AI** (`vertex`) — Project + Location + ADC auth (service account key file via config, `GOOGLE_APPLICATION_CREDENTIALS` env var, or ADC discovery via gcloud / GCE metadata). Default model: `gemini-3.1-pro-preview` with location `global`.

Both appear in the Ctrl+M model picker. Both receive the Brave-backed core `web_search` tool (fantasy's google provider does not expose a `WebSearchTool`).

## Motivation

ask is positioned as a multi-provider coding agent, but it had no first-class path to the Gemini line. Two distinct Google entry points need to work for the project to be useful in the Google ecosystem:

1. **AI Studio** is the API-key path for ad-hoc use and free-tier experimentation — the same shape as DeepSeek/Kimi/MiniMax.
2. **Vertex** is the GCP path for production workloads where the project/region/SA-key triad is mandatory. The standard auth chain in the fantasy upstream is `cc.UseDefaultCredentials()`, which we drive with a per-call `GOOGLE_APPLICATION_CREDENTIALS` env mutation (the simplest workable seam in the v1 cadence — fantasy's google options don't yet expose a `WithCredentials`).

A handful of additional design decisions were made during implementation:

- **Claude-on-Vertex is intentionally out of scope.** Fantasy's google provider transparently delegates model ids containing "anthropic" or "claude" to `anthropic.WithVertex`. Their reasoning enum (`low/medium/high/max`) is incompatible with Gemini's (`minimal/low/medium/high`), so we filter those five Claude ids out of the Vertex `modelOptions`. Users who want Claude on Vertex should use the regular Anthropic provider; surfacing them in the Vertex picker would crash on `StartSession`.
- **`catalogClampEffort` is applied per-model.** `gemini-3.1-pro` rejects `minimal`; `gemini-2.5-pro` has no reasoning levels at all. The spec clamps to the nearest supported value so the user can pick a level and the wire request stays valid.
- **`vertexPrepareCredentials` extracted as a swappable var.** The SA-key path (config → env → ADC discovery) is much easier to test in isolation than driving it through `StartSession` and `google.New`. The seam sits at the natural unit boundary.
- **`/config → Vertex AI` sub-picker** for the project/location/SA-key path trio. Google AI Studio uses the existing inline API-key prompt in the model picker (`providerKeySpecs`); Vertex needs a multi-field editor so it gets its own screen.

## Testing / validation

- `go build ./...` clean.
- `go vet ./...` clean.
- `go test ./...` — all new tests pass.

**New tests added (full kimi-style surface plus Vertex auth chain):**

| File | Coverage |
|------|----------|
| `googleai_test.go` | metadata, settings round-trip, options (effort mapping incl. `minimal`), no-key fail-fast, full session lifecycle (send/kill/resume/Materialize), store-root, max-output-tokens (catalog-driven), image support, `modelContextLimit`. |
| `vertex_test.go` | All of the above plus: `resolveLocation` (config > default), `resolveProject` (config > env > empty), `missing-project` fail-fast, SA-key chain (not-found / parsed / env-fallback / ADC-discovery), Claude-id filter, `vertexPrepareCredentials` env-mutation seam. |
| `config_vertex_test.go` | Picker state machine mirroring `config_websearch_test.go`: global row presence, project/location regex validation, SA-key `expandTilde` + readable-file check, persistence, paste accumulation, invalid input keeps editor open, summary state (`"off"` / `"<project>/global"`). |
| `model_picker_test.go` | Extended with `TestModelPicker_GoogleAIAppearsAsSection`, `TestModelPicker_VertexAppearsAsSection`, `TestModelPicker_VertexNoKeyPrompt` (verifies Vertex picks apply directly without an inline key prompt). |

**Pre-existing test failures (unrelated):**

The full suite has 5 failing tests in `agent_tools_test.go` (`TestAgentTodosTool`, `TestAgentTodosWorkflowGuard_InertWithoutWorkflows`, `TestRequireTodosBeforeEdit`, `TestRequireTodosBeforeWrite`, `TestRequireTodos_AppliesInAllProjects`). These fail on the base branch before any of my changes and concern the two-stage workflow guard in `agent_tools_todos.go`. They are documented in the iteration-1 notes (`ask/plans/Implement-and-validate/1/notes.md`) and are out of scope for this PR.

**Deviations from the original plan (with rationale):**

1. **`vertexPrepareCredentials` extracted** as a swappable var (the plan said to swap `vertexApplyEnv` only). The SA-key path forms a natural unit that is much easier to test in isolation than driving it through `StartSession`. The original `vertexApplyEnv` seam is preserved as the lowest-level test point.
2. **Catwalk-driven `maxOutputTokens` for default models.** The catalog has published `default_max_tokens` for both `gemini-3.1-pro-preview-customtools` (64000) and `gemini-3.1-pro-preview` (64000), so the spec returns those for the defaults; the fallback only kicks in for unknown ids. Tests assert "not the fallback" instead of "equals the fallback" to match the catalog.
3. **`expandTilde` (paths.go:114)** is the path helper, not `expandHome`. Matches the kimi-validator's Correction #5.

**Files changed:**

| File | Change |
|------|--------|
| `googleai.go` / `googleai_test.go` | New — provider spec + tests. |
| `vertex.go` / `vertex_test.go` | New — provider spec + tests (with Claude-id filter + auth chain). |
| `config_vertex.go` / `config_vertex_test.go` | New — `/config → Vertex AI` sub-picker. |
| `config.go` | Add `GoogleAI apiProviderConfig`, `Vertex vertexConfig` (embeds `apiProviderConfig`), `googleaiEnvAPIKey`, `resolveGoogleAIAPIKey`. |
| `provider.go` | Register `googleaiAgentProvider()` and `vertexAgentProvider()`. |
| `model_picker.go` | Add `googleai` to `providerKeySpecs`, add both to `catwalkProviderIDs`. |
| `config_modal.go`, `types.go`, `update.go`, `view.go`, `tabs.go` | Vertex picker state, dispatcher, overlay, paste, supplant. |
| `usage.go` | Gemini + VertexAI catalog lookups in `modelContextLimit`. |
| `model_picker_test.go` | New provider appearance / no-key-prompt tests. |
| `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` | Layout / test-layout / in-process providers / provider-id list updates. |
