### PR TITLE
Fix 'Enter your own' model picker option for workflow steps

### DIFF
--- a/workflows_screen.go
+++ b/workflows_screen.go
@@ -1031,6 +1031,21 @@ func (m model) workflowsBuilderUpdateModelPicker(msg tea.KeyPressMsg) (model, te
 			return m, nil, true
 		}
 		picked := b.modelPickerOpts[b.modelCursor]
+		if picked == switcherCustomRowLabel {
+			b.modelPicker = false
+			b.renaming = "model"
+			if t, ok := b.currentStepTarget(); ok && !t.isLoop {
+				step := b.stepAt(t)
+				if step.Model != switcherCustomRowLabel {
+					b.renameDraft = step.Model
+				} else {
+					b.renameDraft = ""
+				}
+			} else {
+				b.renameDraft = ""
+			}
+			return m, nil, true
+		}
 		if t, ok := b.currentStepTarget(); ok && !t.isLoop {
 			b.stepAt(t).Model = picked
 			if err := b.commitItems(); err != nil {
@@ -1100,6 +1115,13 @@ func (m model) workflowsBuilderUpdateRename(msg tea.KeyPressMsg) (model, tea.Cmd
 				}
 			}
 			b.stepAt(t).Name = draft
+		case "model":
+			t, ok := b.currentStepTarget()
+			if !ok {
+				b.renaming = ""
+				return m, nil, true
+			}
+			b.stepAt(t).Model = draft
 		}
 		if err := b.commitItems(); err != nil {
 			b.toast = "save failed: " + err.Error()
@@ -1924,6 +1946,9 @@ func (b *workflowsBuilderState) renderRename(width, height int) string {
 		title = "Rename step"
 	case "workflow":
 		title = "Rename workflow"
+	case "model":
+		title = "Step Model"
+		hint = "Type custom model ID; enter to save, esc to cancel"
 	case "maxiter":
 		title = "Max iterations"
 		hint = "Whole number (blank = default of 10); enter to save"

--- a/workflows_screen_branches_test.go
+++ b/workflows_screen_branches_test.go
@@ -314,3 +314,59 @@ func TestUpdateRename_DuplicateNameToasts(t *testing.T) {
 		t.Errorf("name should not change on duplicate; got %q", got.workflowsBuilder.items[0].Name)
 	}
 }
+
+func TestUpdateModelPicker_EnterYourOwn(t *testing.T) {
+	m := withWorkflowsBuilder(t, workflowDef{
+		Name: "wf",
+		Steps: []workflowStep{
+			{Name: "s1", Provider: "fake", Model: "old-model"},
+		},
+	})
+	m.workflowsBuilder.listCursor = 1 // select wf
+	m.workflowsBuilder.syncRightFromLeft()
+	m.workflowsBuilder.rightMode = workflowsBuilderRightSteps
+	m.workflowsBuilder.stepsCursor = 1 // on s1
+
+	m.workflowsBuilder.modelPicker = true
+	m.workflowsBuilder.modelPickerOpts = []string{"opt1", switcherCustomRowLabel}
+	m.workflowsBuilder.modelCursor = 1
+
+	m2, _, _ := m.workflowsBuilderUpdateModelPicker(tea.KeyPressMsg{Code: tea.KeyEnter})
+	b := m2.workflowsBuilder
+
+	if b.modelPicker {
+		t.Error("modelPicker should be closed")
+	}
+	if b.renaming != "model" {
+		t.Errorf("renaming = %q want 'model'", b.renaming)
+	}
+	if b.renameDraft != "old-model" {
+		t.Errorf("renameDraft = %q want 'old-model'", b.renameDraft)
+	}
+}
+
+func TestUpdateRename_CustomModel(t *testing.T) {
+	m := withWorkflowsBuilder(t, workflowDef{
+		Name: "wf",
+		Steps: []workflowStep{
+			{Name: "s1", Provider: "fake", Model: "old-model"},
+		},
+	})
+	m.workflowsBuilder.listCursor = 1 // select wf
+	m.workflowsBuilder.syncRightFromLeft()
+	m.workflowsBuilder.rightMode = workflowsBuilderRightSteps
+	m.workflowsBuilder.stepsCursor = 1 // on s1
+
+	m.workflowsBuilder.renaming = "model"
+	m.workflowsBuilder.renameDraft = "my-custom-model-id"
+
+	m2, _, _ := m.workflowsBuilderUpdateRename(tea.KeyPressMsg{Code: tea.KeyEnter})
+	b := m2.workflowsBuilder
+
+	if b.renaming != "" {
+		t.Error("renaming should be cleared")
+	}
+	if step := b.items[0].Steps[0]; step.Model != "my-custom-model-id" {
+		t.Errorf("step model = %q want 'my-custom-model-id'", step.Model)
+	}
+}


### PR DESCRIPTION
## Summary
Fixes the "Enter your own" model picker option for workflow steps. Previously, selecting this option would literal save "Enter your own…" as the model ID.

## Motivation
Users could not type or pick a custom model ID because selecting "Enter your own" would just commit the literal string. This PR fixes the issue by transitioning the UI into a rename state where the user can input the custom model ID.

## Testing Performed
Added two new behavioral tests (\`TestUpdateModelPicker_EnterYourOwn\` and \`TestUpdateRename_CustomModel\`) to verify the state transitions and data mutation. Also ran local builds to ensure the fix is solid.