### PR TITLE
feat: make planning mode toggle dynamic

### DIFF
--- a/agent_run.go
+++ b/agent_run.go
@@ -45,6 +45,7 @@ type agentSession struct {
 	spec   *agentProviderSpec
 	model  fantasy.LanguageModel
 	env    *agentToolEnv
+	sysMu  sync.RWMutex
 	system string
 
 	// coreTools are the harness natives — the ONLY tools that reach
@@ -170,6 +171,17 @@ func (s *agentSession) setTurnCancel(fn context.CancelFunc) {
 	s.turnMu.Lock()
 	defer s.turnMu.Unlock()
 	s.turnCancel = fn
+}
+
+// SetPlanningMode updates the session's planning mode toggle and regenerates
+// the system prompt in-place.
+func (s *agentSession) SetPlanningMode(enabled bool) {
+	s.args.PlanningMode = enabled
+	s.env.planningMode.Store(enabled)
+	newSystem := buildAgentSystemPrompt(s.args)
+	s.sysMu.Lock()
+	s.system = newSystem
+	s.sysMu.Unlock()
 }
 
 // stepCost prices one API call of this session's model. Safe on
@@ -325,8 +337,12 @@ func (s *agentSession) runTurn(turn agentTurn) {
 	// never appears as a construct in the transcript.
 	displayNames := map[string]string{}
 
+	s.sysMu.RLock()
+	systemPrompt := s.system
+	s.sysMu.RUnlock()
+
 	agentOpts := []fantasy.AgentOption{
-		fantasy.WithSystemPrompt(s.system),
+		fantasy.WithSystemPrompt(systemPrompt),
 		fantasy.WithTools(s.currentTools()...),
 		fantasy.WithStopConditions(
 			agentLoopDetectionCondition(),
@@ -452,11 +468,11 @@ func (s *agentSession) runTurn(turn agentTurn) {
 		debugLog("agent.Stream failed: %v", err)
 		debugLog("agent.Stream failed full error: %+v", err)
 		debugLog("agent.Stream model ID: %s", s.modelID)
-		sysExcerpt := s.system
+		sysExcerpt := systemPrompt
 		if len(sysExcerpt) > 1000 {
 			sysExcerpt = sysExcerpt[:1000] + "..."
 		}
-		debugLog("agent.Stream system prompt length: %d", len(s.system))
+		debugLog("agent.Stream system prompt length: %d", len(systemPrompt))
 		debugLog("agent.Stream system prompt excerpt: %q", sysExcerpt)
 		tools := s.currentTools()
 		debugLog("agent.Stream tools count: %d", len(tools))

--- a/agent_tools.go
+++ b/agent_tools.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -69,7 +70,7 @@ type agentToolEnv struct {
 	// editing. When the gate is false (default), this flag is unused.
 	// Guarded by wfMu.
 	todosApplied bool
-	planningMode bool
+	planningMode atomic.Bool
 }
 
 func newAgentToolEnv(cwd string, tabID int, skipPermissions bool, gateTodosBeforeMutate bool, planningMode bool, emit func(tea.Msg)) *agentToolEnv {
@@ -78,12 +79,12 @@ func newAgentToolEnv(cwd string, tabID int, skipPermissions bool, gateTodosBefor
 		tabID:                 tabID,
 		skipPermissions:       skipPermissions,
 		gateTodosBeforeMutate: gateTodosBeforeMutate,
-		planningMode:          planningMode,
 		emit:                  emit,
 		files:                 newAgentFileTracker(),
 		jobs:                  newAgentJobManager(),
 		workflowsAvailable:    len(listAllWorkflows(cwd)) > 0,
 	}
+	env.planningMode.Store(planningMode)
 	env.approve = env.approveViaModal
 	return env
 }

--- a/agent_tools_file.go
+++ b/agent_tools_file.go
@@ -121,7 +121,7 @@ func agentWriteTool(env *agentToolEnv) fantasy.AgentTool {
 		"write",
 		agentWriteToolDescription,
 		func(ctx context.Context, p agentWriteParams, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
-			if env.planningMode {
+			if env.planningMode.Load() {
 				return fantasy.NewTextResponse("Planning mode is ON. File modifications are currently blocked."), nil
 			}
 			if strings.TrimSpace(p.FilePath) == "" {
@@ -202,7 +202,7 @@ func agentEditTool(env *agentToolEnv) fantasy.AgentTool {
 		"edit",
 		agentEditToolDescription,
 		func(ctx context.Context, p agentEditParams, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
-			if env.planningMode {
+			if env.planningMode.Load() {
 				return fantasy.NewTextResponse("Planning mode is ON. File modifications are currently blocked."), nil
 			}
 			if strings.TrimSpace(p.FilePath) == "" {

--- a/agent_tools_test.go
+++ b/agent_tools_test.go
@@ -1435,7 +1435,7 @@ func TestAgentJobAppendOutput(t *testing.T) {
 func TestPlanningMode_AgentTools(t *testing.T) {
 	isolateHome(t)
 	env, _ := newTestToolEnv(t)
-	env.planningMode = true
+	env.planningMode.Store(true)
 
 	write := agentWriteTool(env)
 	resp := runTool(t, write, agentWriteParams{FilePath: "x.txt", Content: "data"})

--- a/agent_tools_workflow.go
+++ b/agent_tools_workflow.go
@@ -74,7 +74,7 @@ func agentWorkflowTools(env *agentToolEnv) []fantasy.AgentTool {
 			}),
 		nativeBridgeTool("workflow_run", workflowRunToolDescription,
 			func(_ context.Context, in workflowRunInput) (*mcp.CallToolResult, workflowRunOutput, error) {
-				if env.planningMode {
+				if env.planningMode.Load() {
 					return &mcp.CallToolResult{
 						Content: []mcp.Content{
 							&mcp.TextContent{

--- a/update.go
+++ b/update.go
@@ -1247,7 +1247,11 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 			if m.planningMode {
 				state = "ON"
 			}
-			m.killProc()
+			if m.proc != nil {
+				if s, ok := m.proc.payload.(*agentSession); ok {
+					s.SetPlanningMode(m.planningMode)
+				}
+			}
 			return m, m.toast.show("Planning mode: " + state)
 		}
 		newM, cmd, _ := m.activeScreen().updateKey(m, msg)

--- a/update_test.go
+++ b/update_test.go
@@ -1743,8 +1743,8 @@ func TestUpdate_ActionPlanningModePreservesSession(t *testing.T) {
 	if m2.sessionID != "test-session-123" {
 		t.Errorf("expected sessionID to be preserved, got %q", m2.sessionID)
 	}
-	if m2.sessionMinted {
-		t.Errorf("expected sessionMinted to be cleared by killProc")
+	if !m2.sessionMinted {
+		t.Errorf("expected sessionMinted to remain true")
 	}
 	if !m2.planningMode {
 		t.Errorf("expected planningMode to be true")


### PR DESCRIPTION
### Summary
This pull request makes the Planning Mode toggle dynamic. Instead of requiring a session restart (killing the provider process and restarting) to change the system prompt, it dynamically hot-swaps the system prompt inline via thread-safe modifications.

### Motivation
Toggling Planning Mode previously required a destructive process reset which could lose temporary context or cause interruption. By modifying the prompt dynamically, we offer a smoother, uninterrupted UX when using `Ctrl+L`.

### Testing and Validation
- Replaced `planningMode` in `agentToolEnv` with an `atomic.Bool`.
- Added `sysMu sync.RWMutex` to `agentSession` with `SetPlanningMode` method.
- Replaced `killProc()` in `update.go` with the new dynamic swap.
- Ran `go test ./...` and confirmed all assertions pass.