### PR TITLE
feat: Add keyboard shortcuts for graceful workflow completions/failures

### DIFF
--- a/view.go
+++ b/view.go
@@ -1266,17 +1266,20 @@ func (m model) renderWorkflowBanner() string {
 			sourceLabel,
 			fmt.Sprintf("step %d", r.StepIdx+1),
 			reason,
+			"r to retry",
 			returnClause,
 			closeClause,
 		))
 	case r.done:
 		box = box.BorderForeground(activeTheme.accent)
 		title = promptStyle.Render("✓ workflow complete: ") + r.Workflow.Name
+		if returnClause == "" {
+			returnClause = "enter to close"
+		}
 		line2 = dimStyle.Render(joinHintClauses(
 			sourceLabel,
 			fmt.Sprintf("%d step(s)", len(r.Workflow.Steps)),
 			returnClause,
-			closeClause,
 		))
 	default:
 		box = box.BorderForeground(activeTheme.accent)

--- a/workflows_run.go
+++ b/workflows_run.go
@@ -29,16 +29,33 @@ func currentWorkflowStepMeta(r *workflowRunState) (name, provider, model string)
 // press can't bleed into the chain.
 func (m model) workflowTabHandleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if currentKeyMap().Matches(ActionTabClose, msg) {
+		if r := m.workflowRun; r != nil && (r.done || r.failed) {
+			if r.supplanted != nil {
+				return m.restoreSupplantedTab()
+			}
+			return m, closeTabCmd(m.id)
+		}
 		return m, closeTabCmd(m.id)
 	}
 	// Enter on a finished supplanted run hands the tab back to the
 	// conversation it took over. Dedicated workflow tabs have nothing
-	// underneath — Enter stays absorbed.
+	// underneath — Enter closes them.
 	if msg.Mod == 0 && msg.Code == tea.KeyEnter {
-		if r := m.workflowRun; r != nil && (r.done || r.failed) && r.supplanted != nil {
-			return m.restoreSupplantedTab()
+		if r := m.workflowRun; r != nil && (r.done || r.failed) {
+			if r.supplanted != nil {
+				return m.restoreSupplantedTab()
+			}
+			return m, closeTabCmd(m.id)
 		}
 		return m, nil
+	}
+	if msg.Mod == 0 && msg.Code == 'r' {
+		if r := m.workflowRun; r != nil && r.failed {
+			r.failed = false
+			r.failedReason = ""
+			workflowTracker().markWorking(m.cwd, r.Source.Key(), r.Workflow.Name, m.id)
+			return m, workflowStartStepCmd(m.id)
+		}
 	}
 	if msg.Mod == tea.ModCtrl && msg.Code == 'c' {
 		// Ctrl+C on a running workflow tab cancels the chain — the


### PR DESCRIPTION
### Summary of Changes
- Added 'r' keyboard shortcut to retry a failed workflow without restarting from the beginning.
- Adjusted tab closing behavior: 'Ctrl+D' and 'Enter' on completed or failed workflows will now correctly restore the supplanted chat tab, or close the tab if it is standalone.
- Updated UI banner text to indicate 'r to retry' on failed states and 'enter to close' on standalone completed workflows.

### Motivation
When a workflow fails, restarting from the beginning can be frustrating if only the current step needs retrying. Furthermore, when a workflow completes (either successfully or with failure), users need intuitive keyboard navigation (\`Ctrl+D\` and \`Enter\`) to gracefully close the workflow tab or return to the original chat tab that spawned it.

### Testing/Validation
- Tested locally by validating the \`go test ./...\` test suite which runs flawlessly.
- Verified that \`r\` successfully restarts a failed step without exiting the workflow or restarting from step 1.
- Validated that \`Ctrl+D\` and \`Enter\` both restore the chat (if supplanted) or close the tab (if standalone) when a workflow finishes.