### PR TITLE
feat(ask): add Ctrl+l planning mode that blocks file edits and workflows

### DIFF
--- a/agent_prompt.go
+++ b/agent_prompt.go
@@ -176,6 +176,13 @@ func buildAgentSystemPrompt(args ProviderSessionArgs) string {
 
 	b.WriteString("\n\n")
 	b.WriteString(steeringPromptFor(args))
+
+	if args.PlanningMode {
+		b.WriteString("\n\n<planning_mode>\n")
+		b.WriteString("PLANNING MODE IS ON. You are currently restricted to exploring the codebase and conversing with the user. You MUST NOT attempt to mutate any files, run mutating commands, or launch workflows. Any tools that modify state will be blocked. Guide the user and outline a plan, but do not execute it.\n")
+		b.WriteString("</planning_mode>")
+	}
+
 	return b.String()
 }
 

--- a/agent_provider.go
+++ b/agent_provider.go
@@ -177,7 +177,7 @@ func (p agentAPIProvider) StartSession(args ProviderSessionArgs) (*providerProc,
 		session.sessionID = newUUIDv4()
 	}
 
-	session.env = newAgentToolEnv(args.Cwd, args.TabID, args.SkipAllPermissions, cfg.UI.GateTodosBeforeMutate != nil && *cfg.UI.GateTodosBeforeMutate, session.emit)
+	session.env = newAgentToolEnv(args.Cwd, args.TabID, args.SkipAllPermissions, cfg.UI.GateTodosBeforeMutate != nil && *cfg.UI.GateTodosBeforeMutate, args.PlanningMode, session.emit)
 	setupAgentSessionTools(session, cfg)
 
 	proc := &providerProc{

--- a/agent_run_test.go
+++ b/agent_run_test.go
@@ -117,7 +117,7 @@ func newTestAgentSession(t *testing.T, lm *fakeLM, store *agentSessionStore) *ag
 		sessionID:     "ses-test",
 		store:         store,
 	}
