### PR TITLE
feat(workflows): redesign step output as spinner header + markdown summary

### DIFF
--- a/config_modal.go
+++ b/config_modal.go
@@ -666,7 +666,7 @@ func (m model) closeThemePicker() model {
 func (m *model) invalidateThemedRender() {
 	for i := range m.history {
 		switch m.history[i].kind {
-		case histResponse, histUser:
+		case histResponse, histUser, histWorkflowDone:
 			invalidateEntryRender(&m.history[i])
 		}
 	}

--- a/themes.go
+++ b/themes.go
@@ -519,6 +519,9 @@ var (
 	themePickerHelpStyle  lipgloss.Style
 	themePickerRowStyle   lipgloss.Style
 
+	workflowMarginStyle lipgloss.Style
+	workflowStepStyle   lipgloss.Style
+
 	themeBackground color.Color
 	themeForeground color.Color
 	activeTheme     theme
@@ -637,6 +640,9 @@ func applyTheme(t theme) {
 	themePickerTitleStyle = lipgloss.NewStyle().Foreground(t.accent).Bold(true)
 	themePickerHelpStyle = lipgloss.NewStyle().Foreground(t.dim)
 	themePickerRowStyle = lipgloss.NewStyle().Foreground(t.darkFG).Background(t.accent).Bold(true)
+
+	workflowMarginStyle = lipgloss.NewStyle().Foreground(t.accentAlt).Bold(true)
+	workflowStepStyle = lipgloss.NewStyle().MarginLeft(5)
 
 }
 

--- a/types.go
+++ b/types.go
@@ -218,12 +218,14 @@ const (
 	histPrerendered historyKind = iota
 	histResponse
 	histUser
+	histWorkflowDone
 )
 
 type historyEntry struct {
-	kind     historyKind
-	text     string
-	rendered string
+	kind           historyKind
+	text           string
+	rendered       string
+	workflowHeader string
 
 	// wrapped is the soft-wrapped slice of rendered lines for the
 	// width recorded in wrappedFor. It is the only thing chatView

--- a/view.go
+++ b/view.go
@@ -233,7 +233,7 @@ func (m *model) ensureEntryWrapped(idx, width int) {
 	e := &m.history[idx]
 	if e.wrappedFor != width {
 		switch e.kind {
-		case histResponse, histUser:
+		case histResponse, histUser, histWorkflowDone:
 			e.rendered = ""
 		}
 	}
@@ -243,6 +243,12 @@ func (m *model) ensureEntryWrapped(idx, width int) {
 	}
 	if needsRender {
 		switch e.kind {
+		case histWorkflowDone:
+			if m.renderer == nil || m.rendererWidth != width {
+				m.renderer = newRenderer(width)
+				m.rendererWidth = width
+			}
+			e.rendered = e.workflowHeader + "\n" + m.renderResponse(e.text)
 		case histResponse:
 			if m.renderer == nil || m.rendererWidth != width {
 				m.renderer = newRenderer(width)
@@ -454,9 +460,24 @@ func (m *model) blankChatFrame(contentH int) string {
 	return m.chat.style.Render(strings.Repeat("\n", max(0, contentH-1)))
 }
 
+func (m model) renderWorkflowActiveLine() string {
+	name, provider, mdl := currentWorkflowStepMeta(m.workflowRun)
+	meta := providerMeta(provider, mdl)
+	line := m.spinner.View() + " " +
+		workflowMarginStyle.Render("|") + " " +
+		promptStyle.Render("▸ "+nonEmpty(name, "step"))
+	if meta != "" {
+		line += dimStyle.Render(" (" + meta + ")")
+	}
+	return workflowStepStyle.Render(line)
+}
+
 func (m model) spinnerLine() string {
 	if m.shellMode {
 		return thinkingStyle.Render(promptStyle.Render("▸ Shell Mode"))
+	}
+	if r := m.workflowRun; r != nil && !r.done && !r.failed {
+		return m.renderWorkflowActiveLine()
 	}
 	if !m.busy {
 		return ""
@@ -469,7 +490,7 @@ func (m model) spinnerLine() string {
 }
 
 func (m model) spinnerBlockHeight() int {
-	if m.shellMode || m.busy {
+	if m.shellMode || m.busy || (m.workflowRun != nil && !m.workflowRun.done && !m.workflowRun.failed) {
 		return 2
 	}
 	return 0
@@ -1282,19 +1303,14 @@ func (m model) renderWorkflowBanner() string {
 // step that hasn't registered a loop decision.
 func (m model) workflowRunningBannerLines(sourceLabel, cancelClause string) (title, line2 string) {
 	r := m.workflowRun
-	stepName := "(unnamed)"
-	stepProvider := ""
-	stepModel := ""
-	stepLabel := ""
+	stepName, stepProvider, stepModel := currentWorkflowStepMeta(r)
+	if stepName == "" {
+		stepName = "(unnamed)"
+	}
+	stepLabel := stepName
 	if r.StepIdx < len(r.Workflow.Steps) {
 		top := r.Workflow.Steps[r.StepIdx]
 		if r.loop != nil && top.isLoop() && r.loop.innerIdx < len(top.Steps) {
-			inner := top.Steps[r.loop.innerIdx]
-			if inner.Name != "" {
-				stepName = inner.Name
-			}
-			stepProvider = inner.Provider
-			stepModel = inner.Model
 			loopName := top.Name
 			if loopName == "" {
 				loopName = "loop"
@@ -1305,12 +1321,6 @@ func (m model) workflowRunningBannerLines(sourceLabel, cancelClause string) (tit
 				stepLabel += fmt.Sprintf(" · re-prompt #%d", r.loop.retry)
 			}
 		} else {
-			if top.Name != "" {
-				stepName = top.Name
-			}
-			stepProvider = top.Provider
-			stepModel = top.Model
-			stepLabel = stepName
 			if r.linearRetry > 0 {
 				stepLabel += fmt.Sprintf(" · re-prompt #%d", r.linearRetry)
 			}

--- a/workflows_run.go
+++ b/workflows_run.go
@@ -9,6 +9,18 @@ import (
 	tea "charm.land/bubbletea/v2"
 )
 
+func currentWorkflowStepMeta(r *workflowRunState) (name, provider, model string) {
+	if r == nil || r.StepIdx < 0 || r.StepIdx >= len(r.Workflow.Steps) {
+		return "", "", ""
+	}
+	top := r.Workflow.Steps[r.StepIdx]
+	if r.loop != nil && top.isLoop() && r.loop.innerIdx < len(top.Steps) {
+		inner := top.Steps[r.loop.innerIdx]
+		return inner.Name, inner.Provider, inner.Model
+	}
+	return top.Name, top.Provider, top.Model
+}
+
 // workflowTabHandleKey gates input on a workflow tab. The user
 // cannot type a turn — there is no chat input on a workflow tab —
 // but they can still scroll the chat viewport to read streaming
@@ -312,7 +324,7 @@ func (m model) advanceWorkflowStep(stepErr error) (tea.Model, tea.Cmd) {
 			return m.dispatchOrFinalize()
 		}
 		// Got the summary: render the step's line, record output, advance.
-		m.appendHistory(stepSummaryLine(step.Name, step.Provider, step.Model, sig.summary))
+		m.appendWorkflowStepDone(step.Name, step.Provider, step.Model, sig.summary)
 		if err := revalidateWorkflowNotesDir(m.cwd, m.worktreeName, r); err != nil {
 			r.remind = remindFixPlanDir
 			r.remindDetail = err.Error()
@@ -346,7 +358,7 @@ func (m model) advanceWorkflowStep(stepErr error) (tea.Model, tea.Cmd) {
 	}
 
 	// We have a summary: render the inner step's line.
-	m.appendHistory(stepSummaryLine(inner.Name, inner.Provider, inner.Model, sig.summary))
+	m.appendWorkflowStepDone(inner.Name, inner.Provider, inner.Model, sig.summary)
 
 	// Break from the tail step exits the loop immediately. Non-tail steps
 	// cannot break the loop; if they pass a decision, it is ignored.
@@ -700,20 +712,22 @@ func loopNoteLine(loopName, action, detail string) string {
 	return workflowNoteLine(fmt.Sprintf("⟳ loop %q %s", loopName, action), detail)
 }
 
-// stepSummaryLine renders a completed step's entry in the workflow log: a
+// appendWorkflowStepDone renders a completed step's entry in the workflow log: a
 // styled "▸ name (provider/model)" header with the agent's end_turn
 // summary beneath it. This per-step content is what replaces the raw
 // transcript on a workflow tab. The summary is not pre-wrapped; the
 // viewport soft-wraps it at render time.
-func stepSummaryLine(name, provider, model, summary string) string {
-	header := promptStyle.Render("▸ " + nonEmpty(name, "step"))
-	if meta := providerMeta(provider, model); meta != "" {
+func (m *model) appendWorkflowStepDone(name, provider, mdl, summary string) {
+	header := "   " + workflowMarginStyle.Render("|") + " " +
+		promptStyle.Render("▸ "+nonEmpty(name, "step"))
+	if meta := providerMeta(provider, mdl); meta != "" {
 		header += dimStyle.Render(" (" + meta + ")")
 	}
-	if s := strings.TrimSpace(summary); s != "" {
-		header += "\n" + outputStyle.Render("  " + s)
-	}
-	return header
+	m.history = append(m.history, historyEntry{
+		kind:           histWorkflowDone,
+		text:           summary,
+		workflowHeader: workflowStepStyle.Render(header),
+	})
 }
 
 // providerMeta renders the "provider/model" suffix shown next to a step

--- a/workflows_run_test.go
+++ b/workflows_run_test.go
@@ -654,30 +654,115 @@ func TestBuildWorkflowStepPrompt_EndTurnInstructions(t *testing.T) {
 	}
 }
 
-// TestStepSummaryLine renders the per-step log entry: name, provider/model
-// meta, and the agent's summary. The summary must NOT be pre-wrapped — the
-// viewport soft-wraps it at render time, so stepSummaryLine returns it as a
-// single unbroken rendered string.
-func TestStepSummaryLine(t *testing.T) {
-	summary := "This is a very long summary that would absolutely wrap under the old narrow width-based logic and must remain a single unbroken rendered string"
-	got := stepSummaryLine("review", "codex", "gpt-5", summary)
+func TestCurrentWorkflowStepMeta(t *testing.T) {
+	name, provider, mdl := currentWorkflowStepMeta(nil)
+	if name != "" || provider != "" || mdl != "" {
+		t.Errorf("expected empty strings for nil run, got %q, %q, %q", name, provider, mdl)
+	}
+
+	run := &workflowRunState{
+		Workflow: workflowDef{
+			Steps: []workflowStep{
+				{Name: "step1", Provider: "p1", Model: "m1"},
+				{
+					Name: "loop1", Kind: "loop", Steps: []workflowStep{
+						{Name: "inner1", Provider: "p2", Model: "m2"},
+					},
+				},
+			},
+		},
+	}
+
+	run.StepIdx = -1
+	name, provider, mdl = currentWorkflowStepMeta(run)
+	if name != "" || provider != "" || mdl != "" {
+		t.Errorf("expected empty strings for out of bounds step, got %q, %q, %q", name, provider, mdl)
+	}
+
+	run.StepIdx = 2
+	name, provider, mdl = currentWorkflowStepMeta(run)
+	if name != "" || provider != "" || mdl != "" {
+		t.Errorf("expected empty strings for out of bounds step, got %q, %q, %q", name, provider, mdl)
+	}
+
+	run.StepIdx = 0
+	name, provider, mdl = currentWorkflowStepMeta(run)
+	if name != "step1" || provider != "p1" || mdl != "m1" {
+		t.Errorf("expected step1, p1, m1, got %q, %q, %q", name, provider, mdl)
+	}
+
+	run.StepIdx = 1
+	run.loop = &loopRunFrame{innerIdx: 0}
+	name, provider, mdl = currentWorkflowStepMeta(run)
+	if name != "inner1" || provider != "p2" || mdl != "m2" {
+		t.Errorf("expected inner1, p2, m2, got %q, %q, %q", name, provider, mdl)
+	}
+
+	run.loop.innerIdx = 1 // out of bounds inner
+	name, provider, mdl = currentWorkflowStepMeta(run)
+	if name != "loop1" || provider != "" || mdl != "" { // falls back to top step
+		t.Errorf("expected fallback to loop step, got %q, %q, %q", name, provider, mdl)
+	}
+}
+
+func TestRenderWorkflowActiveLine(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m.workflowRun = &workflowRunState{
+		Workflow: workflowDef{
+			Name: "test-flow",
+			Steps: []workflowStep{
+				{Name: "step1", Provider: "p1", Model: "m1"},
+			},
+		},
+		StepIdx: 0,
+	}
+	line := m.spinnerLine()
+	if !strings.Contains(line, "|") {
+		t.Errorf("expected active line to contain |, got %q", line)
+	}
+	if !strings.Contains(line, "step1") {
+		t.Errorf("expected active line to contain step1, got %q", line)
+	}
+}
+
+func TestEnsureEntryWrapped_WorkflowDone(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m.appendWorkflowStepDone("step1", "p1", "m1", "**bold** summary")
+	if len(m.history) == 0 {
+		t.Fatal("expected history entry")
+	}
+	m.ensureEntryWrapped(0, 80)
+	e := &m.history[0]
+	if e.rendered == "" {
+		t.Error("expected rendered text to be populated")
+	}
+	if !strings.Contains(e.rendered, "|") || !strings.Contains(e.rendered, "step1") {
+		t.Errorf("expected rendered text to contain header, got %q", e.rendered)
+	}
+	if !strings.Contains(e.rendered, "bold") || !strings.Contains(e.rendered, "summary") { // glamour adds ANSI between words
+		t.Errorf("expected rendered text to contain rendered markdown, got %q", e.rendered)
+	}
+}
+
+// TestAppendWorkflowStepDone appends the per-step log entry to history: kind histWorkflowDone,
+// text = summary, and workflowHeader populated.
+func TestAppendWorkflowStepDone(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	summary := "This is a very long summary"
+	m.appendWorkflowStepDone("review", "codex", "gpt-5", summary)
+	if len(m.history) == 0 {
+		t.Fatal("expected history entry")
+	}
+	e := m.history[len(m.history)-1]
+	if e.kind != histWorkflowDone {
+		t.Errorf("expected kind histWorkflowDone, got %v", e.kind)
+	}
+	if e.text != summary {
+		t.Errorf("expected text %q, got %q", summary, e.text)
+	}
 	for _, want := range []string{"review", "codex/gpt-5"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("summary line missing %q; got %q", want, got)
-		}
-	}
-	if !strings.Contains(got, summary) {
-		t.Errorf("full summary text must appear verbatim; got %q", got)
-	}
-	// No hard newline should break a word in the summary body. Splitting on
-	// newlines and looking for the summary header line (which starts with "▸")
-	// vs the summary body line — the body line must carry the full text.
-	for _, ln := range strings.Split(got, "\n") {
-		if strings.HasPrefix(ln, "▸") {
-			continue
-		}
-		if strings.Contains(ln, "summary") && !strings.Contains(ln, summary) {
-			t.Errorf("summary body line contains a fragment but not the full text — hard-wrapped; line=%q", ln)
+		if !strings.Contains(e.workflowHeader, want) {
+			t.Errorf("header missing %q; got %q", want, e.workflowHeader)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Workflow tabs previously rendered a single pre-formatted line per completed step (`stepSummaryLine`). The header sat inline with raw assistant text and the summary sat underneath with no visual relation to chat responses, which made a multi-step run read as a stream of disconnected lines.

This PR splits the active and completed states:

- **Active step** renders as a transient line above the input banner: `[spinner] | ▸ Step Name (provider/model)`. It lives **outside** `m.history` so spinner ticks do not invalidate the viewport cache or re-render the markdown pipeline.
- **Completed step** appends a new `histWorkflowDone` history entry. Its `workflowHeader` carries the colored `|` margin and `▸ name`, and its `text` flows through `m.renderResponse` so the summary is full-glossy markdown at the same 5-column indent as a normal chat response.

Shared metadata helper `currentWorkflowStepMeta` deduplicates the step-name/provider/model extraction between the active line and the running banner (also resolves the inner-loop step when applicable).

## Motivation

A workflow tab transcript previously looked nothing like the chat tab: a bare `▸ step (provider/model)` line followed by plain raw text with two-space indent. Users running a 3-step workflow could not distinguish step boundaries from generic output, and the active step had no visual presence at all until it completed. The only signal was the bottom banner.

The redesign:

1. **Visual continuity with chat** - completed steps now look exactly like assistant responses (same 5-column indent, full-glossy markdown tables/code blocks), so a workflow run reads as a conversation.
2. **Distinct step boundary** - the colored `|` margin marks step output without intruding on the summary itself.
3. **Spinner efficiency** - keeping the active line in `spinnerLine()` (the existing transient status area) instead of pushing a `historyEntry` per tick avoids re-wrapping the whole transcript every 33ms. `contentFingerprint()` does not include the spinner frame, so the viewport cache stays warm.
4. **Resize correctness** - adding `histWorkflowDone` to the width-invalidation switch in `ensureEntryWrapped` (and to `invalidateThemedRender` for theme changes) means tables and code blocks in a step summary re-flow correctly on terminal resize and theme switch, just like `histResponse`.

## Files changed

| File | Purpose |
|---|---|
| `themes.go` | New `workflowMarginStyle` (accentAlt, bold) and `workflowStepStyle` (MarginLeft 5) - same indent as `outputStyle`. |
| `types.go` | New `histWorkflowDone` history kind + `workflowHeader string` field on `historyEntry`. |
| `view.go` | New `renderWorkflowActiveLine`; wired into `spinnerLine`/`spinnerBlockHeight`; `ensureEntryWrapped` renders `histWorkflowDone` through `renderResponse` and invalidates it on width change; refactored `workflowRunningBannerLines` to share `currentWorkflowStepMeta`. |
| `workflows_run.go` | New `currentWorkflowStepMeta` shared helper; new `appendWorkflowStepDone` replaces `stepSummaryLine` and appends a typed history entry instead of a pre-rendered string. |
| `config_modal.go` | `invalidateThemedRender` now also invalidates `histWorkflowDone` entries on theme change. |
| `workflows_run_test.go` | Replaced `TestStepSummaryLine` (helper deleted) with `TestCurrentWorkflowStepMeta`, `TestRenderWorkflowActiveLine`, `TestEnsureEntryWrapped_WorkflowDone`, and `TestAppendWorkflowStepDone`. |

## Testing

- `go test ./...` - full suite passes.
- `go vet ./...` - clean.
- `go build ./...` - clean.

New behavioral coverage:

- **`TestCurrentWorkflowStepMeta`** - nil run, out-of-bounds step, top-level step, inner-loop step, and out-of-bounds inner fallback to the loop own name.
- **`TestRenderWorkflowActiveLine`** - running a workflow tab produces a `spinnerLine()` containing the colored `|` and the step name.
- **`TestEnsureEntryWrapped_WorkflowDone`** - a `histWorkflowDone` entry `rendered` is populated, contains the header (`|` + step name) AND the markdown-emitted summary (glamour adds ANSI between bold tokens and surrounding words, so the substring assertion covers that path).
- **`TestAppendWorkflowStepDone`** - kind, text, and `workflowHeader` shape (name + `provider/model`) on the new entry.

## Acceptance criteria

- `go test ./...` passes.
- Active workflow step displays only `[spinner] | ▸ Step Name (provider/model)` above the banner.
- Completed step shows the colored `|` header followed by the markdown summary with a 5-column left indent.
- Spinner tick does not invalidate the viewport cache.
- No streaming assistant text appears in the workflow tab transcript (workflow tabs already stream into `m.status`, which the banner consumes - unchanged from before).
