### PR TITLE
Render question-modal answers as Markdown in chat UI

### DIFF
--- a/ask_question.go
+++ b/ask_question.go
@@ -451,33 +451,55 @@ func (m model) submitAsk() (model, tea.Cmd) {
 		m.askReply <- askReply{answers: m.askAnswers}
 		m.status = "thinking…"
 	}
-	m.appendHistory(renderAskHistorySummary(m.askQuestions, m.askAnswers))
+	m.appendResponse(renderAskHistorySummary(m.askQuestions, m.askAnswers))
 	return m.clearAsk(), nil
 }
 
 func renderAskHistorySummary(questions []question, answers []qAnswer) string {
 	var b strings.Builder
-	b.WriteString(promptStyle.Render("✓ answered"))
+	b.WriteString("### ✓ answered\n")
 	for i, q := range questions {
 		b.WriteString("\n")
-		b.WriteString(dimStyle.Render(fmt.Sprintf("%d. ", i+1)))
-		b.WriteString(q.prompt)
-		b.WriteString("\n   → ")
-		b.WriteString(renderAnswerSummary(q, answers[i]))
+		b.WriteString(fmt.Sprintf("%d. %s  \n", i+1, q.prompt))
+		b.WriteString("↳ ")
+		b.WriteString(renderAnswerSummaryMarkdown(q, answers[i]))
 		if note := answers[i].note; note != "" {
-			b.WriteString("\n   ")
+			b.WriteString("  \n")
+			b.WriteString("**note:** ")
 			noteLines := strings.Split(note, "\n")
 			for j, ln := range noteLines {
-				if j == 0 {
-					b.WriteString(askNoteLabelStyle.Render("note: "))
-				} else {
-					b.WriteString("\n         ")
+				if j > 0 {
+					b.WriteString("  \n")
 				}
 				b.WriteString(ln)
 			}
 		}
 	}
-	return outputStyle.Render(b.String())
+	return b.String()
+}
+
+func renderAnswerSummaryMarkdown(q question, ans qAnswer) string {
+	if len(ans.picks) == 0 {
+		return "*(no answer)*"
+	}
+	picked := make([]string, 0, len(ans.picks))
+	customIdx := len(q.options) - 1
+	isCustom := strings.EqualFold(q.options[customIdx], switcherCustomRowLabel)
+	for i, opt := range q.options {
+		if !ans.picks[i] {
+			continue
+		}
+		if isCustom && i == customIdx {
+			if ans.custom != "" {
+				picked = append(picked, fmt.Sprintf("%q", ans.custom))
+			} else {
+				picked = append(picked, "*(custom, empty)*")
+			}
+		} else {
+			picked = append(picked, opt)
+		}
+	}
+	return strings.Join(picked, ", ")
 }
 
 func renderAnswerSummary(q question, ans qAnswer) string {

--- a/ask_question_test.go
+++ b/ask_question_test.go
@@ -508,3 +508,98 @@ func TestIsCustomOption(t *testing.T) {
 		t.Error("question with no custom row should NOT be flagged")
 	}
 }
+
+func TestRenderAskHistorySummary_Markdown(t *testing.T) {
+	qs := []question{
+		{prompt: "What is your quest?", options: []string{"a"}},
+		{prompt: "What is your favorite color?", options: []string{"blue"}},
+	}
+	ans := []qAnswer{
+		{picks: map[int]bool{0: true}},
+		{picks: map[int]bool{0: true}, note: "Yellow\nNo wait!"},
+	}
+	got := renderAskHistorySummary(qs, ans)
+	
+	// Assert no ANSI escapes
+	if strings.Contains(got, "\x1b[") {
+		t.Errorf("history summary contains ANSI escapes: %q", got)
+	}
+
+	wantSubstrings := []string{
+		"### ✓ answered\n",
+		"1. What is your quest?  \n",
+		"↳ a",
+		"2. What is your favorite color?  \n",
+		"↳ blue  \n",
+		"**note:** Yellow  \n",
+		"No wait!",
+	}
+	for _, sub := range wantSubstrings {
+		if !strings.Contains(got, sub) {
+			t.Errorf("summary missing %q; got:\n%s", sub, got)
+		}
+	}
+}
+
+func TestRenderAnswerSummaryMarkdown(t *testing.T) {
+	q := question{
+		options: []string{"opt1", "opt2", switcherCustomRowLabel},
+	}
+
+	t.Run("no answer", func(t *testing.T) {
+		got := renderAnswerSummaryMarkdown(q, qAnswer{picks: map[int]bool{}})
+		if got != "*(no answer)*" {
+			t.Errorf("got %q want *(no answer)*", got)
+		}
+	})
+	t.Run("single pick", func(t *testing.T) {
+		got := renderAnswerSummaryMarkdown(q, qAnswer{picks: map[int]bool{0: true}})
+		if got != "opt1" {
+			t.Errorf("got %q want opt1", got)
+		}
+	})
+	t.Run("multiple picks", func(t *testing.T) {
+		got := renderAnswerSummaryMarkdown(q, qAnswer{picks: map[int]bool{0: true, 1: true}})
+		if got != "opt1, opt2" {
+			t.Errorf("got %q want opt1, opt2", got)
+		}
+	})
+	t.Run("custom populated", func(t *testing.T) {
+		got := renderAnswerSummaryMarkdown(q, qAnswer{
+			picks:  map[int]bool{2: true},
+			custom: "my \"custom\" value",
+		})
+		want := `"my \"custom\" value"`
+		if got != want {
+			t.Errorf("got %q want %q", got, want)
+		}
+	})
+	t.Run("custom empty", func(t *testing.T) {
+		got := renderAnswerSummaryMarkdown(q, qAnswer{
+			picks: map[int]bool{2: true},
+		})
+		if got != "*(custom, empty)*" {
+			t.Errorf("got %q want *(custom, empty)*", got)
+		}
+	})
+}
+
+func TestSubmitAsk_AppendsResponseEntry(t *testing.T) {
+	m, reply := newAskModel(t)
+	m = m.startAsk([]question{{kind: qPickOne, prompt: "Q", options: []string{"a"}}})
+	m.askAnswers[0].picks[0] = true
+	m.askTab = 1 // confirm
+	got, _ := m.submitAsk()
+
+	if len(got.history) == 0 {
+		t.Fatal("history empty")
+	}
+	last := got.history[len(got.history)-1]
+	if last.kind != histResponse {
+		t.Errorf("history kind=%v want histResponse", last.kind)
+	}
+	if !strings.Contains(last.text, "### ✓ answered") {
+		t.Errorf("history text missing markdown heading; got: %q", last.text)
+	}
+	_ = reply
+}


### PR DESCRIPTION
### Summary
Changes \`submitAsk()\` to store the answered-question summary as \`histResponse\` instead of \`histPrerendered\` and updates the format to be Markdown. This allows the chat UI to render the modal answers using the Glamour Markdown renderer, properly wrapping long text.

### Motivation
Previously, the answered question summary was rendered as raw ANSI-styled text, which didn't properly word-wrap long questions or answers in the chat UI. Emitting Markdown and routing it through the standard \`histResponse\` path fixes line wrapping and spacing, providing a more consistent and robust user experience.

### Testing/Validation
- Added unit tests (\`TestRenderAskHistorySummary_Markdown\`, \`TestRenderAnswerSummaryMarkdown\`, \`TestSubmitAsk_AppendsResponseEntry\`) in \`ask_question_test.go\` validating the correct Markdown output and history entry type.
- Full suite passes cleanly via \`go test ./...\`.