-	s.env = newAgentToolEnv(s.args.Cwd, 1, true, true, s.emit)
+	s.env = newAgentToolEnv(s.args.Cwd, 1, true, true, false, s.emit)
 	s.tools = []fantasy.AgentTool{
 		fantasy.NewAgentTool("ping", "test echo tool",
 			func(_ context.Context, in struct {

--- a/agent_tools.go
+++ b/agent_tools.go
@@ -69,14 +69,16 @@ type agentToolEnv struct {
 	// editing. When the gate is false (default), this flag is unused.
 	// Guarded by wfMu.
 	todosApplied bool
+	planningMode bool
 }
 
-func newAgentToolEnv(cwd string, tabID int, skipPermissions bool, gateTodosBeforeMutate bool, emit func(tea.Msg)) *agentToolEnv {
+func newAgentToolEnv(cwd string, tabID int, skipPermissions bool, gateTodosBeforeMutate bool, planningMode bool, emit func(tea.Msg)) *agentToolEnv {
 	env := &agentToolEnv{
 		cwd:                   cwd,
 		tabID:                 tabID,
 		skipPermissions:       skipPermissions,
 		gateTodosBeforeMutate: gateTodosBeforeMutate,
+		planningMode:          planningMode,
 		emit:                  emit,
 		files:                 newAgentFileTracker(),
 		jobs:                  newAgentJobManager(),

--- a/agent_tools_file.go
+++ b/agent_tools_file.go
@@ -121,6 +121,9 @@ func agentWriteTool(env *agentToolEnv) fantasy.AgentTool {
 		"write",
 		agentWriteToolDescription,
 		func(ctx context.Context, p agentWriteParams, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			if env.planningMode {
+				return fantasy.NewTextResponse("Planning mode is ON. File modifications are currently blocked."), nil
+			}
 			if strings.TrimSpace(p.FilePath) == "" {
 				return fantasy.NewTextErrorResponse("file_path is required"), nil
 			}
@@ -199,6 +202,9 @@ func agentEditTool(env *agentToolEnv) fantasy.AgentTool {
 		"edit",
 		agentEditToolDescription,
 		func(ctx context.Context, p agentEditParams, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			if env.planningMode {
+				return fantasy.NewTextResponse("Planning mode is ON. File modifications are currently blocked."), nil
+			}
 			if strings.TrimSpace(p.FilePath) == "" {
 				return fantasy.NewTextErrorResponse("file_path is required"), nil
 			}

--- a/agent_tools_registry_test.go
+++ b/agent_tools_registry_test.go
@@ -327,7 +327,7 @@ func toolNames(tools []fantasy.AgentTool) []string {
 func TestSetupAgentSessionTools_RegistrySurface(t *testing.T) {
 	isolateHome(t)
 	s := &agentSession{args: ProviderSessionArgs{Cwd: t.TempDir(), TabID: 1}}
-	s.env = newAgentToolEnv(s.args.Cwd, 1, true, true, func(tea.Msg) {})
+	s.env = newAgentToolEnv(s.args.Cwd, 1, true, true, false, func(tea.Msg) {})
 	setupAgentSessionTools(s, askConfig{})
 
 	wire := map[string]bool{}
@@ -381,7 +381,7 @@ func TestSetupAgentSessionTools_WebSearchSelection(t *testing.T) {
 
 	// No native search → Brave core tool on the wire, no provider tool.
 	noNative := &agentSession{args: ProviderSessionArgs{Cwd: t.TempDir(), TabID: 1}}
-	noNative.env = newAgentToolEnv(noNative.args.Cwd, 1, true, true, func(tea.Msg) {})
+	noNative.env = newAgentToolEnv(noNative.args.Cwd, 1, true, true, false, func(tea.Msg) {})
 	setupAgentSessionTools(noNative, askConfig{})
 	wire := map[string]bool{}
 	for _, name := range toolNames(noNative.currentTools()) {
@@ -402,7 +402,7 @@ func TestSetupAgentSessionTools_WebSearchSelection(t *testing.T) {
 		},
 	}
 	native := &agentSession{args: ProviderSessionArgs{Cwd: t.TempDir(), TabID: 2}, spec: spec}
-	native.env = newAgentToolEnv(native.args.Cwd, 2, true, true, func(tea.Msg) {})
+	native.env = newAgentToolEnv(native.args.Cwd, 2, true, true, false, func(tea.Msg) {})
 	setupAgentSessionTools(native, askConfig{})
 	for _, name := range toolNames(native.currentTools()) {
 		if name == "web_search" {

--- a/agent_tools_test.go
+++ b/agent_tools_test.go
@@ -25,7 +25,7 @@ func newTestToolEnv(t *testing.T) (*agentToolEnv, *[]tea.Msg) {
 	t.Helper()
 	var mu sync.Mutex
 	msgs := &[]tea.Msg{}
-	env := newAgentToolEnv(t.TempDir(), 1, true, true, func(m tea.Msg) {
+	env := newAgentToolEnv(t.TempDir(), 1, true, true, false, func(m tea.Msg) {
 		mu.Lock()
 		defer mu.Unlock()
 		*msgs = append(*msgs, m)
@@ -820,7 +820,7 @@ func TestAgentTodosWorkflowGuard(t *testing.T) {
 	}
 
 	var msgs []tea.Msg
-	env := newAgentToolEnv(cwd, 1, true, true, func(m tea.Msg) { msgs = append(msgs, m) })
+	env := newAgentToolEnv(cwd, 1, true, true, false, func(m tea.Msg) { msgs = append(msgs, m) })
 	if !env.workflowsAvailable {
 		t.Fatal("env.workflowsAvailable should be true when the project defines a workflow")
 	}
@@ -873,7 +873,7 @@ func TestAgentTodosWorkflowGuard_DisarmedByCheck(t *testing.T) {
 		t.Fatalf("saveAllWorkflows: %v", err)
 	}
 	var msgs []tea.Msg
-	env := newAgentToolEnv(cwd, 1, true, true, func(m tea.Msg) { msgs = append(msgs, m) })
+	env := newAgentToolEnv(cwd, 1, true, true, false, func(m tea.Msg) { msgs = append(msgs, m) })
 
 	// Calling the workflow_list core tool disarms the first-stage
 	// guard. After the workflow tools were promoted to the core wire
@@ -939,7 +939,7 @@ func TestAgentTodosWorkflowGuard_DisarmedByRun(t *testing.T) {
 		t.Fatalf("saveAllWorkflows: %v", err)
 	}
 	var msgs []tea.Msg
-	env := newAgentToolEnv(cwd, 1, true, true, func(m tea.Msg) { msgs = append(msgs, m) })
+	env := newAgentToolEnv(cwd, 1, true, true, false, func(m tea.Msg) { msgs = append(msgs, m) })
 
 	// workflow_run dispatches into a fresh tab via the swap, so the
 	// test runs without a real tea.Program wired.
@@ -1282,7 +1282,7 @@ func TestWorkflowGuard_GateOff_Inert(t *testing.T) {
 		t.Fatalf("saveAllWorkflows: %v", err)
 	}
 	var msgs []tea.Msg
-	env := newAgentToolEnv(cwd, 1, true, true, func(m tea.Msg) { msgs = append(msgs, m) })
+	env := newAgentToolEnv(cwd, 1, true, true, false, func(m tea.Msg) { msgs = append(msgs, m) })
 	env.gateTodosBeforeMutate = false
 	if !env.workflowsAvailable {
 		t.Fatal("env.workflowsAvailable should be true when project defines workflows")
@@ -1319,7 +1319,7 @@ func TestWorkflowGuard_GateOn_Fires(t *testing.T) {
 		t.Fatalf("saveAllWorkflows: %v", err)
 	}
 	var msgs []tea.Msg
-	env := newAgentToolEnv(cwd, 1, true, true, func(m tea.Msg) { msgs = append(msgs, m) })
+	env := newAgentToolEnv(cwd, 1, true, true, false, func(m tea.Msg) { msgs = append(msgs, m) })
 	env.gateTodosBeforeMutate = true
 	if !env.workflowsAvailable {
 		t.Fatal("env.workflowsAvailable should be true")
@@ -1344,7 +1344,7 @@ func TestWorkflowGuard_GateOn_Fires(t *testing.T) {
 func TestGateTodosBeforeMutate_EnvDefaultFalse(t *testing.T) {
 	cwd := t.TempDir()
 	var msgs []tea.Msg
-	env := newAgentToolEnv(cwd, 1, true, false, func(m tea.Msg) { msgs = append(msgs, m) })
+	env := newAgentToolEnv(cwd, 1, true, false, false, func(m tea.Msg) { msgs = append(msgs, m) })
 	if env.gateTodosBeforeMutate {
 		t.Error("gateTodosBeforeMutate should default to false")
 	}
@@ -1429,5 +1429,31 @@ func TestAgentJobAppendOutput(t *testing.T) {
 	}
 	if strings.HasSuffix(out, "more") {
 		t.Error("post-cap append must not write to the buffer")
+	}
+}
+
+func TestPlanningMode_AgentTools(t *testing.T) {
+	isolateHome(t)
+	env, _ := newTestToolEnv(t)
+	env.planningMode = true
+
+	write := agentWriteTool(env)
+	resp := runTool(t, write, agentWriteParams{FilePath: "x.txt", Content: "data"})
+	if resp.IsError || !strings.Contains(resp.Content, "Planning mode is ON") {
+		t.Errorf("write in planning mode: %q", resp.Content)
+	}
+
+	edit := agentEditTool(env)
+	resp = runTool(t, edit, agentEditParams{FilePath: "x.txt", OldString: "a", NewString: "b"})
+	if resp.IsError || !strings.Contains(resp.Content, "Planning mode is ON") {
+		t.Errorf("edit in planning mode: %q", resp.Content)
+	}
+
+	run := workflowToolByName(t, env, "workflow_run")
+	if r, _ := run.Run(context.Background(), fantasy.ToolCall{
+		ID: "1", Name: "workflow_run",
+		Input: `{"name":"ship-it","append":"plan"}`,
+	}); r.IsError || !strings.Contains(r.Content, "Planning mode is ON") {
+		t.Errorf("workflow_run in planning mode: %q", r.Content)
 	}
 }

--- a/agent_tools_workflow.go
+++ b/agent_tools_workflow.go
@@ -74,6 +74,15 @@ func agentWorkflowTools(env *agentToolEnv) []fantasy.AgentTool {
 			}),
 		nativeBridgeTool("workflow_run", workflowRunToolDescription,
 			func(_ context.Context, in workflowRunInput) (*mcp.CallToolResult, workflowRunOutput, error) {
+				if env.planningMode {
+					return &mcp.CallToolResult{
+						Content: []mcp.Content{
+							&mcp.TextContent{
+								Text: "Planning mode is ON. Workflows are currently blocked.",
+							},
+						},
+					}, workflowRunOutput{}, nil
+				}
 				env.markWorkflowsChecked()
 				env.markWorkflowRunDispatched()
 				return workflowRunCore(cwd(), env.tabID, in)

--- a/agent_tools_workflow_test.go
+++ b/agent_tools_workflow_test.go
@@ -315,7 +315,7 @@ func TestAgentWorkflowTools_DisarmHooksFire(t *testing.T) {
 	}
 	// env must point at the seeded cwd so workflow_run resolves
 	// "ship-it" (env.cwd is the only place workflow tools look).
-	env := newAgentToolEnv(cwd, 1, true, true, func(tea.Msg) {})
+	env := newAgentToolEnv(cwd, 1, true, true, false, func(tea.Msg) {})
 
 	list := workflowToolByName(t, env, "workflow_list")
 	if r, _ := list.Run(context.Background(), fantasy.ToolCall{ID: "1", Name: "workflow_list", Input: `{}`}); r.IsError {

--- a/keymap.go
+++ b/keymap.go
@@ -55,6 +55,7 @@ const (
 	// model.wantsTabKey.
 	ActionSidebarFocus Action = "sidebar.focus"
 	ActionAppSuspend   Action = "app.suspend"
+	ActionPlanningMode Action = "app.planningMode"
 )
 
 // KeyBinding is a parsed Mod+Code pair. The zero value (Mod==0,
@@ -253,6 +254,7 @@ var defaultKeyBindings = map[Action]KeyBinding{
 	ActionTabNextAlt:   {Mod: tea.ModCtrl, Code: tea.KeyDown},
 	ActionSidebarFocus: {Code: tea.KeyTab},
 	ActionAppSuspend:   {Mod: tea.ModCtrl, Code: 'z'},
+	ActionPlanningMode: {Mod: tea.ModCtrl, Code: 'l'},
 }
 
 func init() {
@@ -371,6 +373,7 @@ var actionGroups = []actionMetaGroup{
 	}},
 	{Heading: "App", Items: []actionMetaItem{
 		{ActionAppSuspend, "Suspend ask"},
+		{ActionPlanningMode, "Planning mode"},
 	}},
 }
 

--- a/mcp_workflows_test.go
+++ b/mcp_workflows_test.go
@@ -979,7 +979,7 @@ func TestWorkflowNative_EditDecodesStepsJSON(t *testing.T) {
 		Name:  "alpha",
 		Steps: []workflowStep{{Name: "old", Provider: "fake"}},
 	}})
-	env := newAgentToolEnv(cwd, 1, true, true, nil)
+	env := newAgentToolEnv(cwd, 1, true, true, false, nil)
 	var tool fantasy.AgentTool
 	for _, bt := range agentWorkflowTools(env) {
 		if bt.Info().Name == "workflow_edit" {

--- a/proc.go
+++ b/proc.go
@@ -31,6 +31,7 @@ func (m model) sessionArgs() ProviderSessionArgs {
 		SkipAllPermissions: m.skipAllPermissions,
 		Worktree:           m.worktree,
 		ResumeCwd:          m.resumeCwd,
+		PlanningMode:       m.planningMode,
 		AddedDirs:          append([]string(nil), m.addedDirs...),
 		ProjectMCP:         projectGitHubMCP(m.cwd),
 	}

--- a/provider.go
+++ b/provider.go
@@ -217,6 +217,7 @@ type ProviderSessionArgs struct {
 	SessionID          string
 	NewSessionID       string
 	ResumeCwd          string
+	PlanningMode       bool
 	// AddedDirs are absolute paths the user has registered with /add-dir.
 	// Providers translate these into their native equivalents (claude:
 	// --add-dir; codex: sandbox_workspace_write.writable_roots). The

--- a/types.go
+++ b/types.go
@@ -376,6 +376,7 @@ type model struct {
 	// providerDoneMsg; cleared by /new and /clear.
 	virtualSessionID string
 	busy             bool
+	planningMode     bool
 	width            int
 	height           int
 

--- a/update.go
+++ b/update.go
@@ -1232,6 +1232,17 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 			}
 			return m.switchScreen(screenAsk), nil
 		}
+		if km.Matches(ActionPlanningMode, msg) && !m.modalOpen() && !deferToPopover {
+			m.planningMode = !m.planningMode
+			state := "OFF"
+			if m.planningMode {
+				state = "ON"
+			}
+			m.killProc()
+			m.sessionID = ""
+			m.sessionMinted = false
+			return m, m.toast.show("Planning mode: " + state)
+		}
 		newM, cmd, _ := m.activeScreen().updateKey(m, msg)
 		return newM, cmd
 


### PR DESCRIPTION
## Summary

Adds a per-tab **planning mode** toggle (default `Ctrl+l`, remappable via `/config → Keybindings`) that flips the LLM into an explore-and-dialogue posture:

- Mutating tools (`write`, `edit`, `workflow_run`) return a non-error text refusal when planning mode is on, so the model can read the block and continue the conversation.
- The coder system prompt gains a `<planning_mode>` block that instructs the model to guide the user and outline a plan rather than execute one.
- Toggling mid-session kills the in-flight provider and clears `sessionID` so the next query rebuilds the system prompt authoritatively.
- A toast ("Planning mode: ON" / "OFF") confirms the toggle.
- State is per-tab (lives on `model`, not global) so users can have a planning tab and an executing tab open side-by-side.

## Motivation

When sketching a feature, debugging an unknown system, or bouncing ideas off the LLM, the user frequently wants the model to *think with them* rather than start mutating files. Today the only way to stop a runaway edit session is to interrupt mid-flight and explain — which is friction-heavy and leaks the user's intent into the model's context as a complaint. A first-class UI toggle:

1. Makes the explore-only posture explicit on both sides of the wire (system prompt + tool refusals).
2. Lets the user flip back to execution mode without losing the planning conversation — same tab, same transcript.
3. Avoids the "model asks, user says yes, model proceeds inline anyway" failure mode by making the refusal a non-error text response the model sees and can react to.

## Implementation

| File | Change |
|------|--------|
| `keymap.go` | New `ActionPlanningMode` action; default `Ctrl+l`; added to `actionGroups["App"]` |
| `types.go` | `planningMode bool` on `model` (per-tab) |
| `update.go` | Toggle on `Ctrl+l`; toast; `killProc()` + clear `sessionID` so the next turn rebuilds the system prompt |
| `proc.go` / `provider.go` | Thread `PlanningMode` through `ProviderSessionArgs` |
| `agent_provider.go` | Pass `args.PlanningMode` into `newAgentToolEnv` |
| `agent_tools.go` | `planningMode bool` on `agentToolEnv`, threaded through constructor |
| `agent_prompt.go` | Append `<planning_mode>` system-prompt block when `args.PlanningMode` is true |
| `agent_tools_file.go` | `write`/`edit` return non-error refusal in planning mode |
| `agent_tools_workflow.go` | `workflow_run` returns non-error `mcp.TextContent` refusal (not error), so the model keeps dialoguing |

### Key design choices

- **Non-error refusal.** `write`/`edit` use `fantasy.NewTextResponse` (not `NewTextErrorResponse`), and `workflow_run` returns a successful `mcp.CallToolResult` carrying the refusal text. An error response would terminate the turn and force the user to send another message; a non-error response lets the model read the block and immediately propose a plan or ask a clarifying question.
- **Session rebuild on toggle.** The system prompt is byte-stable for DeepSeek prefix caching, so editing it mid-session is hostile. The toggle kills the proc and clears `sessionID`; the next user turn spins up a fresh session with the new prompt — same approach as `/new` or a provider swap.
- **Per-tab state.** `planningMode` lives on `model`, not globally, so users can have an exploration tab next to an execution tab.
- **No self-disable.** No tool lets the model turn planning mode off — only the user can.

## Testing

### Automated

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — passes (full suite, ~29s)
- New test `TestPlanningMode_AgentTools` in `agent_tools_test.go` exercises the three blocking paths:
  - `write` → `Planning mode is ON. File modifications are currently blocked.`
  - `edit` → same
  - `workflow_run` → `Planning mode is ON. Workflows are currently blocked.`
- Existing `newAgentToolEnv` callers updated for the new `planningMode` parameter (test wiring only).
- `TestDefaultKeyMap_CoversAllActions` inherently pins `ActionPlanningMode` (no separate keymap test required).

### Manual

Recommended follow-up smoke test in a TUI session:
1. Open a fresh tab, hit `Ctrl+l`, observe the toast.
2. Send a planning message — verify the LLM is informed and offers a plan.
3. Ask it to "just do it" — verify `write`/`edit` calls come back with the refusal text and the LLM continues the dialogue rather than running the tool.
4. Hit `Ctrl+l` again, observe the toast, send a follow-up — verify normal execution resumes.

## Risks / Follow-ups

- **Resume after toggle:** A resumed session is built from the stored transcript, so the planning-mode block would be lost if the user toggles ON and then `/resume`s. The current implementation only rebuilds the prompt for the next *fresh* session; documented limitation, low-priority follow-up.
- **Key conflict:** `Ctrl+l` was unbound; no conflict.
- **In-flight turn:** Toggling while a turn is running does not interrupt it; the change applies to the next turn. `killProc` already cleans up safely.