### PR TITLE
feat: implement finalized_plan tool and dialog

### DIFF
--- a/agent_prompt.go
+++ b/agent_prompt.go
@@ -182,6 +182,7 @@ func buildAgentSystemPrompt(args ProviderSessionArgs) string {
 	if args.PlanningMode {
 		b.WriteString("\n\n<planning_mode>\n")
 		b.WriteString("PLANNING MODE IS ON. You are currently restricted to exploring the codebase and conversing with the user. You MUST NOT attempt to mutate any files, run mutating commands, or launch workflows. Any tools that modify state will be blocked. Guide the user and outline a plan, but do not execute it.\n")
+		b.WriteString("Once you have developed and discussed the plan with the user and are ready to execute it, you MUST present the plan to the user using the 'finalized_plan' tool. Doing so ends your turn, presents a structured confirmation dialog to the user, and lets them choose how to execute the plan (e.g. running it in a workflow, executing inline directly, or continuing discussion).\n")
 		b.WriteString("</planning_mode>")
 	}
 

--- a/agent_provider.go
+++ b/agent_provider.go
@@ -233,6 +233,9 @@ func setupAgentSessionTools(s *agentSession, cfg askConfig) {
 		agentSearchToolsTool(s.deferredTools),
 		agentInvokeToolTool(s.deferredTools, s.isCoreToolName, env),
 	}
+	if s.args.PlanningMode {
+		s.coreTools = append(s.coreTools, agentFinalizedPlanTool(env))
+	}
 	if s.args.IsWorkflowFinalStep {
 		s.coreTools = append(s.coreTools, agentFinishWorkflowTool(env))
 	}

--- a/agent_tools_ask.go
+++ b/agent_tools_ask.go
@@ -166,3 +166,61 @@ func agentEndTurnTool(env *agentToolEnv) fantasy.AgentTool {
 		},
 	)
 }
+
+type agentFinalizedPlanParams struct {
+	Plan            string `json:"plan" description:"required: the full markdown plan covering the necessary file changes, tests, and verification steps"`
+	Explanation     string `json:"explanation" description:"required: one or two sentences explaining why this plan is optimal"`
+	DefaultWorkflow string `json:"default_workflow,omitempty" description:"optional: the matched/suggested workflow name (e.g. 'ship') if any matches the plan"`
+}
+
+// agentFinalizedPlanTool ends the LLM turn and displays a near full-screen
+// confirmation dialog where the user can choose to run the plan in a workflow,
+// select a different workflow, execute inline without a workflow, or continue discussion.
+func agentFinalizedPlanTool(env *agentToolEnv) fantasy.AgentTool {
+	return fantasy.NewAgentTool(
+		"finalized_plan",
+		"Present a finalized implementation plan to the user for confirmation and execution choice.",
+		func(ctx context.Context, p agentFinalizedPlanParams, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			plan := strings.TrimSpace(p.Plan)
+			explanation := strings.TrimSpace(p.Explanation)
+			if plan == "" {
+				return fantasy.NewTextErrorResponse("plan is required"), nil
+			}
+			if explanation == "" {
+				return fantasy.NewTextErrorResponse("explanation is required"), nil
+			}
+
+			reply := make(chan finalizedPlanReply, 1)
+			if !agentSendToProgram(finalizedPlanRequestMsg{
+				tabID:           env.tabID,
+				plan:            plan,
+				explanation:     explanation,
+				defaultWorkflow: strings.TrimSpace(p.DefaultWorkflow),
+				reply:           reply,
+			}) {
+				return fantasy.NewTextErrorResponse("ask UI not ready"), nil
+			}
+
+			select {
+			case resp := <-reply:
+				if resp.headless {
+					return fantasy.NewTextResponse("This step is running headless as part of an automated workflow. Continuing directly."), nil
+				}
+				if resp.cancelled {
+					return fantasy.NewTextErrorResponse("user cancelled or closed the finalized plan dialog"), nil
+				}
+				if resp.talkMore {
+					return fantasy.NewTextResponse("The user declined the plan and wants to continue discussing. Re-evaluate your approach based on the user's feedback."), nil
+				}
+				if resp.executeInline {
+					env.markWorkflowsChecked()
+					env.markWorkflowRunDispatched()
+					return fantasy.NewTextResponse("Plan approved for inline execution. Planning mode has been turned OFF and todos guards have been disarmed. You can now execute your plan directly using write/edit/bash/etc."), nil
+				}
+				return fantasy.NewTextResponse(fmt.Sprintf("Plan approved. Executing in workflow %q.", resp.workflowName)), nil
+			case <-ctx.Done():
+				return fantasy.NewTextErrorResponse("cancelled while waiting for user confirmation"), nil
+			}
+		},
+	)
+}

