### PR TITLE
fix: move embedding model to global ask directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LLAMA_BRANCH := master
 
 # Model details
 MODEL_URL := https://huggingface.co/ggml-org/embeddinggemma-300M-GGUF/resolve/main/embeddinggemma-300M-Q8_0.gguf
-MODEL_DIR := build/models
+MODEL_DIR := $(HOME)/.local/share/ask/models
 MODEL_FILE := $(MODEL_DIR)/embeddinggemma-300M-Q8_0.gguf
 
 export CGO_LDFLAGS=-L$(PWD)/$(LLAMA_DIR)/build/src -L$(PWD)/$(LLAMA_DIR)/build/ggml/src -lllama -lggml -lstdc++ -lm

--- a/agent_memory_sqlite.go
+++ b/agent_memory_sqlite.go
@@ -40,22 +40,17 @@ func openMemoryService(cfg askConfig) error {
 		return nil
 	}
 
-	modelPath := filepath.Join(projectRoot("."), "build", "models", "embeddinggemma-300M-Q8_0.gguf")
-	if !filepath.IsAbs(modelPath) {
-		cwd, _ := os.Getwd()
-		modelPath = filepath.Join(projectRoot(cwd), "build", "models", "embeddinggemma-300M-Q8_0.gguf")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
 	}
+	modelPath := filepath.Join(home, ".local", "share", "ask", "models", "embeddinggemma-300M-Q8_0.gguf")
 
 	model, err := LoadEmbeddingModel(modelPath)
 	if err != nil {
 		return fmt.Errorf("failed to load embedding model: %w", err)
 	}
 
-	home, err := os.UserHomeDir()
-	if err != nil {
-		model.Close()
-		return err
-	}
 	dbDir := filepath.Join(home, ".config", "ask", "memory")
 	if err := os.MkdirAll(dbDir, 0700); err != nil {
 		model.Close()


### PR DESCRIPTION
## Summary
This PR updates the embedding model path from the local build directory to a global ask models directory.

## Motivation
The memory service was previously downloading and trying to load the embedding model from a local \`build/models\` directory. Moving this to \`~/.local/share/ask/models\` ensures a common, global location across different projects, avoiding duplicate downloads and local pollution.

## Testing Performed
- Updated \`Makefile\` and verified \`make download-model\` properly places the model in the global directory.
- Ran \`make test\` which successfully executes tests with Llama.cpp integration and no compilation issues.