### PR TITLE
feat: implement finish_workflow tool and enforce on final step

### DIFF
--- a/agent_provider.go
+++ b/agent_provider.go
@@ -233,6 +233,9 @@ func setupAgentSessionTools(s *agentSession, cfg askConfig) {
 		agentSearchToolsTool(s.deferredTools),
 		agentInvokeToolTool(s.deferredTools, s.isCoreToolName, env),
 	}
+	if s.args.IsWorkflowFinalStep {
+		s.coreTools = append(s.coreTools, agentFinishWorkflowTool(env))
+	}
 	// The ask-built-in workflow tools (workflow_list/get/create/edit/
 	// delete/copy/run + clear_plans) are deliberate core exceptions —
 	// the two-stage workflow guard forces the model to call

--- a/agent_tools_ask.go
+++ b/agent_tools_ask.go
@@ -94,6 +94,38 @@ func agentAskUserQuestionTool(env *agentToolEnv) fantasy.AgentTool {
 	)
 }
 
+type agentFinishWorkflowParams struct {
+	Description string   `json:"description" description:"required: summary of the workflow outcome"`
+	Artifacts   []string `json:"artifacts,omitempty" description:"list of created/modified artifacts (e.g. PR link). If a PR was created, it MUST be a part of the artifacts"`
+}
+
+// agentFinishWorkflowTool is the tool to be called at the end of a workflow
+// to provide the final outcome and artifacts.
+func agentFinishWorkflowTool(env *agentToolEnv) fantasy.AgentTool {
+	return fantasy.NewAgentTool(
+		"finish_workflow",
+		"Report the final outcome and artifacts of the workflow. REQUIRED on the final step.",
+		func(ctx context.Context, p agentFinishWorkflowParams, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			desc := strings.TrimSpace(p.Description)
+			if desc == "" {
+				return fantasy.NewTextErrorResponse("description is required: provide a summary of the workflow outcome"), nil
+			}
+
+			if !agentSendToProgram(finishWorkflowSignalMsg{
+				tabID: env.tabID,
+				data: &finishWorkflowData{
+					Description: desc,
+					Artifacts:   p.Artifacts,
+				},
+			}) {
+				return fantasy.NewTextErrorResponse("ask UI not ready"), nil
+			}
+
+			return fantasy.NewTextResponse("finish_workflow recorded. Now call end_turn to complete the step."), nil
+		},
+	)
+}
+
 type agentEndTurnParams struct {
 	Summary  string `json:"summary" description:"required: 1-3 sentence summary of what you did this step (and what remains), recorded as this step's line in the workflow log"`
 	Decision string `json:"decision,omitempty" enum:",continue,break" description:"loop control, required only on the final step of a loop iteration: 'continue' to run another iteration or 'break' to end the loop; omit when not the final step of a loop"`

--- a/agent_tools_ask_test.go
+++ b/agent_tools_ask_test.go
@@ -108,3 +108,46 @@ func TestAgentEndTurnTool(t *testing.T) {
 		t.Errorf("bad decision should error: %+v", resp)
 	}
 }
