### PR TITLE
fix(workflows): restrict loop break to the tail step only

### DIFF
--- a/workflows_run.go
+++ b/workflows_run.go
@@ -277,9 +277,10 @@ func (m model) workflowFinalize(ok bool, reason string) (tea.Model, tea.Cmd) {
 //
 //	any step      · no end_turn → re-prompt the same step (need a summary)
 //	linear        · summary     → record, advance the top-level cursor
-//	loop any      · break       → exit loop now, skip rest of the iteration
+//	loop non-tail · break       → ignored (advances to next inner step)
 //	loop non-tail · else        → run the next inner step (same iteration)
 //	loop tail     · no decision → re-prompt the tail (need continue/break)
+//	loop tail     · break       → exit loop now
 //	loop tail     · continue    → next iteration, or soft-exit on the cap
 func (m model) advanceWorkflowStep(stepErr error) (tea.Model, tea.Cmd) {
 	r := m.workflowRun
@@ -347,9 +348,9 @@ func (m model) advanceWorkflowStep(stepErr error) (tea.Model, tea.Cmd) {
 	// We have a summary: render the inner step's line.
 	m.appendHistory(stepSummaryLine(inner.Name, inner.Provider, inner.Model, sig.summary))
 
-	// Break from any inner step exits the loop immediately, skipping the
-	// rest of the iteration.
-	if sig.decision == workflowLoopBreak {
+	// Break from the tail step exits the loop immediately. Non-tail steps
+	// cannot break the loop; if they pass a decision, it is ignored.
+	if isTail && sig.decision == workflowLoopBreak {
 		r.prevNotesDir = r.currentNotesDir
 		if txt != "" {
 			r.loop.iterationLog = append(r.loop.iterationLog, txt)
@@ -634,8 +635,7 @@ func buildWorkflowStepPrompt(step workflowStep, source workflowSource, prevOutpu
 // endTurnInstructionBlock renders the auto-injected end_turn contract for
 // a step. Every step is told to call end_turn with a summary; a loop step
 // additionally gets the loop framing, and its tail the "you MUST include a
-// decision" clause (a non-tail step is told to break only in the
-// exceptional case the exit goal is already met).
+// decision" clause (a non-tail step is told to omit decision entirely).
 func endTurnInstructionBlock(loop *loopPromptCtx) string {
 	var b strings.Builder
 	if loop != nil {
@@ -656,8 +656,7 @@ func endTurnInstructionBlock(loop *loopPromptCtx) string {
 				"loop's exit goal is met — breaking should be exceptional.")
 		} else {
 			b.WriteString(" You are inside a loop but not its final step, so omit `decision` and let the loop " +
-				"proceed — unless the exit goal is already met and the remaining steps should be skipped, in which " +
-				"case pass `decision=\"break\"` (this should be exceptional).")
+				"proceed.")
 		}
 	}
 	return b.String()

--- a/workflows_run_test.go
+++ b/workflows_run_test.go
@@ -366,23 +366,26 @@ func TestWorkflowLoop_TailBreakExitsToNextStep(t *testing.T) {
 	assertStartStepCmd(t, cmd, m.id)
 }
 
-// TestWorkflowLoop_NonTailBreakSkipsRestOfIteration: a break from a
-// non-tail step exits immediately without running later inner steps.
-func TestWorkflowLoop_NonTailBreakSkipsRestOfIteration(t *testing.T) {
+// TestWorkflowLoop_NonTailBreakIgnored: a break from a
+// non-tail step is ignored, proceeding to the next inner step.
+func TestWorkflowLoop_NonTailBreakIgnored(t *testing.T) {
 	m := loopRunModel(t, loopInner2, 5, 0, 1)
 	m.workflowRun.currentStep.WriteString("early done")
 	m.workflowRun.pendingEndTurn = &endTurnSignal{decision: workflowLoopBreak, summary: "trivial"}
 
 	newM, _ := m.advanceWorkflowStep(nil)
 	r := newM.(model).workflowRun
-	if r.loop != nil {
-		t.Error("non-tail break should exit the loop")
+	if r.loop == nil || r.loop.innerIdx != 1 {
+		t.Fatalf("should advance to inner 1; got %+v", r.loop)
 	}
-	if r.StepIdx != 1 {
-		t.Errorf("StepIdx=%d want 1", r.StepIdx)
+	if r.loop.iteration != 1 {
+		t.Errorf("iteration should stay 1; got %d", r.loop.iteration)
 	}
-	if len(r.stepLog) != 1 || r.stepLog[0] != "early done" {
-		t.Errorf("partial iteration output should be committed; got %+v", r.stepLog)
+	if len(r.loop.iterationLog) != 1 || r.loop.iterationLog[0] != "early done" {
+		t.Errorf("iterationLog=%+v want [early done]", r.loop.iterationLog)
+	}
+	if !wfHistoryHas(newM.(model), "trivial") {
+		t.Errorf("non-tail summary should be rendered")
 	}
 }
 


### PR DESCRIPTION
## Summary

Restrict the `decision="break"` end_turn signal inside workflow loops so only the **tail** (final) inner step can exit the loop. A break decision from any earlier inner step is now ignored, and the runner advances to the next inner step in the same iteration, identical to a normal non-tail proceed.

The change touches three things:

- **`workflows_run.go` — `advanceWorkflowStep`** — the break branch is now gated on `isTail`. Non-tail breaks fall through to the existing non-tail proceed path.
- **`workflows_run.go` — `endTurnInstructionBlock`** — the prompt block for non-tail loop steps no longer tells the model it can pass `decision="break"`; it now only instructs the model to omit `decision` and let the loop proceed. The tail-step block ("you MUST include `decision`") is unchanged.
- **`workflows_run.go` — `advanceWorkflowStep` decision-table doc comment** — refreshed to spell out the new rule.

Tests:

- **Renamed** `TestWorkflowLoop_NonTailBreakSkipsRestOfIteration` → `TestWorkflowLoop_NonTailBreakIgnored` and rewrote its assertions:
  - loop is **not** exited (`r.loop != nil`),
  - `r.loop.innerIdx == 1` (advances to the next inner step),
  - `r.loop.iteration == 1` (same iteration),
  - `r.loop.iterationLog == ["early done"]` (summary recorded into the iteration log),
  - non-tail summary text is rendered into history.

## Motivation

Today any inner step in a workflow loop can break the loop by passing `decision="break"`. That contradicts the loop contract: the exit goal should be evaluated by the **final** inner step, and earlier steps should be able to finish their work without short-circuiting the iteration. The previous behavior was surprising — a non-tail step could abort the loop on a transient judgement call, leaving later inner steps in the iteration unrun. Restricting break to the tail step:

- aligns the runtime with how loop iteration is described in `endTurnInstructionBlock` ("You MUST include `decision`" only applies to the tail),
- prevents one inner step from unilaterally abandoning the iteration's remaining work,
- removes the exceptional-case escape hatch the prompt previously advertised (which the model rarely had good reason to use anyway).

The user-reported scenario was specifically that any inner step could break, and they wanted to tighten that surface so only the tail can.

## Testing / Validation

- `go test ./...` — full suite passes (`ok  github.com/Cidan/ask  29.436s`).
- New test `TestWorkflowLoop_NonTailBreakIgnored` covers the ignored-break path: break from a non-tail step continues to the next inner step in the same iteration.
- Existing loop decision-table tests (`TestWorkflowLoop_*`) continue to pass unchanged, confirming the tail-only break restriction does not regress the tail-break exit path, non-tail proceed, tail no-decision re-prompt, max-iter soft-exit, or iteration bookkeeping.
- `git diff` is scoped to exactly two files: `workflows_run.go` and `workflows_run_test.go`.

## Files changed

- `workflows_run.go`
- `workflows_run_test.go`