### PR TITLE
Fix dynamic toggling of finalized_plan tool in planning mode

### DIFF
--- a/agent_provider.go
+++ b/agent_provider.go
@@ -177,7 +177,7 @@ func (p agentAPIProvider) StartSession(args ProviderSessionArgs) (*providerProc,
 		session.sessionID = newUUIDv4()
 	}
 
-	session.env = newAgentToolEnv(args.Cwd, args.TabID, args.SkipAllPermissions, cfg.UI.GateTodosBeforeMutate != nil && *cfg.UI.GateTodosBeforeMutate, args.PlanningMode, session.emit)
+	session.env = newAgentToolEnv(args.Cwd, args.TabID, args.SkipAllPermissions, cfg.UI.GateTodosBeforeMutate != nil && *cfg.UI.GateTodosBeforeMutate, args.PlanningMode && !args.InWorkflow, session.emit)
 	setupAgentSessionTools(session, cfg)
 
 	proc := &providerProc{

--- a/agent_run.go
+++ b/agent_run.go
@@ -109,8 +109,10 @@ type agentSession struct {
 // SDK goroutines; the next turn (and the next search_tools call)
 // picks the new sets up.
 func (s *agentSession) refreshToolset() {
+	s.toolsMu.Lock()
 	tools := append([]fantasy.AgentTool(nil), s.coreTools...)
 	deferred := append([]fantasy.AgentTool(nil), s.deferredBase...)
+	s.toolsMu.Unlock()
 	if s.mcp != nil {
 		deferred = append(deferred, s.mcp.tools()...)
 	}
@@ -140,6 +142,8 @@ func (s *agentSession) deferredTools() []fantasy.AgentTool {
 // invoke_tool can steer the model back to a direct call instead of a
 // generic "unknown tool" error.
 func (s *agentSession) isCoreToolName(name string) bool {
+	s.toolsMu.Lock()
+	defer s.toolsMu.Unlock()
 	for _, t := range s.coreTools {
 		if t.Info().Name == name {
 			return true
@@ -177,7 +181,33 @@ func (s *agentSession) setTurnCancel(fn context.CancelFunc) {
 // the system prompt in-place.
 func (s *agentSession) SetPlanningMode(enabled bool) {
 	s.args.PlanningMode = enabled
-	s.env.planningMode.Store(enabled)
+	s.env.planningMode.Store(enabled && !s.args.InWorkflow)
+
+	s.toolsMu.Lock()
+	if enabled {
+		found := false
+		for _, t := range s.coreTools {
+			if t.Info().Name == "finalized_plan" {
+				found = true
+				break
+			}
+		}
+		if !found && !s.args.InWorkflow {
+			s.coreTools = append(s.coreTools, agentFinalizedPlanTool(s.env))
+		}
+	} else {
+		var filtered []fantasy.AgentTool
+		for _, t := range s.coreTools {
+			if t.Info().Name != "finalized_plan" {
+				filtered = append(filtered, t)
+			}
+		}
+		s.coreTools = filtered
+	}
+	s.toolsMu.Unlock()
+
+	s.refreshToolset()
+
 	newSystem := buildAgentSystemPrompt(s.args)
 	s.sysMu.Lock()
 	s.system = newSystem

--- a/agent_run_test.go
+++ b/agent_run_test.go
@@ -888,3 +888,68 @@ func TestAgentSession_CompactRetries(t *testing.T) {
 		t.Errorf("history head must be the summary: %+v", s.messages)
 	}
 }
+
+func TestAgentSession_SetPlanningMode(t *testing.T) {
+	s := &agentSession{
+		args:   ProviderSessionArgs{Cwd: t.TempDir(), TabID: 1},
+		closed: make(chan struct{}),
+	}
+	s.env = newAgentToolEnv(s.args.Cwd, 1, true, true, false, s.emit)
+	s.coreTools = []fantasy.AgentTool{
+		fantasy.NewAgentTool("ping", "test", func(_ context.Context, in struct{}, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			return fantasy.NewTextResponse("pong"), nil
+		}),
+	}
+
+	// 1. Enabling planning mode should add finalized_plan tool
+	s.SetPlanningMode(true)
+
+	if !s.args.PlanningMode {
+		t.Error("expected s.args.PlanningMode to be true")
+	}
+	if !s.env.planningMode.Load() {
+		t.Error("expected s.env.planningMode to be true")
+	}
+
+	hasFinalizedPlan := func(tools []fantasy.AgentTool) bool {
+		for _, tool := range tools {
+			if tool.Info().Name == "finalized_plan" {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !hasFinalizedPlan(s.coreTools) {
+		t.Error("expected finalized_plan to be in coreTools when planning mode enabled")
+	}
+	if !hasFinalizedPlan(s.currentTools()) {
+		t.Error("expected finalized_plan to be in currentTools() when planning mode enabled")
+	}
+
+	// 2. Disabling planning mode should remove finalized_plan tool
+	s.SetPlanningMode(false)
+
+	if s.args.PlanningMode {
+		t.Error("expected s.args.PlanningMode to be false")
+	}
+	if s.env.planningMode.Load() {
+		t.Error("expected s.env.planningMode to be false")
+	}
+	if hasFinalizedPlan(s.coreTools) {
+		t.Error("expected finalized_plan to be removed from coreTools when planning mode disabled")
+	}
+	if hasFinalizedPlan(s.currentTools()) {
+		t.Error("expected finalized_plan to be removed from currentTools() when planning mode disabled")
+	}
+
+	// 3. Planning mode inside workflow should not register finalized_plan
+	s.args.InWorkflow = true
+	s.SetPlanningMode(true)
+	if s.env.planningMode.Load() {
+		t.Error("expected env.planningMode to be false when InWorkflow is true")
+	}
+	if hasFinalizedPlan(s.coreTools) {
+		t.Error("expected finalized_plan not to be registered when InWorkflow is true")
+	}
+}


### PR DESCRIPTION
### Summary of changes
* \`SetPlanningMode(enabled bool)\` in \`agent_run.go\` now dynamically mutates \`s.coreTools\` under \`s.toolsMu\` protection. It appends the \`finalized_plan\` tool when planning mode is enabled and filters it out when disabled.
* \`refreshToolset()\` has been updated to acquire \`s.toolsMu\` before reading \`s.coreTools\` and \`s.deferredBase\` to guarantee thread-safety across concurrent UI-triggered and MCP-triggered refreshes.
* Session initialization in \`agent_provider.go\` and \`SetPlanningMode\` now ensure that \`planningMode\` is not incorrectly enforced (and \`finalized_plan\` not registered) when running inside an active workflow step (\`!args.InWorkflow\`).
* Added \`TestAgentSession_SetPlanningMode\` in \`agent_run_test.go\` to verify the dynamic addition and removal of the tool, as well as the in-workflow constraint.

### Motivation
Toggling Planning Mode mid-session updated the system prompt and the mutation-blocking atomic flag, but it did not dynamically rebuild the active tools sent to the LLM on the wire. This led to a highly asymmetric state:
- Toggling Planning Mode ON mid-session left the LLM without the \`finalized_plan\` tool, trapping it in planning mode since it could neither mutate files nor call the tool required to transition out.
- Toggling Planning Mode OFF mid-session left \`finalized_plan\` in the active tools list despite the mode being inactive.

### Validation
- Validated via \`make test\` passing successfully without regressions.
- Added comprehensive unit test \`TestAgentSession_SetPlanningMode\` that guarantees this behavior going forward, ensuring the thread-safety guards and conditional checks operate as designed.