+
+func TestAgentFinishWorkflowTool(t *testing.T) {
+	env, _ := newTestToolEnv(t)
+	env.tabID = 4
+	tool := agentFinishWorkflowTool(env)
+
+	captured := swapProgramSend(t, func(msg tea.Msg) bool {
+		sig, ok := msg.(finishWorkflowSignalMsg)
+		if !ok {
+			t.Fatalf("unexpected msg type %T", msg)
+		}
+		if sig.tabID != 4 {
+			t.Errorf("tabID=%d want 4", sig.tabID)
+		}
+		if sig.data.Description != "done" {
+			t.Errorf("Description=%q want done", sig.data.Description)
+		}
+		if len(sig.data.Artifacts) != 1 || sig.data.Artifacts[0] != "PR: #123" {
+			t.Errorf("Artifacts=%+v want [PR: #123]", sig.data.Artifacts)
+		}
+		return true
+	})
+
+	resp := runTool(t, tool, agentFinishWorkflowParams{
+		Description: "done",
+		Artifacts:   []string{"PR: #123"},
+	})
+	if resp.IsError {
+		t.Fatalf("finish_workflow error: %s", resp.Content)
+	}
+	if !strings.Contains(resp.Content, "finish_workflow recorded. Now call end_turn to complete the step.") {
+		t.Errorf("unexpected success reply: %q", resp.Content)
+	}
+	if len(*captured) != 1 {
+		t.Errorf("expected 1 message, got %d", len(*captured))
+	}
+
+	// Test missing description validation
+	resp = runTool(t, tool, agentFinishWorkflowParams{})
+	if !resp.IsError || !strings.Contains(resp.Content, "description is required") {
+		t.Errorf("expected validation error for empty description, got: %+v", resp)
+	}
+}

