### PR TITLE
build: refactor Makefile and silence llama.cpp startup logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean setup-llama download-model
+.PHONY: all build clean setup-llama download-model install
 
 # Variables
 LLAMA_DIR := build/llama.cpp
@@ -10,6 +10,10 @@ LLAMA_BRANCH := master
 MODEL_URL := https://huggingface.co/ggml-org/embeddinggemma-300M-GGUF/resolve/main/embeddinggemma-300M-Q8_0.gguf
 MODEL_DIR := build/models
 MODEL_FILE := $(MODEL_DIR)/embeddinggemma-300M-Q8_0.gguf
+
+export CGO_LDFLAGS=-L$(PWD)/$(LLAMA_DIR)/build/src -L$(PWD)/$(LLAMA_DIR)/build/ggml/src -lllama -lggml -lstdc++ -lm
+export CGO_CXXFLAGS=-I$(PWD)/$(LLAMA_DIR)/include -I$(PWD)/$(LLAMA_DIR)/ggml/include
+export CGO_CFLAGS=-I$(PWD)
 
 all: setup-llama download-model build
 
@@ -31,16 +35,14 @@ download-model:
 
 build: setup-llama download-model
 	@echo "Building ask..."
-	CGO_LDFLAGS="-L$(PWD)/$(LLAMA_DIR)/build/src -L$(PWD)/$(LLAMA_DIR)/build/ggml/src -lllama -lggml -lstdc++ -lm" \
-	CGO_CXXFLAGS="-I$(PWD)/$(LLAMA_DIR)/include -I$(PWD)/$(LLAMA_DIR)/ggml/include" \
-	CGO_CFLAGS="-I$(PWD)" \
 	go build -o bin/ask .
+
+install: setup-llama download-model
+	@echo "Installing ask..."
+	go install .
 
 test: setup-llama download-model
 	@echo "Testing ask..."
-	CGO_LDFLAGS="-L$(PWD)/$(LLAMA_DIR)/build/src -L$(PWD)/$(LLAMA_DIR)/build/ggml/src -lllama -lggml -lstdc++ -lm" \
-	CGO_CXXFLAGS="-I$(PWD)/$(LLAMA_DIR)/include -I$(PWD)/$(LLAMA_DIR)/ggml/include" \
-	CGO_CFLAGS="-I$(PWD)" \
 	go test ./...
 
 clean:

--- a/agent_embed.go
+++ b/agent_embed.go
@@ -10,6 +10,14 @@ package main
 #include "ggml-backend.h"
 
 // Helper function to tokenize
+static void empty_log_callback(enum ggml_log_level level, const char * text, void * user_data) {
+    // empty
+}
+
+static void silence_llama_logs() {
+    llama_log_set(empty_log_callback, NULL);
+}
+
 static int tokenize(struct llama_model * model, const char * text, int text_len, llama_token * tokens, int n_max_tokens, bool add_bos, bool special) {
     const struct llama_vocab * vocab = llama_model_get_vocab(model);
     return llama_tokenize(vocab, text, text_len, tokens, n_max_tokens, add_bos, special);
@@ -30,6 +38,7 @@ type EmbeddingModel struct {
 }
 
 func LoadEmbeddingModel(path string) (*EmbeddingModel, error) {
+	C.silence_llama_logs()
 	C.ggml_backend_load_all()
 	C.llama_backend_init()
 


### PR DESCRIPTION
### Summary
- Extracted \`CGO_LDFLAGS\`, \`CGO_CXXFLAGS\`, and \`CGO_CFLAGS\` variables at the top of the Makefile so they are not duplicated across targets.
- Added a new \`install\` target to the Makefile that depends on \`setup-llama\` and \`download-model\`, which runs \`go install .\`.
- Added an empty C log callback in \`agent_embed.go\` to silence \`llama.cpp\` startup logs.

### Motivation
To avoid noisy \`llama.cpp\` diagnostic logs that print to the screen before the Bubble Tea TUI boots, disrupting the CLI startup experience. Additionally, the Makefile refactoring removes duplicated CGO flags and provides an easy \`install\` target for users to install the \`ask\` binary.

### Testing/Validation
- Ran \`make build\` and \`make test\`, both passing cleanly.
- Verified that \`llama.cpp\` initialization logs are successfully silenced by the empty C callback.