### PR TITLE
feat(ask): add bold blue [ planning ] chip next to worktree chip

### DIFF
--- a/themes.go
+++ b/themes.go
@@ -452,6 +452,7 @@ var (
 	outputStyle      lipgloss.Style
 	thinkingStyle    lipgloss.Style
 	chipStyle        lipgloss.Style
+	planningChipStyle lipgloss.Style
 	scrollThumbStyle lipgloss.Style
 	scrollTrackStyle lipgloss.Style
 	thumbBorderStyle lipgloss.Style
@@ -546,6 +547,7 @@ func applyTheme(t theme) {
 	outputStyle = lipgloss.NewStyle().MarginLeft(5)
 	thinkingStyle = lipgloss.NewStyle().MarginLeft(3)
 	chipStyle = lipgloss.NewStyle().MarginLeft(3).Foreground(t.accent).Bold(true)
+	planningChipStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Bold(true)
 	scrollThumbStyle = lipgloss.NewStyle().Foreground(t.dim)
 	scrollTrackStyle = lipgloss.NewStyle().Foreground(t.scrollTrack)
 	thumbBorderStyle = lipgloss.NewStyle().Foreground(t.accentAlt)

--- a/view.go
+++ b/view.go
@@ -1455,20 +1455,23 @@ func (m model) statusChipHeight() int {
 // upward and never recovered.
 func (m model) worktreeChip() string {
 	var parts []string
+	if m.planningMode {
+		parts = append(parts, planningChipStyle.Render("[ planning ]"))
+	}
 	if m.worktreeName != "" {
-		parts = append(parts, "[🌳 "+m.worktreeName+"]")
+		parts = append(parts, dimStyle.Render("[🌳 "+m.worktreeName+"]"))
 	}
 	if n := len(m.bgTasks); n > 0 {
 		label := "agent"
 		if n != 1 {
 			label = "agents"
 		}
-		parts = append(parts, fmt.Sprintf("[%d background %s active]", n, label))
+		parts = append(parts, dimStyle.Render(fmt.Sprintf("[%d background %s active]", n, label)))
 	}
 	if len(parts) == 0 {
 		return ""
 	}
-	return dimStyle.Render(strings.Join(parts, "  "))
+	return strings.Join(parts, "  ")
 }
 
 // providerChip is the right-anchored status badge: current provider ID,


### PR DESCRIPTION
## Summary

Adds a bright-blue `[ planning ]` chip to the status row when Ctrl+l planning mode is active, sitting just to the left of the existing worktree chip (and the background-tasks chip when present). The chip is bold and uses ANSI color 12 (bright blue, matching the prompt color for theme consistency) so it stands out from the dim styling of its neighbors.

The change is small and tightly scoped:

- `themes.go`: new package-level `planningChipStyle` variable, initialized in `applyTheme()` to `lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Bold(true)`.
- `view.go`: `worktreeChip()` no longer wraps the entire joined string in `dimStyle`. Instead, each chip is rendered with its own style — the planning chip uses `planningChipStyle`, while the worktree and background-tasks chips keep `dimStyle`. Parts are still joined with two spaces (`"  "`).

## Motivation

PR #73 introduced the Ctrl+l planning-mode toggle that puts the LLM into an explore-and-dialogue posture where `write`, `edit`, and `workflow_run` refuse to mutate state. The user has no way to see, at a glance in the status row, whether planning mode is currently active — the only feedback is a system-prompt block the model sees, plus a one-shot toast on toggle. The toast disappears in a few seconds and the system prompt is invisible to the user, so it's easy to forget the toggle is on and be confused when an edit is silently refused.

A persistent visual indicator in the same status row as the worktree chip solves this with a single, immediately-recognizable affordance. Because the chip shares the row with the worktree and background-tasks chips, the styling had to be split: `worktreeChip()` used to apply `dimStyle` to the whole joined string, which would have leaked onto the new chip. The refactor to per-part rendering keeps the planning chip bold blue while leaving the existing chips at their original dim styling.

## Testing / Validation

- `go build ./...` — fails with `package main` collision because the workflow-created `ask/plans/` directory shadows the default binary name `ask`. The package itself compiles cleanly with an explicit output path (e.g. `go build -o /tmp/ask .`), so this is an environmental artifact of the workflow tooling, not a code regression.
- `go vet ./...` — clean.
- `go test ./...` — `ok  github.com/Cidan/ask  31.749s` (full suite green).
- The change is rendering-only and the existing test suite is behavior-only (no view-string assertions), so no new tests were added; existing tests pass unchanged.
- Manual TUI exercise remains the user's responsibility per `CLAUDE.md` ("TUI-level feature changes must still be exercised by the user; code alone won't catch layout regressions").