### PR TITLE
Fix workflow output alignment in chat

### DIFF
--- a/view.go
+++ b/view.go
@@ -248,7 +248,11 @@ func (m *model) ensureEntryWrapped(idx, width int) {
 				m.renderer = newRenderer(width)
 				m.rendererWidth = width
 			}
-			e.rendered = e.workflowHeader + "\n" + m.renderResponse(e.text)
+			if e.workflowHeader != "" {
+				e.rendered = e.workflowHeader + "\n" + m.renderResponse(e.text)
+			} else {
+				e.rendered = m.renderResponse(e.text)
+			}
 		case histResponse:
 			if m.renderer == nil || m.rendererWidth != width {
 				m.renderer = newRenderer(width)
@@ -460,26 +464,11 @@ func (m *model) blankChatFrame(contentH int) string {
 	return m.chat.style.Render(strings.Repeat("\n", max(0, contentH-1)))
 }
 
-func (m model) renderWorkflowActiveLine() string {
-	name, provider, mdl := currentWorkflowStepMeta(m.workflowRun)
-	meta := providerMeta(provider, mdl)
-	line := m.spinner.View() + " " +
-		workflowMarginStyle.Render("|") + " " +
-		promptStyle.Render("▸ "+nonEmpty(name, "step"))
-	if meta != "" {
-		line += dimStyle.Render(" (" + meta + ")")
-	}
-	return workflowStepStyle.Render(line)
-}
-
 func (m model) spinnerLine() string {
 	if m.shellMode {
 		return thinkingStyle.Render(promptStyle.Render("▸ Shell Mode"))
 	}
-	if r := m.workflowRun; r != nil && !r.done && !r.failed {
-		return m.renderWorkflowActiveLine()
-	}
-	if !m.busy {
+	if !m.busy && (m.workflowRun == nil || m.workflowRun.done || m.workflowRun.failed) {
 		return ""
 	}
 	s := m.status

--- a/workflows_run.go
+++ b/workflows_run.go
@@ -149,6 +149,15 @@ func (m model) startWorkflowStep() (tea.Model, tea.Cmd) {
 		step = top.Steps[r.loop.innerIdx]
 	}
 
+	if r.remind == remindNone {
+		header := "   " + workflowMarginStyle.Render("|") + " " +
+			promptStyle.Render("▸ "+nonEmpty(step.Name, "step"))
+		if meta := providerMeta(step.Provider, step.Model); meta != "" {
+			header += dimStyle.Render(" (" + meta + ")")
+		}
+		m.appendHistory(header)
+	}
+
 	if m.worktreeName == "" && m.worktree && worktreeBackendAt(m.cwd) != workspaceBackendNone {
 		m.worktreeName = newWorktreeName(m.cwd)
 	}
@@ -712,21 +721,14 @@ func loopNoteLine(loopName, action, detail string) string {
 	return workflowNoteLine(fmt.Sprintf("⟳ loop %q %s", loopName, action), detail)
 }
 
-// appendWorkflowStepDone renders a completed step's entry in the workflow log: a
-// styled "▸ name (provider/model)" header with the agent's end_turn
-// summary beneath it. This per-step content is what replaces the raw
-// transcript on a workflow tab. The summary is not pre-wrapped; the
-// viewport soft-wraps it at render time.
+// appendWorkflowStepDone renders a completed step's entry in the workflow log.
+// The summary is not pre-wrapped; the viewport soft-wraps it at render time.
+// The step title (header) is emitted exactly once when the step starts.
 func (m *model) appendWorkflowStepDone(name, provider, mdl, summary string) {
-	header := "   " + workflowMarginStyle.Render("|") + " " +
-		promptStyle.Render("▸ "+nonEmpty(name, "step"))
-	if meta := providerMeta(provider, mdl); meta != "" {
-		header += dimStyle.Render(" (" + meta + ")")
-	}
 	m.history = append(m.history, historyEntry{
 		kind:           histWorkflowDone,
 		text:           summary,
-		workflowHeader: workflowStepStyle.Render(header),
+		workflowHeader: "",
 	})
 }
 

--- a/workflows_run_test.go
+++ b/workflows_run_test.go
@@ -716,12 +716,10 @@ func TestRenderWorkflowActiveLine(t *testing.T) {
 		},
 		StepIdx: 0,
 	}
+	m.status = "executing bash"
 	line := m.spinnerLine()
-	if !strings.Contains(line, "|") {
-		t.Errorf("expected active line to contain |, got %q", line)
-	}
-	if !strings.Contains(line, "step1") {
-		t.Errorf("expected active line to contain step1, got %q", line)
+	if !strings.Contains(line, "executing bash") {
+		t.Errorf("expected active line to contain status, got %q", line)
 	}
 }
 
@@ -736,8 +734,8 @@ func TestEnsureEntryWrapped_WorkflowDone(t *testing.T) {
 	if e.rendered == "" {
 		t.Error("expected rendered text to be populated")
 	}
-	if !strings.Contains(e.rendered, "|") || !strings.Contains(e.rendered, "step1") {
-		t.Errorf("expected rendered text to contain header, got %q", e.rendered)
+	if strings.Contains(e.rendered, "|") || strings.Contains(e.rendered, "step1") {
+		t.Errorf("expected rendered text to NOT contain header, got %q", e.rendered)
 	}
 	if !strings.Contains(e.rendered, "bold") || !strings.Contains(e.rendered, "summary") { // glamour adds ANSI between words
 		t.Errorf("expected rendered text to contain rendered markdown, got %q", e.rendered)
@@ -745,7 +743,7 @@ func TestEnsureEntryWrapped_WorkflowDone(t *testing.T) {
 }
 
 // TestAppendWorkflowStepDone appends the per-step log entry to history: kind histWorkflowDone,
-// text = summary, and workflowHeader populated.
+// text = summary, and workflowHeader empty.
 func TestAppendWorkflowStepDone(t *testing.T) {
 	m := newTestModel(t, newFakeProvider())
 	summary := "This is a very long summary"
@@ -760,10 +758,8 @@ func TestAppendWorkflowStepDone(t *testing.T) {
 	if e.text != summary {
 		t.Errorf("expected text %q, got %q", summary, e.text)
 	}
-	for _, want := range []string{"review", "codex/gpt-5"} {
-		if !strings.Contains(e.workflowHeader, want) {
-			t.Errorf("header missing %q; got %q", want, e.workflowHeader)
-		}
+	if e.workflowHeader != "" {
+		t.Errorf("expected empty header, got %q", e.workflowHeader)
 	}
 }
 


### PR DESCRIPTION
### Summary of Changes
- Removed \`renderWorkflowActiveLine()\` logic from \`view.go\` so the spinner correctly falls back to showing live tool output during workflow execution.
- Modified \`startWorkflowStep()\` in \`workflows_run.go\` to append the step title directly to the chat history when it starts, perfectly aligning with user-typed messages (3 spaces, 1-char border, 1-space padding).
- Updated \`appendWorkflowStepDone()\` to only append the step summary and no longer prepend the title (by setting \`workflowHeader: ""\`), avoiding redundant output.
- Adjusted \`workflows_run_test.go\` to assert the new layout and behavior.

### Motivation
The Step Title was previously rendered in the bottom status bar, replacing live tool logs during workflow runs. By moving it into the main chat history at the start of a step, we restore visibility of active tool execution in the status bar while creating a cleaner, chat-aligned visual log of workflow steps.

### Testing Performed
- Validated UI rendering manually (verified exact vertical bar alignment with user input).
- Ran \`go vet ./...\` which completed with no issues.
- Ran \`go test ./...\` verifying that all unit tests pass, and updated tests matching the new history rendering format.
- Compiled successfully via \`go build -o /tmp/ask .\`.