### PR TITLE
fix(ask): preserve session when toggling planning mode

### DIFF
--- a/update.go
+++ b/update.go
@@ -1239,8 +1239,6 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 				state = "ON"
 			}
 			m.killProc()
-			m.sessionID = ""
-			m.sessionMinted = false
 			return m, m.toast.show("Planning mode: " + state)
 		}
 		newM, cmd, _ := m.activeScreen().updateKey(m, msg)

--- a/update_test.go
+++ b/update_test.go
@@ -1731,3 +1731,22 @@ func TestUpdate_PasteMsgInConfigWithoutEditorIsAbsorbed(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdate_ActionPlanningModePreservesSession(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m.sessionID = "test-session-123"
+	m.sessionMinted = true
+	m.planningMode = false
+
+	m2, _ := runUpdate(t, m, tea.KeyPressMsg{Mod: tea.ModCtrl, Code: 'l'})
+
+	if m2.sessionID != "test-session-123" {
+		t.Errorf("expected sessionID to be preserved, got %q", m2.sessionID)
+	}
+	if m2.sessionMinted {
+		t.Errorf("expected sessionMinted to be cleared by killProc")
+	}
+	if !m2.planningMode {
+		t.Errorf("expected planningMode to be true")
+	}
+}


### PR DESCRIPTION
Fixes a bug where toggling planning mode would destructively clear the active session ID, causing the conversation history to be lost. Instead, we now just kill the provider proc so it respawns with the updated system prompt, preserving the session.