--- a/ask_wire.go
+++ b/ask_wire.go
@@ -213,3 +213,20 @@ func permissionRuleFor(toolName string, input map[string]any) permissionRule {
 	}
 	return r
 }
+
+type finalizedPlanReply struct {
+	headless      bool
+	cancelled     bool
+	talkMore      bool
+	executeInline bool
+	workflowName  string
+}
+
+type finalizedPlanRequestMsg struct {
+	tabID           int
+	plan            string
+	defaultWorkflow string
+	explanation     string
+	reply           chan finalizedPlanReply
+}
+

--- a/finalized_plan.go
+++ b/finalized_plan.go
@@ -1,0 +1,339 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	lipgloss "charm.land/lipgloss/v2"
+)
+
+func (m *model) clearFinalizedPlan() {
+	m.finalizedPlan = ""
+	m.finalizedPlanWorkflow = ""
+	m.finalizedPlanExplanation = ""
+	m.finalizedPlanReply = nil
+	m.finalizedPlanCursor = 0
+	m.finalizedPlanScrollY = 0
+	m.finalizedPlanSelectingWorkflow = false
+	m.finalizedPlanWorkflowCursor = 0
+	m.finalizedPlanWorkflows = nil
+}
+
+func (m model) finalizedPlanOptions() []string {
+	var opts []string
+	allWfs := listAllWorkflows(m.cwd)
+	workflowExists := func(name string) bool {
+		for _, w := range allWfs {
+			if w.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+	if m.finalizedPlanWorkflow != "" && workflowExists(m.finalizedPlanWorkflow) {
+		opts = append(opts, fmt.Sprintf("Execute in workflow %s", m.finalizedPlanWorkflow))
+	}
+	if len(allWfs) > 0 {
+		opts = append(opts, "Pick a different workflow...")
+	}
+	opts = append(opts, "Execute without a workflow")
+	opts = append(opts, "I want to talk about this some more")
+	return opts
+}
+
+func (m model) updateFinalizedPlan(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if msg.Mod == tea.ModCtrl && msg.Code == 'c' {
+		if m.finalizedPlanReply != nil {
+			m.finalizedPlanReply <- finalizedPlanReply{cancelled: true}
+		}
+		m.mode = modeInput
+		m.clearFinalizedPlan()
+		return m, nil
+	}
+
+	if m.finalizedPlanSelectingWorkflow {
+		switch {
+		case msg.Code == tea.KeyEsc:
+			m.finalizedPlanSelectingWorkflow = false
+			return m, nil
+		case listNavPrev(msg):
+			m.finalizedPlanWorkflowCursor = listNavWrap(m.finalizedPlanWorkflowCursor, -1, len(m.finalizedPlanWorkflows))
+			return m, nil
+		case listNavNext(msg):
+			m.finalizedPlanWorkflowCursor = listNavWrap(m.finalizedPlanWorkflowCursor, +1, len(m.finalizedPlanWorkflows))
+			return m, nil
+		case msg.Code == tea.KeyEnter:
+			if len(m.finalizedPlanWorkflows) == 0 {
+				return m, nil
+			}
+			picked := m.finalizedPlanWorkflows[m.finalizedPlanWorkflowCursor]
+			src := chatWorkflowSource(m.id, m.history)
+			cmd := func() tea.Msg {
+				return spawnWorkflowTabMsg{
+					OriginTabID:  m.id,
+					Cwd:          m.cwd,
+					WorktreeName: m.worktreeName,
+					Workflow:     picked,
+					Source:       src,
+				}
+			}
+			if m.finalizedPlanReply != nil {
+				m.finalizedPlanReply <- finalizedPlanReply{workflowName: picked.Name}
+			}
+			m.mode = modeInput
+			m.clearFinalizedPlan()
+			return m, cmd
+		}
+		return m, nil
+	}
+
+	opts := m.finalizedPlanOptions()
+	scrollDelta := 0
+	switch {
+	case msg.Code == tea.KeyPgUp || (msg.Mod == tea.ModCtrl && msg.Code == 'u'):
+		scrollDelta = -10
+	case msg.Code == tea.KeyPgDown || (msg.Mod == tea.ModCtrl && msg.Code == 'd'):
+		scrollDelta = 10
+	case listNavPrev(msg):
+		m.finalizedPlanCursor = listNavWrap(m.finalizedPlanCursor, -1, len(opts))
+		return m, nil
+	case listNavNext(msg):
+		m.finalizedPlanCursor = listNavWrap(m.finalizedPlanCursor, +1, len(opts))
+		return m, nil
+	case msg.Code == tea.KeyEsc:
+		if m.finalizedPlanReply != nil {
+			m.finalizedPlanReply <- finalizedPlanReply{cancelled: true}
+		}
+		m.mode = modeInput
+		m.clearFinalizedPlan()
+		return m, nil
+	case msg.Code == tea.KeyEnter:
+		if len(opts) == 0 {
+			return m, nil
+		}
+		pickedOpt := opts[m.finalizedPlanCursor]
+		switch {
+		case strings.HasPrefix(pickedOpt, "Execute in workflow"):
+			var pickedDef workflowDef
+			for _, w := range listAllWorkflows(m.cwd) {
+				if w.Name == m.finalizedPlanWorkflow {
+					pickedDef = w
+					break
+				}
+			}
+			src := chatWorkflowSource(m.id, m.history)
+			cmd := func() tea.Msg {
+				return spawnWorkflowTabMsg{
+					OriginTabID:  m.id,
+					Cwd:          m.cwd,
+					WorktreeName: m.worktreeName,
+					Workflow:     pickedDef,
+					Source:       src,
+				}
+			}
+			if m.finalizedPlanReply != nil {
+				m.finalizedPlanReply <- finalizedPlanReply{workflowName: m.finalizedPlanWorkflow}
+			}
+			m.mode = modeInput
+			m.clearFinalizedPlan()
+			return m, cmd
+
+		case pickedOpt == "Pick a different workflow...":
+			m.finalizedPlanWorkflows = listAllWorkflows(m.cwd)
+			m.finalizedPlanWorkflowCursor = 0
+			m.finalizedPlanSelectingWorkflow = true
+			return m, nil
+
+		case pickedOpt == "Execute without a workflow":
+			m.planningMode = false
+			if m.proc != nil {
+				if s, ok := m.proc.payload.(*agentSession); ok {
+					s.SetPlanningMode(false)
+				}
+			}
+			if m.finalizedPlanReply != nil {
+				m.finalizedPlanReply <- finalizedPlanReply{executeInline: true}
+			}
+			m.mode = modeInput
+			m.clearFinalizedPlan()
+			return m, nil
+
+		case pickedOpt == "I want to talk about this some more":
+			if m.finalizedPlanReply != nil {
+				m.finalizedPlanReply <- finalizedPlanReply{talkMore: true}
+			}
+			m.mode = modeInput
+			m.clearFinalizedPlan()
+			return m, nil
+		}
+	}
+
+	if scrollDelta != 0 {
+		width := 84
+		if width > m.width-8 {
+			width = m.width - 8
+		}
+		contentW := width - 6
+		lines := m.renderMarkdown(m.finalizedPlan, contentW)
+		scrollH := (m.height - 4) - 10
+		if scrollH < 3 {
+			scrollH = 3
+		}
+		maxScrollY := len(lines) - scrollH
+		if maxScrollY < 0 {
+			maxScrollY = 0
+		}
+		m.finalizedPlanScrollY += scrollDelta
+		if m.finalizedPlanScrollY < 0 {
+			m.finalizedPlanScrollY = 0
+		}
+		if m.finalizedPlanScrollY > maxScrollY {
+			m.finalizedPlanScrollY = maxScrollY
+		}
+	}
+
+	return m, nil
+}
+
+func (m model) viewFinalizedPlan() string {
+	width := 84
+	if width > m.width-8 {
+		width = m.width - 8
+	}
+	if width < 40 {
+		width = 40
+	}
+	height := 24
+	if height > m.height-4 {
+		height = m.height - 4
+	}
+	if height < 12 {
+		height = 12
+	}
+
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(activeTheme.accent).
+		Padding(1, 2)
+
+	contentW := width - 6
+
+	title := configTitleStyle.Render("Confirm Finalized Plan")
+	lines := m.renderMarkdown(m.finalizedPlan, contentW)
+
+	scrollH := height - 10
+	if scrollH < 3 {
+		scrollH = 3
+	}
+	maxScrollY := len(lines) - scrollH
+	if maxScrollY < 0 {
+		maxScrollY = 0
+	}
+	if m.finalizedPlanScrollY > maxScrollY {
+		m.finalizedPlanScrollY = maxScrollY
+	}
+	if m.finalizedPlanScrollY < 0 {
+		m.finalizedPlanScrollY = 0
+	}
+
+	endY := m.finalizedPlanScrollY + scrollH
+	if endY > len(lines) {
+		endY = len(lines)
+	}
+
+	var planText string
+	if len(lines) > 0 {
+		planText = strings.Join(lines[m.finalizedPlanScrollY:endY], "\n")
+	} else {
+		planText = m.finalizedPlan
+	}
+
+	linesRenderedCount := endY - m.finalizedPlanScrollY
+	if linesRenderedCount < scrollH {
+		planText += strings.Repeat("\n", scrollH-linesRenderedCount)
+	}
+
+	scrollLine := configHelpStyle.Render(fmt.Sprintf("▲ --- Line %d to %d of %d --- ▼", m.finalizedPlanScrollY+1, endY, len(lines)))
+	if len(lines) <= scrollH {
+		scrollLine = configHelpStyle.Render("--- Complete Plan ---")
+	}
+
+	explTitle := configHelpStyle.Bold(true).Render("Explanation:")
+	wrappedExpl := wrapText(m.finalizedPlanExplanation, contentW)
+
+	helpText := configHelpStyle.Render("PgUp/PgDn or Ctrl+U/Ctrl+D: scroll plan · Esc: cancel/exit")
+	divider := configHelpStyle.Render(strings.Repeat("─", contentW))
+
+	var optionsArea string
+	if m.finalizedPlanSelectingWorkflow {
+		optionsArea = configTitleStyle.Render("Select a workflow to run:") + "\n"
+		for i, wf := range m.finalizedPlanWorkflows {
+			row := "  " + wf.Name
+			if wf.Description != "" {
+				row += " - " + wf.Description
+			}
+			row = truncateForRow(row, contentW)
+			if i == m.finalizedPlanWorkflowCursor {
+				optionsArea += configSelectedRowStyle.Width(contentW).Render(row) + "\n"
+			} else {
+				optionsArea += row + "\n"
+			}
+		}
+		for i := len(m.finalizedPlanWorkflows); i < 4; i++ {
+			optionsArea += "\n"
+		}
+	} else {
+		opts := m.finalizedPlanOptions()
+		for i, opt := range opts {
+			row := "  " + opt
+			if i == m.finalizedPlanCursor {
+				optionsArea += configSelectedRowStyle.Width(contentW).Render(row) + "\n"
+			} else {
+				optionsArea += row + "\n"
+			}
+		}
+		for i := len(opts); i < 4; i++ {
+			optionsArea += "\n"
+		}
+	}
+
+	boxContent := title + "\n" +
+		planText + "\n" +
+		scrollLine + "\n" +
+		divider + "\n" +
+		explTitle + " " + wrappedExpl + "\n" +
+		divider + "\n" +
+		optionsArea +
+		helpText
+
+	return box.Width(width).Height(height).Render(boxContent)
+}
+
+func (m model) renderMarkdown(raw string, width int) []string {
+	r := newRenderer(width)
+	rendered, err := r.Render(raw)
+	if err != nil {
+		return strings.Split(raw, "\n")
+	}
+	return strings.Split(strings.TrimRight(rendered, "\n"), "\n")
+}
+
+func wrapText(text string, width int) string {
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return ""
+	}
+	var lines []string
+	currentLine := words[0]
+	for _, word := range words[1:] {
+		if len(currentLine)+1+len(word) > width {
+			lines = append(lines, currentLine)
+			currentLine = word
+		} else {
+			currentLine += " " + word
+		}
+	}
+	lines = append(lines, currentLine)
+	return strings.Join(lines, "\n")
+}

--- a/finalized_plan_test.go
+++ b/finalized_plan_test.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestFinalizedPlan_ClearPlan(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m.finalizedPlan = "plan content"
+	m.finalizedPlanWorkflow = "ship"
+	m.finalizedPlanExplanation = "explanation"
+	m.finalizedPlanCursor = 1
+	m.clearFinalizedPlan()
+
+	if m.finalizedPlan != "" || m.finalizedPlanWorkflow != "" || m.finalizedPlanExplanation != "" {
+		t.Errorf("clearFinalizedPlan did not reset values")
+	}
+	if m.finalizedPlanCursor != 0 {
+		t.Errorf("clearFinalizedPlan did not reset finalizedPlanCursor")
+	}
+}
+
+func TestFinalizedPlan_Options(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m.finalizedPlanWorkflow = "nonexistent"
+
+	opts := m.finalizedPlanOptions()
+	for _, o := range opts {
+		if strings.HasPrefix(o, "Execute in workflow") {
+			t.Errorf("Should not show option for nonexistent workflow")
+		}
+	}
+}
+
+func TestFinalizedPlan_NavigateAndScroll(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m.finalizedPlan = "plan content"
+	m.width = 80
+	m.height = 20
+
+	// Check main options navigation
+	m2, _ := m.updateFinalizedPlan(tea.KeyPressMsg{Code: tea.KeyDown})
+	mm := m2.(model)
+	if mm.finalizedPlanCursor != 1 {
+		t.Errorf("Down should move finalizedPlanCursor to 1, got %d", mm.finalizedPlanCursor)
+	}
+
+	m3, _ := mm.updateFinalizedPlan(tea.KeyPressMsg{Code: tea.KeyUp})
+	mm = m3.(model)
+	if mm.finalizedPlanCursor != 0 {
+		t.Errorf("Up should move finalizedPlanCursor to 0, got %d", mm.finalizedPlanCursor)
+	}
+
+	// Scroll down
+	m4, _ := mm.updateFinalizedPlan(tea.KeyPressMsg{Code: tea.KeyPgDown})
+	mm = m4.(model)
+	// Even on short text scroll works or clamps
+	if mm.finalizedPlanScrollY != 0 {
+		t.Errorf("ScrollY should stay at 0 for short text")
+	}
+}
+
+func TestFinalizedPlan_WorkflowSelection(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m.finalizedPlan = "plan content"
+	m.finalizedPlanExplanation = "expl"
+	m.finalizedPlanReply = make(chan finalizedPlanReply, 1)
+
+	// Press Esc on main screen cancels
+	m2, _ := m.updateFinalizedPlan(tea.KeyPressMsg{Code: tea.KeyEsc})
+	mm := m2.(model)
+	select {
+	case reply := <-m.finalizedPlanReply:
+		if !reply.cancelled {
+			t.Errorf("expected reply.cancelled to be true")
+		}
+	default:
+		t.Errorf("expected reply on channel")
+	}
+	if mm.mode != modeInput {
+		t.Errorf("expected mode to reset to modeInput")
+	}
+}
+
+func TestFinalizedPlan_TalkMoreSelection(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m.finalizedPlan = "plan content"
+	m.finalizedPlanExplanation = "expl"
+	m.finalizedPlanReply = make(chan finalizedPlanReply, 1)
+
+	// Cursor at the last element (which is always "I want to talk about this some more")
+	opts := m.finalizedPlanOptions()
+	m.finalizedPlanCursor = len(opts) - 1
+
+	m2, _ := m.updateFinalizedPlan(tea.KeyPressMsg{Code: tea.KeyEnter})
+	mm := m2.(model)
+	select {
+	case reply := <-m.finalizedPlanReply:
+		if !reply.talkMore {
+			t.Errorf("expected reply.talkMore to be true")
+		}
+	default:
+		t.Errorf("expected reply on channel")
+	}
+	if mm.mode != modeInput {
+		t.Errorf("expected mode to reset to modeInput")
+	}
+}
+
+func TestFinalizedPlan_ExecuteInlineSelection(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m.finalizedPlan = "plan content"
+	m.finalizedPlanExplanation = "expl"
+	m.finalizedPlanReply = make(chan finalizedPlanReply, 1)
+	m.planningMode = true
+
+	// Navigate to "Execute without a workflow"
+	opts := m.finalizedPlanOptions()
+	for idx, o := range opts {
+		if o == "Execute without a workflow" {
+			m.finalizedPlanCursor = idx
+			break
+		}
+	}
+
+	m2, _ := m.updateFinalizedPlan(tea.KeyPressMsg{Code: tea.KeyEnter})
+	mm := m2.(model)
+	select {
+	case reply := <-m.finalizedPlanReply:
+		if !reply.executeInline {
+			t.Errorf("expected reply.executeInline to be true")
+		}
+	default:
+		t.Errorf("expected reply on channel")
+	}
+	if mm.planningMode {
+		t.Errorf("expected planningMode to be false")
+	}
+}
+
+func TestFinalizedPlan_ToolGoroutineInlineDisarm(t *testing.T) {
+	// Verify that finalized_plan tool disarms todos guards on executeInline
+	env := newAgentToolEnv(t.TempDir(), 1, true, false, true, func(tea.Msg) {})
+	env.workflowsAvailable = true
+
+	tool := agentFinalizedPlanTool(env)
+
+	// Since we are running the tool function, we can override agentSendToProgram
+	oldSend := agentSendToProgram
+	defer func() { agentSendToProgram = oldSend }()
+	agentSendToProgram = func(msg tea.Msg) bool {
+		req, ok := msg.(finalizedPlanRequestMsg)
+		if !ok {
+			return false
+		}
+		// Forward reply channel
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			req.reply <- finalizedPlanReply{executeInline: true}
+		}()
+		return true
+	}
+
+	resp := runTool(t, tool, agentFinalizedPlanParams{
+		Plan:        "Plan Markdown",
+		Explanation: "Optimal",
+	})
+
+	if resp.IsError {
+		t.Fatalf("tool run failed: %s", resp.Content)
+	}
+
+	if strings.Contains(resp.Content, "error") {
+		t.Fatalf("tool response error: %s", resp.Content)
+	}
+
+	env.wfMu.Lock()
+	checked := env.workflowsChecked
+	runDispatched := env.workflowRunDispatched
+	env.wfMu.Unlock()
+
+	if !checked || !runDispatched {
+		t.Errorf("executeInline did not disarm workflow checked/dispatched guards: checked=%v, run=%v", checked, runDispatched)
+	}
+}
+
+func TestFinalizedPlan_DrainPendingReplies(t *testing.T) {
+	m := newTestModel(t, newFakeProvider())
+	m.finalizedPlanReply = make(chan finalizedPlanReply, 1)
+
+	m.drainPendingReplies()
+
+	if m.finalizedPlanReply != nil {
+		t.Errorf("drainPendingReplies did not set finalizedPlanReply to nil")
+	}
+}