--- a/provider.go
+++ b/provider.go
@@ -218,6 +218,7 @@ type ProviderSessionArgs struct {
 	NewSessionID       string
 	ResumeCwd          string
 	PlanningMode       bool
+	IsWorkflowFinalStep bool
 	// AddedDirs are absolute paths the user has registered with /add-dir.
 	// Providers translate these into their native equivalents (claude:
 	// --add-dir; codex: sandbox_workspace_write.writable_roots). The

--- a/types.go
+++ b/types.go
@@ -339,6 +339,16 @@ type workflowRunStepDoneMsg struct {
 	err   error
 }
 
+type finishWorkflowData struct {
+	Description string   `json:"description"`
+	Artifacts   []string `json:"artifacts"`
+}
+
+type finishWorkflowSignalMsg struct {
+	tabID int
+	data  *finishWorkflowData
+}
+
 // startupResumeMsg is fired by Init when the model was pre-seeded with
 // a virtualSessionID by `ask resume <vid>` on the CLI. It's the same
 // trigger as picking the row from the /resume picker — Update routes it
@@ -793,6 +803,9 @@ type workflowRunState struct {
 	// user left it (restoreSupplantedTab). Nil on a dedicated
 	// workflow tab — there is nothing underneath to return to.
 	supplanted *workflowTabSnapshot
+
+	// finishData holds the result of the finish_workflow tool call.
+	finishData *finishWorkflowData
 }
 
 // workflowTabSnapshot is the pre-run state of a chat tab a workflow

--- a/update.go
+++ b/update.go
@@ -839,6 +839,15 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 	case workflowRunStepDoneMsg:
 		return m.workflowRunHandleStepDone(msg)
 
+	case finishWorkflowSignalMsg:
+		if msg.tabID != m.id {
+			return m, nil
+		}
+		if r := m.workflowRun; r != nil && !r.done && !r.failed {
+			r.finishData = msg.data
+		}
+		return m, nil
+
 	case endTurnSignalMsg:
 		return m.handleEndTurnSignal(msg)
 

--- a/workflows_run.go
+++ b/workflows_run.go
@@ -197,11 +197,12 @@ func (m model) startWorkflowStep() (tea.Model, tea.Cmd) {
 	}
 	r.currentNotesDir = notesDir
 	pc := &stepPromptCtx{
-		remind:       r.remind,
-		remindDetail: r.remindDetail,
-		notesDir:     notesDir,
-		prevNotesDir: r.prevNotesDir,
-		isStartStep:  isStartStep || isLoopStartStep,
+		remind:              r.remind,
+		remindDetail:        r.remindDetail,
+		notesDir:            notesDir,
+		prevNotesDir:        r.prevNotesDir,
+		isStartStep:         isStartStep || isLoopStartStep,
+		isWorkflowFinalStep: r.StepIdx == len(r.Workflow.Steps)-1,
 	}
 	if r.loop != nil {
 		pc.loop = &loopPromptCtx{
@@ -284,7 +285,20 @@ func (m model) workflowFinalize(ok bool, reason string) (tea.Model, tea.Cmd) {
 	if ok {
 		r.done = true
 		workflowTracker().markFinal(m.cwd, r.Source.Key(), r.Workflow.Name, workflowStatusDone, r.StepIdx)
-		m.appendHistory(outputStyle.Render(promptStyle.Render("✓ workflow complete: " + r.Workflow.Name)))
+		
+		var out strings.Builder
+		out.WriteString(promptStyle.Render("✓ workflow complete: " + r.Workflow.Name))
+		if r.finishData != nil {
+			out.WriteString("\n  Outcome: " + r.finishData.Description)
+			if len(r.finishData.Artifacts) > 0 {
+				out.WriteString("\n  Artifacts:")
+				for _, art := range r.finishData.Artifacts {
+					out.WriteString("\n  • " + art)
+				}
+			}
+		}
+		m.appendHistory(outputStyle.Render(out.String()))
+
 		if err := removeAllWorkflowPlans(m.cwd, m.worktreeName); err != nil {
 			debugLog("workflow cleanup: %v", err)
 		}
@@ -375,6 +389,16 @@ func (m model) advanceWorkflowStep(stepErr error) (tea.Model, tea.Cmd) {
 		}
 		// Got the summary: render the step's line, record output, advance.
 		m.appendWorkflowStepDone(step.Name, step.Provider, step.Model, sig.summary)
+
+		if r.StepIdx == len(r.Workflow.Steps)-1 && r.finishData == nil {
+			r.linearRetry++
+			r.linearText = txt
+			r.remind = remindNoFinishTool
+			m.appendHistory(workflowNoteLine(
+				fmt.Sprintf("re-prompting %q for finish_workflow (attempt %d)", nonEmpty(step.Name, "step"), r.linearRetry+1), ""))
+			return m.dispatchOrFinalize()
+		}
+
 		if err := revalidateWorkflowNotesDir(m.cwd, m.worktreeName, r); err != nil {
 			r.remind = remindFixPlanDir
 			r.remindDetail = err.Error()
@@ -413,6 +437,14 @@ func (m model) advanceWorkflowStep(stepErr error) (tea.Model, tea.Cmd) {
 	// Break from the tail step exits the loop immediately. Non-tail steps
 	// cannot break the loop; if they pass a decision, it is ignored.
 	if isTail && sig.decision == workflowLoopBreak {
+		if r.StepIdx == len(r.Workflow.Steps)-1 && r.finishData == nil {
+			r.loop.retry++
+			r.loop.retryText = txt
+			r.remind = remindNoFinishTool
+			m.appendHistory(loopNoteLine(top.Name,
+				fmt.Sprintf("re-prompting %q for finish_workflow (attempt %d)", nonEmpty(inner.Name, "step"), r.loop.retry+1), ""))
+			return m.dispatchOrFinalize()
+		}
 		r.prevNotesDir = r.currentNotesDir
 		if txt != "" {
 			r.loop.iterationLog = append(r.loop.iterationLog, txt)
@@ -464,6 +496,14 @@ func (m model) advanceWorkflowStep(stepErr error) (tea.Model, tea.Cmd) {
 		r.loop.iterationLog = append(r.loop.iterationLog, txt)
 	}
 	if r.loop.iteration >= top.effectiveMaxIterations() {
+		if r.StepIdx == len(r.Workflow.Steps)-1 && r.finishData == nil {
+			r.loop.retry++
+			r.loop.retryText = txt
+			r.remind = remindNoFinishTool
+			m.appendHistory(loopNoteLine(top.Name,
+				fmt.Sprintf("re-prompting %q for finish_workflow (attempt %d)", nonEmpty(inner.Name, "step"), r.loop.retry+1), ""))
+			return m.dispatchOrFinalize()
+		}
 		m.appendHistory(loopNoteLine(top.Name, "hit iteration limit",
 			fmt.Sprintf("%d iteration(s)", r.loop.iteration)))
 		r.exitLoop()
@@ -601,6 +641,7 @@ const (
 	remindNoSummary             // the prior turn ended without calling end_turn
 	remindNoDecision            // a loop tail called end_turn but omitted its decision
 	remindFixPlanDir            // a workflow notes directory is missing or is a file
+	remindNoFinishTool          // the prior turn ended the workflow without calling finish_workflow
 )
 
 // stepPromptCtx carries the per-dispatch facts buildWorkflowStepPrompt
@@ -608,12 +649,13 @@ const (
 // why this dispatch is a re-prompt (remindNone on a normal first dispatch),
 // and the current/previous notes directories.
 type stepPromptCtx struct {
-	loop         *loopPromptCtx
-	remind       remindKind
-	remindDetail string
-	notesDir     string
-	prevNotesDir string
-	isStartStep  bool
+	loop                *loopPromptCtx
+	remind              remindKind
+	remindDetail        string
+	notesDir            string
+	prevNotesDir        string
+	isStartStep         bool
+	isWorkflowFinalStep bool
 }
 
 // loopPromptCtx carries the per-dispatch loop facts injected into an
@@ -681,12 +723,14 @@ func buildWorkflowStepPrompt(step workflowStep, source workflowSource, prevOutpu
 	}
 	var loop *loopPromptCtx
 	remind := remindNone
+	isFinalStep := false
 	if pc != nil {
 		loop = pc.loop
 		remind = pc.remind
+		isFinalStep = pc.isWorkflowFinalStep
 	}
 	b.WriteString("\n\n")
-	b.WriteString(endTurnInstructionBlock(loop))
+	b.WriteString(endTurnInstructionBlock(loop, isFinalStep))
 	if remind != remindNone {
 		b.WriteString("\n\n")
 		b.WriteString(endTurnReminder(remind, pc.remindDetail))
@@ -698,7 +742,7 @@ func buildWorkflowStepPrompt(step workflowStep, source workflowSource, prevOutpu
 // a step. Every step is told to call end_turn with a summary; a loop step
 // additionally gets the loop framing, and its tail the "you MUST include a
 // decision" clause (a non-tail step is told to omit decision entirely).
-func endTurnInstructionBlock(loop *loopPromptCtx) string {
+func endTurnInstructionBlock(loop *loopPromptCtx, isFinalStep bool) string {
 	var b strings.Builder
 	if loop != nil {
 		fmt.Fprintf(&b, "[Workflow loop %q · iteration %d of up to %d]", loop.name, loop.iteration, loop.maxIterations)
@@ -707,6 +751,16 @@ func endTurnInstructionBlock(loop *loopPromptCtx) string {
 			b.WriteString(cond)
 		}
 		b.WriteString("\n")
+	}
+	if isFinalStep {
+		if loop != nil && loop.isTail {
+			b.WriteString("This is the final step of the workflow. If you choose to pass `decision: \"break\"` to `end_turn`, you MUST FIRST call the `finish_workflow` tool to summarize the outcome.\n")
+		} else if loop == nil {
+			b.WriteString("This is the final step of the workflow. You MUST call the `finish_workflow` tool before calling `end_turn`.\n")
+		}
+		if loop != nil && loop.iteration >= loop.maxIterations && loop.isTail {
+			b.WriteString("This is the maximum iteration limit. You MUST break and you MUST call finish_workflow before end_turn.\n")
+		}
 	}
 	b.WriteString("When you have finished this step, you MUST call the end_turn tool as your final action, with " +
 		"a `summary` of 1-3 sentences describing what you did and the outcome. This records your progress in the " +
@@ -728,6 +782,8 @@ func endTurnInstructionBlock(loop *loopPromptCtx) string {
 // why it's being asked again without making it redo the work shown above.
 func endTurnReminder(k remindKind, detail string) string {
 	switch k {
+	case remindNoFinishTool:
+		return "REMINDER: You ended the workflow but forgot to call the `finish_workflow` tool. Call it with your description and artifacts, then call `end_turn` again."
 	case remindNoDecision:
 		return "REMINDER: you called end_turn without a `decision`, which is required for the final step of a " +
 			"loop iteration. You have already done the work shown above — do NOT repeat it. Call end_turn again now " +

--- a/workflows_run_test.go
+++ b/workflows_run_test.go
@@ -121,6 +121,7 @@ func TestAdvanceWorkflowStep_FinalisesOnLastStep(t *testing.T) {
 		StepIdx: 0,
 	}
 	m.workflowRun.pendingEndTurn = &endTurnSignal{summary: "all done"}
+	m.workflowRun.finishData = &finishWorkflowData{Description: "done"}
 	workflowTracker().markWorking(cwd, issue.Key(), "single", m.id)
 
 	newM, _ := m.advanceWorkflowStep(nil)
@@ -137,6 +138,43 @@ func TestAdvanceWorkflowStep_FinalisesOnLastStep(t *testing.T) {
 	if sess.Status != workflowStatusDone {
 		t.Errorf("session status: got %q want %q", sess.Status, workflowStatusDone)
 	}
+}
+
+// TestAdvanceWorkflowStep_LinearFinalStepNoFinishToolRePrompts verifies that the final
+// linear step requires a finish_workflow tool call before it can be finalised.
+func TestAdvanceWorkflowStep_LinearFinalStepNoFinishToolRePrompts(t *testing.T) {
+	cwd := isolateHome(t)
+	resetWorkflowTrackerForTest()
+	m := newTestModel(t, newFakeProvider())
+	m.cwd = cwd
+	issue := issueRef{Provider: "github", Project: "ow/r", Number: 1}
+	m.workflowRun = &workflowRunState{
+		Workflow: workflowDef{
+			Name:  "wf",
+			Steps: []workflowStep{{Name: "only"}},
+		},
+		Source:  issueWorkflowSource(issue),
+		StepIdx: 0,
+	}
+	m.workflowRun.currentStep.WriteString("did work but no finishData")
+	m.workflowRun.pendingEndTurn = &endTurnSignal{summary: "done"}
+	workflowTracker().markWorking(cwd, m.workflowRun.Source.Key(), "wf", m.id)
+
+	newM, cmd := m.advanceWorkflowStep(nil)
+	r := newM.(model).workflowRun
+	if r.done {
+		t.Errorf("must not be done without finish_workflow")
+	}
+	if r.linearRetry != 1 {
+		t.Errorf("linearRetry=%d want 1", r.linearRetry)
+	}
+	if r.linearText != "did work but no finishData" {
+		t.Errorf("linearText=%q", r.linearText)
+	}
+	if r.remind != remindNoFinishTool {
+		t.Errorf("remind=%v want remindNoFinishTool", r.remind)
+	}
+	assertStartStepCmd(t, cmd, m.id)
 }
 
 // TestAdvanceWorkflowStep_FailsOnError covers the `failed` path: an error
@@ -274,6 +312,7 @@ func TestAdvanceWorkflowStep_RetriesOnError(t *testing.T) {
 	// Branch A: Success after retries
 	mmSuccess := mm
 	mmSuccess.workflowRun.pendingEndTurn = &endTurnSignal{summary: "success"}
+	mmSuccess.workflowRun.finishData = &finishWorkflowData{Description: "done"}
 	newMSuccess, _ := mmSuccess.advanceWorkflowStep(nil)
 	mm2 := newMSuccess.(model)
 	if mm2.workflowRun.stepErrorRetry != 0 {
@@ -496,6 +535,34 @@ func TestWorkflowLoop_NonTailBreakIgnored(t *testing.T) {
 	}
 }
 
+// TestWorkflowLoop_TailBreakFinalStepNoFinishToolRePrompts verifies that if the loop
+// is the final step in the workflow, breaking from its tail requires a finish_workflow
+// tool call before finalisation.
+func TestWorkflowLoop_TailBreakFinalStepNoFinishToolRePrompts(t *testing.T) {
+	m := loopRunModel(t, loopInner2, 5, 1, 3)
+	// Make the loop the final step
+	m.workflowRun.Workflow.Steps = m.workflowRun.Workflow.Steps[:1]
+	m.workflowRun.loop.iterationLog = []string{"code out"}
+	m.workflowRun.currentStep.WriteString("looks good but no finishData")
+	m.workflowRun.pendingEndTurn = &endTurnSignal{decision: workflowLoopBreak, summary: "no issues"}
+
+	newM, cmd := m.advanceWorkflowStep(nil)
+	r := newM.(model).workflowRun
+	if r.done {
+		t.Errorf("must not be done without finish_workflow")
+	}
+	if r.loop.retry != 1 {
+		t.Errorf("loop.retry=%d want 1", r.loop.retry)
+	}
+	if r.loop.retryText != "looks good but no finishData" {
+		t.Errorf("retryText=%q", r.loop.retryText)
+	}
+	if r.remind != remindNoFinishTool {
+		t.Errorf("remind=%v want remindNoFinishTool", r.remind)
+	}
+	assertStartStepCmd(t, cmd, m.id)
+}
+
 // TestWorkflowLoop_NonTailProceedsToNextInner: a non-tail step that
 // registers a summary with no decision simply advances to the next inner
 // step in the same iteration.
@@ -634,6 +701,33 @@ func TestWorkflowLoop_MaxIterationsSoftExit(t *testing.T) {
 	if r.failed {
 		t.Error("hitting the cap must not fail the run (soft proceed)")
 	}
+}
+
+// TestWorkflowLoop_MaxIterationsSoftExitFinalStepNoFinishToolRePrompts: hitting the iteration cap on a
+// final loop step without finishData reprompts for finish_workflow instead of soft-exiting.
+func TestWorkflowLoop_MaxIterationsSoftExitFinalStepNoFinishToolRePrompts(t *testing.T) {
+	m := loopRunModel(t, loopInner2, 2, 1, 2)
+	// Make the loop the final step
+	m.workflowRun.Workflow.Steps = m.workflowRun.Workflow.Steps[:1]
+	m.workflowRun.loop.iterationLog = []string{"code out"}
+	m.workflowRun.currentStep.WriteString("still not done")
+	m.workflowRun.pendingEndTurn = &endTurnSignal{decision: workflowLoopContinue, summary: "more"}
+
+	newM, cmd := m.advanceWorkflowStep(nil)
+	r := newM.(model).workflowRun
+	if r.done {
+		t.Errorf("must not be done without finish_workflow")
+	}
+	if r.loop.retry != 1 {
+		t.Errorf("loop.retry=%d want 1", r.loop.retry)
+	}
+	if r.loop.retryText != "still not done" {
+		t.Errorf("retryText=%q", r.loop.retryText)
+	}
+	if r.remind != remindNoFinishTool {
+		t.Errorf("remind=%v want remindNoFinishTool", r.remind)
+	}
+	assertStartStepCmd(t, cmd, m.id)
 }
 
 // TestStartWorkflowStep_EntersLoop: dispatching onto a loop step creates


### PR DESCRIPTION
### Summary
Implemented the finish_workflow tool and enforced its usage on the final step of any workflow (both linear and loop tail steps). The tool requires a description and artifacts. If a workflow run is finished successfully and finishData is present, it will append an Option A styled outcome block (✓ workflow complete: <name> followed by Outcome and Artifacts) to the chat history.

### Motivation
To ensure that all workflows end with a formal, summarized conclusion rather than just abruptly ending or missing important artifact links (like pull requests). This makes the end of workflows much clearer, ensuring the AI provides a final status and generated output links before calling end_turn.

### Testing / Validation
- Ran the internal test suite and verified that tests continue to pass.
- Verified loop max iterations and tail logic ensure the tool is prompted without confusing non-tail steps.