--- a/proc.go
+++ b/proc.go
@@ -525,4 +525,11 @@ func (m *model) drainPendingReplies() {
 		}
 		m.approvalReply = nil
 	}
+	if m.finalizedPlanReply != nil {
+		select {
+		case m.finalizedPlanReply <- finalizedPlanReply{cancelled: true}:
+		default:
+		}
+		m.finalizedPlanReply = nil
+	}
 }

--- a/tabs.go
+++ b/tabs.go
@@ -176,6 +176,8 @@ func (a app) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case askToolRequestMsg:
 		return a.dispatchByTabID(m.tabID, msg)
+	case finalizedPlanRequestMsg:
+		return a.dispatchByTabID(m.tabID, msg)
 	case approvalRequestMsg:
 		return a.dispatchByTabID(m.tabID, msg)
 	case shellBatchMsg:
@@ -263,6 +265,10 @@ func (a app) dispatchByTabID(tabID int, msg tea.Msg) (tea.Model, tea.Cmd) {
 		case askToolRequestMsg:
 			if m.reply != nil {
 				m.reply <- askReply{cancelled: true}
+			}
+		case finalizedPlanRequestMsg:
+			if m.reply != nil {
+				m.reply <- finalizedPlanReply{cancelled: true}
 			}
 		case approvalRequestMsg:
 			if m.reply != nil {

--- a/types.go
+++ b/types.go
@@ -39,6 +39,7 @@ const (
 	modeApproval
 	modeConfig
 	modeModelPicker
+	modeFinalizedPlan
 )
 
 type streamStatusMsg struct {
@@ -683,6 +684,16 @@ type model struct {
 	// title call (tab_title.go) and persisted on the VirtualSession.
 	// Empty until the first turn; /new and /clear reset it.
 	tabTitle string
+
+	finalizedPlan                  string
+	finalizedPlanWorkflow          string
+	finalizedPlanExplanation       string
+	finalizedPlanReply             chan finalizedPlanReply
+	finalizedPlanCursor            int
+	finalizedPlanScrollY           int
+	finalizedPlanSelectingWorkflow bool
+	finalizedPlanWorkflowCursor    int
+	finalizedPlanWorkflows         []workflowDef
 }
 
 // workflowRunState carries per-tab workflow execution state. Owned

--- a/update.go
+++ b/update.go
@@ -802,6 +802,30 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 		m.askReply = msg.reply
 		return m, nil
 
+	case finalizedPlanRequestMsg:
+		debugLog("finalizedPlanRequestMsg plan len=%d", len(msg.plan))
+		if m.workflowRun != nil {
+			if msg.reply != nil {
+				msg.reply <- finalizedPlanReply{headless: true}
+			}
+			return m, nil
+		}
+		if m.mode == modeFinalizedPlan {
+			if msg.reply != nil {
+				msg.reply <- finalizedPlanReply{cancelled: true}
+			}
+			return m, nil
+		}
+		m.mode = modeFinalizedPlan
+		m.finalizedPlan = msg.plan
+		m.finalizedPlanExplanation = msg.explanation
+		m.finalizedPlanWorkflow = msg.defaultWorkflow
+		m.finalizedPlanReply = msg.reply
+		m.finalizedPlanCursor = 0
+		m.finalizedPlanScrollY = 0
+		m.finalizedPlanSelectingWorkflow = false
+		return m, nil
+
 	case approvalRequestMsg:
 		debugLog("approvalRequestMsg tool=%s id=%s", msg.toolName, msg.toolUseID)
 		if m.workflowRun != nil {
@@ -1117,6 +1141,8 @@ func (m model) Update(msg tea.Msg) (newModel tea.Model, cmd tea.Cmd) {
 			return m.updateConfigModal(msg)
 		case modeModelPicker:
 			return m.updateModelPicker(msg)
+		case modeFinalizedPlan:
+			return m.updateFinalizedPlan(msg)
 		}
 		// Workflow tabs are read-only: the input area is replaced
 		// with a status banner and the user has no way to type a

--- a/view.go
+++ b/view.go
@@ -595,8 +595,9 @@ func (m model) View() tea.View {
 	needCancelConfirm := m.cancelTurnConfirming && m.mode == modeInput
 	needCloseTabConfirm := m.closeTabConfirming && m.mode == modeInput
 	needMergeConfirm := m.mergePRConfirming && m.mode == modeInput
+	needFinalizedPlan := m.mode == modeFinalizedPlan
 
-	if (needBox || needModal || needApproval || needConfig || needSwitch || needCancelConfirm || needCloseTabConfirm || needMergeConfirm) && m.width > 0 && m.height > 0 {
+	if (needBox || needModal || needApproval || needConfig || needSwitch || needCancelConfirm || needCloseTabConfirm || needMergeConfirm || needFinalizedPlan) && m.width > 0 && m.height > 0 {
 		cbStart := time.Now()
 		canvas := uv.NewScreenBuffer(m.width, m.height)
 		uv.NewStyledString(body).Draw(canvas, image.Rectangle{
@@ -888,6 +889,23 @@ func (m model) View() tea.View {
 			uv.NewStyledString(confirm).Draw(canvas, image.Rectangle{
 				Min: image.Pt(cX, cY),
 				Max: image.Pt(cX+cW, cY+cH),
+			})
+		}
+		if needFinalizedPlan {
+			modal := m.viewFinalizedPlan()
+			mW := lipgloss.Width(modal)
+			mH := lipgloss.Height(modal)
+			mX := (m.width - mW) / 2
+			mY := (m.height - mH) / 2
+			if mX < 0 {
+				mX = 0
+			}
+			if mY < 0 {
+				mY = 0
+			}
+			uv.NewStyledString(modal).Draw(canvas, image.Rectangle{
+				Min: image.Pt(mX, mY),
+				Max: image.Pt(mX+mW, mY+mH),
 			})
 		}
 		rStart := time.Now()


### PR DESCRIPTION
### Summary
Implemented a new \`finalized_plan\` tool that ends the LLM turn and displays a near full-screen confirmation dialog. This dialog allows users to review the plan and select how to proceed: executing in a matched workflow, selecting another workflow, running inline without a workflow, or continuing discussion.

### Motivation
This overhaul improves the planning mode experience by introducing a structured, user-friendly transition out of planning. It provides explicit options to manage workflows or bypass them with conscious consent, resolving ambiguous transitions and disarming \`todos\` guards safely when executing inline.

### Testing/Validation
- Added a robust test suite (\`finalized_plan_test.go\`) containing 8 behavioral tests that cover tool operations, UI interactions, guard disarming, scrolling, and dead-tab handling.
- Verified that all tests compile and pass perfectly with zero failures.
- Verified correct Goroutine lifecycle management to ensure pending replies are drained safely when tabs close.